### PR TITLE
Fix incorrectly-placed UTF-16 BOM

### DIFF
--- a/src/DiffSharp/AD.Float32.fs
+++ b/src/DiffSharp/AD.Float32.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 /// Nested forward and reverse mode automatic differentiation module
 module DiffSharp.AD.Float32

--- a/src/DiffSharp/AD.Float64.fs
+++ b/src/DiffSharp/AD.Float64.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 /// Nested forward and reverse mode automatic differentiation module
 module DiffSharp.AD.Float64

--- a/src/DiffSharp/Backend.OpenBLAS.fs
+++ b/src/DiffSharp/Backend.OpenBLAS.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 #nowarn "9"
 #nowarn "51"

--- a/src/DiffSharp/Backend.fs
+++ b/src/DiffSharp/Backend.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 namespace DiffSharp.Backend
 

--- a/src/DiffSharp/Config.fs
+++ b/src/DiffSharp/Config.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 namespace DiffSharp.Config
 

--- a/src/DiffSharp/Interop.Float32.fs
+++ b/src/DiffSharp/Interop.Float32.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 /// Interoperability layer, for C# and other CLR languages
 namespace DiffSharp.Interop.Float32

--- a/src/DiffSharp/Interop.Float64.fs
+++ b/src/DiffSharp/Interop.Float64.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 /// Interoperability layer, for C# and other CLR languages
 namespace DiffSharp.Interop.Float64

--- a/src/DiffSharp/Numerical.Float32.fs
+++ b/src/DiffSharp/Numerical.Float32.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 /// Numerical differentiation module
 module DiffSharp.Numerical.Float32

--- a/src/DiffSharp/Numerical.Float64.fs
+++ b/src/DiffSharp/Numerical.Float64.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 /// Numerical differentiation module
 module DiffSharp.Numerical.Float64

--- a/src/DiffSharp/Symbolic.Float32.fs
+++ b/src/DiffSharp/Symbolic.Float32.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 /// Symbolic differentiation module
 module DiffSharp.Symbolic.Float32

--- a/src/DiffSharp/Symbolic.Float64.fs
+++ b/src/DiffSharp/Symbolic.Float64.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 /// Symbolic differentiation module
 module DiffSharp.Symbolic.Float64

--- a/src/DiffSharp/Util.fs
+++ b/src/DiffSharp/Util.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 /// Various utility functions
 module DiffSharp.Util

--- a/tests/DiffSharp.Tests/AD.Float32.fs
+++ b/tests/DiffSharp.Tests/AD.Float32.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 module DiffSharp.Tests.AD.Float32
 

--- a/tests/DiffSharp.Tests/Backend.OpenBLAS.fs
+++ b/tests/DiffSharp.Tests/Backend.OpenBLAS.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 module DiffSharp.Tests.Backend.OpenBLAS
 

--- a/tests/DiffSharp.Tests/Tests.fs
+++ b/tests/DiffSharp.Tests/Tests.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 namespace DiffSharp.Tests
 

--- a/tests/Dsbench/Program.fs
+++ b/tests/Dsbench/Program.fs
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 open System.Diagnostics
 open DiffSharp.AD.Float64


### PR DESCRIPTION
The recently-inserted license header (f88e387f) was added before the BOM (`U+FEFF`) in some files, causing invalid encodings and a confusing error when attempting to build the solution, at least on macOS:

> error FS0010: Unexpected character ''

For additional context, see: https://medium.freecodecamp.org/a-quick-tale-about-feff-the-invisible-character-cd25cd4630e7

Fixed via:
```sh
bom="$(printf '\ufeff')"
sed -i -e "s/${bom}//g" -e "1s/^/${bom}/" **/*.fs
```
