### PR TITLE
remove sec attributes

### DIFF
--- a/src/DiffSharp/Backend.OpenBLAS.fs
+++ b/src/DiffSharp/Backend.OpenBLAS.fs
@@ -65,39 +65,30 @@ module OpenBLAS =
             member this.Dispose() = h.Free()
 
     module BLAS =
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="isamax_")>]
         extern int isamax_(int *n, float32 *x, int *incx);
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="saxpy_")>]
         extern void saxpy_(int *n, float32 *a, float32 *x, int *incx, float32 *y, int *incy);
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="sscal_")>]
         extern void sscal_(int *n, float32 *alpha, float32 *x, int *incx)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="sdot_")>]
         extern float32 sdot_(int *n, float32 *x, int *incx, float32 *y, int *incy);
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="sger_")>]
         extern void sger_(int *m, int *n, float32 *alpha, float32 *x, int *incx, float32 *y, int *incy, float32 *a, int *lda)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="sasum_")>]
         extern float32 sasum_(int *n, float32 *x, int *incx)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="snrm2_")>]
         extern float32 snrm2_(int *n, float32 *x, int *incx)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="sgemm_")>]
         extern void sgemm_(char *transa, char *transb, int *m, int *n, int *k, float32 *alpha, float32 *a, int *lda, float32 *b, int *ldb, float32 *beta, float32 *c, int *ldc);
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="sgemv_")>]
         extern void sgemv_(char *trans, int *m, int *n, float32 *alpha, float32 *a, int *lda, float32 *x, int *incx, float32 *beta, float32 *y, int *incy)
 
@@ -228,39 +219,30 @@ module OpenBLAS =
             use arg_y = new PinnedArray<float32>(y)
             sgemv_(&&arg_trans, &&arg_m, &&arg_n, &&arg_alpha, arg_a.Ptr, &&arg_lda, arg_x.Ptr, &&arg_incx, &&arg_beta, arg_y.Ptr, &&arg_incy)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="idamax_")>]
         extern int idamax_(int *n, float *x, int *incx);
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="daxpy_")>]
         extern void daxpy_(int *n, float *a, float *x, int *incx, float *y, int *incy);
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="dscal_")>]
         extern void dscal_(int *n, float *alpha, float *x, int *incx)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="ddot_")>]
         extern float ddot_(int *n, float *x, int *incx, float *y, int *incy);
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="dger_")>]
         extern void dger_(int *m, int *n, float *alpha, float *x, int *incx, float *y, int *incy, float *a, int *lda)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="dasum_")>]
         extern float dasum_(int *n, float *x, int *incx)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="dnrm2_")>]
         extern float dnrm2_(int *n, float *x, int *incx)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="dgemm_")>]
         extern void dgemm_(char *transa, char *transb, int *m, int *n, int *k, float *alpha, float *a, int *lda, float *b, int *ldb, float *beta, float *c, int *ldc);
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="dgemv_")>]
         extern void dgemv_(char *trans, int *m, int *n, float *alpha, float *a, int *lda, float *x, int *incx, float *beta, float *y, int *incy)
 
@@ -392,11 +374,10 @@ module OpenBLAS =
             dgemv_(&&arg_trans, &&arg_m, &&arg_n, &&arg_alpha, arg_a.Ptr, &&arg_lda, arg_x.Ptr, &&arg_incx, &&arg_beta, arg_y.Ptr, &&arg_incy)
 
     module BLASExtensions =
-        [<SuppressUnmanagedCodeSecurity>]
+
         [<DllImport("libopenblas", EntryPoint="cblas_simatcopy")>]
         extern void cblas_simatcopy(int ordering, int trans, int rows, int cols, float32 alpha, float32 *a, int lda, int ldb)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="cblas_somatcopy")>]
         extern void cblas_somatcopy(int ordering, int trans, int rows, int cols, float32 alpha, float32 *a, int lda, float32 *b, int ldb)
 
@@ -430,11 +411,9 @@ module OpenBLAS =
             let arg_ldb = m
             cblas_somatcopy(arg_ordering, arg_trans, arg_rows, arg_cols, arg_alpha, arg_a.Ptr, arg_lda, arg_b.Ptr, arg_ldb)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="cblas_dimatcopy")>]
         extern void cblas_dimatcopy(int ordering, int trans, int rows, int cols, float alpha, float *a, int lda, int ldb)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="cblas_domatcopy")>]
         extern void cblas_domatcopy(int ordering, int trans, int rows, int cols, float alpha, float *a, int lda, float *b, int ldb)
 
@@ -469,19 +448,16 @@ module OpenBLAS =
             cblas_domatcopy(arg_ordering, arg_trans, arg_rows, arg_cols, arg_alpha, arg_a.Ptr, arg_lda, arg_b.Ptr, arg_ldb)
 
     module LAPACK =
-        [<SuppressUnmanagedCodeSecurity>]
+
         [<DllImport("libopenblas", EntryPoint="sgesv_")>]
         extern void sgesv_(int *n, int *nrhs, float32 *a, int *lda, int *ipiv, float32 *b, int *ldb, int *info)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="ssysv_")>]
         extern void ssysv_(char *uplo, int *n, int *nrhs, float32 *a, int *lda, int *ipiv, float32 *b, int *ldb, float32 *work, int *lwork, int *info)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="sgetrf_")>]
         extern void sgetrf_(int *m, int *n, float32 *a, int *lda, int *ipiv, int *info)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="sgetri_")>]
         extern void sgetri_(int *n, float32 *a, int *lda, int *ipiv, float32 *work, int *lwork, int *info)
 
@@ -557,19 +533,15 @@ module OpenBLAS =
             else
                 None
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="dgesv_")>]
         extern void dgesv_(int *n, int *nrhs, float *a, int *lda, int *ipiv, float *b, int *ldb, int *info)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="dsysv_")>]
         extern void dsysv_(char *uplo, int *n, int *nrhs, float *a, int *lda, int *ipiv, float *b, int *ldb, float *work, int *lwork, int *info)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="dgetrf_")>]
         extern void dgetrf_(int *m, int *n, float *a, int *lda, int *ipiv, int *info)
 
-        [<SuppressUnmanagedCodeSecurity>]
         [<DllImport("libopenblas", EntryPoint="dgetri_")>]
         extern void dgetri_(int *n, float *a, int *lda, int *ipiv, float *work, int *lwork, int *info)
 


### PR DESCRIPTION
It's not necessary to use these attributes in modern .NET (code access security is basically deprecated and doesn't appear in .NET Core or .NET Standard for example)