### PR TITLE
Update docs codegen with HTTPS changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 DiffSharp: Differentiable Functional Programming
 ------------------------------------------------
 
-DiffSharp is a functional [automatic differentiation](http://en.wikipedia.org/wiki/Automatic_differentiation) (AD) library implemented in the F# language. It supports C# and the other [CLI languages](http://en.wikipedia.org/wiki/List_of_CLI_languages). The library is being developed mainly for research applications in machine learning, by [Atılım Güneş Baydin](http://www.cs.nuim.ie/~gunes/) and [Barak A. Pearlmutter](http://bcl.hamilton.ie/~barak/), within the [Brain and Computation Lab](http://www.bcl.hamilton.ie/), National University of Ireland Maynooth.
+DiffSharp is a functional [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation) (AD) library implemented in the F# language. It supports C# and the other [CLI languages](https://en.wikipedia.org/wiki/List_of_CLI_languages). The library is being developed mainly for research applications in machine learning, by [Atılım Güneş Baydin](https://www.cs.nuim.ie/~gunes/) and [Barak A. Pearlmutter](http://bcl.hamilton.ie/~barak/), within the [Brain and Computation Lab](http://www.bcl.hamilton.ie/), National University of Ireland Maynooth.
 
-Please visit the [project website](http://diffsharp.github.io/DiffSharp/) for detailed documentation and examples.
+Please visit the [project website](https://diffsharp.github.io/DiffSharp/) for detailed documentation and examples.
 
 You can come and join the Gitter chat room, if you want to chat with us:
 
@@ -11,8 +11,8 @@ You can come and join the Gitter chat room, if you want to chat with us:
 
 ### Project statistics
 
-[![Issue Stats](http://issuestats.com/github/diffsharp/diffsharp/badge/pr?style=flat-square)](http://issuestats.com/github/diffsharp/diffsharp)
-[![Issue Stats](http://issuestats.com/github/diffsharp/diffsharp/badge/issue?style=flat-square)](http://issuestats.com/github/diffsharp/diffsharp)
+[![Issue Stats](https://issuestats.com/github/diffsharp/diffsharp/badge/pr?style=flat-square)](https://issuestats.com/github/diffsharp/diffsharp)
+[![Issue Stats](https://issuestats.com/github/diffsharp/diffsharp/badge/issue?style=flat-square)](https://issuestats.com/github/diffsharp/diffsharp)
 
 ### Current build status
 
@@ -33,5 +33,5 @@ DiffSharp is licensed under the BSD 2-clause "Simplified" license, which means t
 
 DiffSharp uses:
 
-* [OpenBLAS](http://www.openblas.net/) by Zhang Xianyi, Wang Qian, Werner Saar (BSD license) for BLAS/LAPACK operations
-* [F# Quotations Evaluator](http://fsprojects.github.io/FSharp.Quotations.Evaluator/) by Paul Westcott and others (Unlicense/public domain) for compiling code quotations
+* [OpenBLAS](https://www.openblas.net/) by Zhang Xianyi, Wang Qian, Werner Saar (BSD license) for BLAS/LAPACK operations
+* [F# Quotations Evaluator](https://fsprojects.github.io/FSharp.Quotations.Evaluator/) by Paul Westcott and others (Unlicense/public domain) for compiling code quotations

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ DiffSharp: Differentiable Functional Programming
 
 DiffSharp is a functional [automatic differentiation](http://en.wikipedia.org/wiki/Automatic_differentiation) (AD) library implemented in the F# language. It supports C# and the other [CLI languages](http://en.wikipedia.org/wiki/List_of_CLI_languages). The library is being developed mainly for research applications in machine learning, by [Atılım Güneş Baydin](http://www.cs.nuim.ie/~gunes/) and [Barak A. Pearlmutter](http://bcl.hamilton.ie/~barak/), within the [Brain and Computation Lab](http://www.bcl.hamilton.ie/), National University of Ireland Maynooth.
 
-Please visit the [project website](http://gbaydin.github.io/DiffSharp/) for detailed documentation and examples.
+Please visit the [project website](http://diffsharp.github.io/DiffSharp/) for detailed documentation and examples.
 
 You can come and join the Gitter chat room, if you want to chat with us:
 

--- a/docs/BuildDocs.fsx
+++ b/docs/BuildDocs.fsx
@@ -1,9 +1,9 @@
-// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
 // Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)
-﻿// This code is licensed under the BSD license (see LICENSE file for details)
+// This code is licensed under the BSD license (see LICENSE file for details)
 
 //
 // Script for generating library documentation

--- a/docs/BuildDocs.fsx
+++ b/docs/BuildDocs.fsx
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)
@@ -53,7 +53,7 @@ for fileInfo in DirectoryInfo(relative "input/files/img").EnumerateFiles() do
 // Generate documentation
 //
 
-let tags = ["project-name", "DiffSharp"; "project-author", "Atılım Güneş Baydin"; "project-github", "http://github.com/DiffSharp/DiffSharp"; "project-nuget", "https://www.nuget.org/packages/diffsharp"; "root", ""]
+let tags = ["project-name", "DiffSharp"; "project-author", "Atılım Güneş Baydin"; "project-github", "https://github.com/DiffSharp/DiffSharp"; "project-nuget", "https://www.nuget.org/packages/diffsharp"; "root", ""]
 
 Literate.ProcessScriptFile(relative "input/index.fsx", relative "input/templates/template.html", relative "output/index.html", replacements = tags)
 Literate.ProcessScriptFile(relative "input/download.fsx", relative "input/templates/template.html", relative "output/download.html", replacements = tags)

--- a/docs/input/api-overview.fsx
+++ b/docs/input/api-overview.fsx
@@ -696,7 +696,7 @@ let s = DV.length v1 // Length of DV
 let s = DV.min v1    // Minimum element of DV
 let s = DV.max v1    // Maximum element of DV
 let s = DV.sum v1    // Sum of elements of DV
-let v = DV.unitVector v1 // Unit vector codirectional with v1
+let v = DV.unitDV v1     // Unit vector codirectional with v1
 let v = DV.normalize v1  // Normalize elements to have zero mean and unit variance
 
 (**
@@ -789,8 +789,8 @@ let m  = DM (array2D [[1.; 2.]; [3.; 4.]]) // Create DM from float[,]
 let m  = toDM [|[|1.; 2.|]; [|3.; 4.|]|] // Create DM from sequence of sequences of floats
 let m  = toDM [[1.; 2.]; [3.; 4.]]       // Create DM from sequence of sequences of floats
 let m  = toDM [[D 1.; D 2.]; [D 3.; D 4.]] // Create DM from sequence of sequences of Ds
-let v  = DM.toVector m1   // Convert DM to DV by stacking rows of matrix
-let m  = DM.ofVector 2 v2 // Convert DV to a DM with a given number of rows
+let v  = DM.toDV m1        // Convert DM to DV by stacking rows of matrix
+let m  = DM.ofDV 2 v2      // Convert DV to a DM with a given number of rows
 let m  = DM.appendRow v m  // Append row to matrix
 let m  = DM.prependRow v m // Prepend row to matrix
 let m  = DM.appendCol v m  // Append column to matrix

--- a/docs/input/api-overview.fsx
+++ b/docs/input/api-overview.fsx
@@ -232,7 +232,7 @@ The original value and the `n`-th derivative of a scalar-to-scalar function `f`,
 grad f x
 
 (**
-The [gradient](http://en.wikipedia.org/wiki/Gradient) of a vector-to-scalar function `f`, at the point `x`.
+The [gradient](https://en.wikipedia.org/wiki/Gradient) of a vector-to-scalar function `f`, at the point `x`.
 
 For a function $f(a_1, \dots, a_n): \mathbb{R}^n \to \mathbb{R}$, and $\mathbf{x} \in \mathbb{R}^n$, this gives the gradient evaluated at $\mathbf{x}$
 
@@ -257,7 +257,7 @@ The original value and the gradient of a vector-to-scalar function `f`, at the p
 gradv f x v
 
 (**
-The [gradient-vector product](http://en.wikipedia.org/wiki/Directional_derivative) (directional derivative) of a vector-to-scalar function `f`, at the point `x`, along the vector `v`.
+The [gradient-vector product](https://en.wikipedia.org/wiki/Directional_derivative) (directional derivative) of a vector-to-scalar function `f`, at the point `x`, along the vector `v`.
 
 For a function $f: \mathbb{R}^n \to \mathbb{R}$, and $\mathbf{x}, \mathbf{v} \in \mathbb{R}^n$, this gives the dot product of the gradient of $f$ at $\mathbf{x}$ with $\mathbf{v}$
 
@@ -284,7 +284,7 @@ The original value and the gradient-vector product (directional derivative) of a
 hessian f x
 
 (**
-The [Hessian](http://en.wikipedia.org/wiki/Hessian_matrix) of a vector-to-scalar function `f`, at the point `x`.
+The [Hessian](https://en.wikipedia.org/wiki/Hessian_matrix) of a vector-to-scalar function `f`, at the point `x`.
 
 For a function $f(a_1, \dots, a_n): \mathbb{R}^n \to \mathbb{R}$, and $\mathbf{x} \in \mathbb{R}^n$, this gives the Hessian matrix evaluated at $\mathbf{x}$
 
@@ -314,7 +314,7 @@ The original value and the Hessian of a vector-to-scalar function `f`, at the po
 hessianv f x v
 
 (**
-The [Hessian-vector product](http://en.wikipedia.org/wiki/Hessian_automatic_differentiation) of a vector-to-scalar function `f`, at the point `x`, along the vector `v`.
+The [Hessian-vector product](https://en.wikipedia.org/wiki/Hessian_automatic_differentiation) of a vector-to-scalar function `f`, at the point `x`, along the vector `v`.
 
 For a function $f: \mathbb{R}^n \to \mathbb{R}$, and $\mathbf{x}, \mathbf{v} \in \mathbb{R}^n$, this gives the multiplication of the Hessian matrix of $f$ at $\mathbf{x}$ with $\mathbf{v}$
 
@@ -381,7 +381,7 @@ The original value, the gradient-vector product (directional derivative), and th
 laplacian f x
 
 (**
-The [Laplacian](http://en.wikipedia.org/wiki/Laplace_operator#Laplace.E2.80.93Beltrami_operator) of a vector-to-scalar function `f`, at the point `x`.
+The [Laplacian](https://en.wikipedia.org/wiki/Laplace_operator#Laplace.E2.80.93Beltrami_operator) of a vector-to-scalar function `f`, at the point `x`.
 
 For a function $f(a_1, \dots, a_n): \mathbb{R}^n \to \mathbb{R}$, and $\mathbf{x} \in \mathbb{R}^n$, this gives the sum of second derivatives evaluated at $\mathbf{x}$
 
@@ -410,7 +410,7 @@ The original value and the Laplacian of a vector-to-scalar function `f`, at the 
 jacobian f x
 
 (**
-The [Jacobian](http://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant) of a vector-to-vector function `f`, at the point `x`.
+The [Jacobian](https://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant) of a vector-to-vector function `f`, at the point `x`.
 
 For a function $\mathbf{F}: \mathbb{R}^n \to \mathbb{R}^m$ with components $F_1 (a_1, \dots, a_n), \dots, F_m (a_1, \dots, a_n)$, and $\mathbf{x} \in \mathbb{R}^n$, this gives the $m$-by-$n$ Jacobian matrix evaluated at $\mathbf{x}$
 
@@ -534,7 +534,7 @@ This can be computed efficiently by the **DiffSharp.AD.Reverse** module in a mat
 curl f x
 
 (**
-The [curl](http://en.wikipedia.org/wiki/Curl_(mathematics)) of a vector-to-vector function `f`, at the point `x`.
+The [curl](https://en.wikipedia.org/wiki/Curl_(mathematics)) of a vector-to-vector function `f`, at the point `x`.
 
 For a function $\mathbf{F}: \mathbb{R}^3 \to \mathbb{R}^3$ with components $F_1(a_1, a_2, a_3),\; F_2(a_1, a_2, a_3),\; F_3(a_1, a_2, a_3)$, and $\mathbf{x} \in \mathbb{R}^3$, this gives
 
@@ -555,7 +555,7 @@ The original value and the curl of a vector-to-vector function `f`, at the point
 div f x
 
 (**
-The [divergence](http://en.wikipedia.org/wiki/Divergence) of a vector-to-vector function `f`, at the point `x`.
+The [divergence](https://en.wikipedia.org/wiki/Divergence) of a vector-to-vector function `f`, at the point `x`.
 
 For a function $\mathbf{F}: \mathbb{R}^n \to \mathbb{R}^n$ with components $F_1(a_1, \dots, a_n),\; \dots, \; F_n(a_1, \dots, a_n)$, and $\mathbf{x} \in \mathbb{R}^n$, this gives
 

--- a/docs/input/csharp.fsx
+++ b/docs/input/csharp.fsx
@@ -3,7 +3,7 @@
 Interoperability with Other Languages
 =====================================
 
-As F# can interoperate seamlessly with C# and other [CLI languages](http://en.wikipedia.org/wiki/List_of_CLI_languages), DiffSharp can be used with these languages as well. Your project should reference the **DiffSharp.dll** assembly, its dependencies, and also the **FSharp.Core.dll** assembly. Please note that your project should target ".NET Framework 4.6" and have "x64" as the platform target. (Also see the installation instructions on the [main page](index.html).)
+As F# can interoperate seamlessly with C# and other [CLI languages](https://en.wikipedia.org/wiki/List_of_CLI_languages), DiffSharp can be used with these languages as well. Your project should reference the **DiffSharp.dll** assembly, its dependencies, and also the **FSharp.Core.dll** assembly. Please note that your project should target ".NET Framework 4.6" and have "x64" as the platform target. (Also see the installation instructions on the [main page](index.html).)
 
 For C# and other languages, the **DiffSharp.Interop** namespace provides a simpler way of using the library. (Without **DiffSharp.Interop**, you can still use the regular DiffSharp namespaces, but you will need to take care of issues such as converting to and from [**FSharp.Core.FSharpFunc**](https://msdn.microsoft.com/en-us/library/ee340302.aspx) objects.)
 
@@ -244,7 +244,7 @@ $$$
 
 Syntax: `public static Func<DV,DV> AD.Grad(Func<DV,D> f)`
 
-For a function $f(a_1, \dots, a_n): \mathbb{R}^n \to \mathbb{R}$, this returns a function that computes the [gradient](http://en.wikipedia.org/wiki/Gradient)
+For a function $f(a_1, \dots, a_n): \mathbb{R}^n \to \mathbb{R}$, this returns a function that computes the [gradient](https://en.wikipedia.org/wiki/Gradient)
 
 $$$
   \nabla f = \left[ \frac{\partial f}{{\partial a}_1}, \dots, \frac{\partial f}{{\partial a}_n} \right] \; .
@@ -275,7 +275,7 @@ $$$
 
 Syntax: `public static D AD.Gradv(Func<DV,D> f, DV x, DV v)`
 
-For a function $f: \mathbb{R}^n \to \mathbb{R}$, and $\mathbf{x}, \mathbf{v} \in \mathbb{R}^n$, this returns the [gradient-vector product](http://en.wikipedia.org/wiki/Directional_derivative) (directional derivative), that is, the dot product of the gradient of $f$ at $\mathbf{x}$ with $\mathbf{v}$
+For a function $f: \mathbb{R}^n \to \mathbb{R}$, and $\mathbf{x}, \mathbf{v} \in \mathbb{R}^n$, this returns the [gradient-vector product](https://en.wikipedia.org/wiki/Directional_derivative) (directional derivative), that is, the dot product of the gradient of $f$ at $\mathbf{x}$ with $\mathbf{v}$
 
 $$$
   \left( \nabla f \right)_\mathbf{x} \cdot \mathbf{v} \; .
@@ -292,7 +292,7 @@ With AD, this value is computed efficiently in one forward evaluation of the fun
 
 Syntax: `public static Func<DV,DM> AD.Hessian(Func<DV,D> f)`
 
-For a function $f(a_1, \dots, a_n): \mathbb{R}^n \to \mathbb{R}$, this returns a function that computes the [Hessian matrix](http://en.wikipedia.org/wiki/Hessian_matrix)
+For a function $f(a_1, \dots, a_n): \mathbb{R}^n \to \mathbb{R}$, this returns a function that computes the [Hessian matrix](https://en.wikipedia.org/wiki/Hessian_matrix)
 
 $$$
   \mathbf{H}_f = \begin{bmatrix}
@@ -333,7 +333,7 @@ $$$
 
 Syntax: `public static DV AD.Hessianv(Func<DV,D> f, DV x, DV v)`
 
-For a function $f: \mathbb{R}^n \to \mathbb{R}$, and $\mathbf{x}, \mathbf{v} \in \mathbb{R}^n$, this returns the [Hessian-vector product](http://en.wikipedia.org/wiki/Hessian_automatic_differentiation), that is, the multiplication of the Hessian matrix of $f$ at $\mathbf{x}$ with $\mathbf{v}$
+For a function $f: \mathbb{R}^n \to \mathbb{R}$, and $\mathbf{x}, \mathbf{v} \in \mathbb{R}^n$, this returns the [Hessian-vector product](https://en.wikipedia.org/wiki/Hessian_automatic_differentiation), that is, the multiplication of the Hessian matrix of $f$ at $\mathbf{x}$ with $\mathbf{v}$
 
 $$$
   \left( \mathbf{H}_f \right)_\mathbf{x} \; \mathbf{v} \; .
@@ -385,7 +385,7 @@ $$$
 
 Syntax: `public static Func<DV,DM> AD.Jacobian(Func<DV,DV> f)`
 
-For a function $\mathbf{F}: \mathbb{R}^n \to \mathbb{R}^m$ with components $F_1 (a_1, \dots, a_n), \dots, F_m (a_1, \dots, a_n)$, this returns a function that computes the $m$-by-$n$ [Jacobian matrix](http://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant)
+For a function $\mathbf{F}: \mathbb{R}^n \to \mathbb{R}^m$ with components $F_1 (a_1, \dots, a_n), \dots, F_m (a_1, \dots, a_n)$, this returns a function that computes the $m$-by-$n$ [Jacobian matrix](https://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant)
 
 $$$
   \mathbf{J}_\mathbf{F} = \begin{bmatrix}
@@ -497,7 +497,7 @@ With AD, this value is computed efficiently in one forward and one reverse evalu
 
 Syntax: `public static Func<DV,DV> AD.Curl(Func<DV,DV> f)`
 
-For a function $\mathbf{F}: \mathbb{R}^3 \to \mathbb{R}^3$ with components $F_1(a_1, a_2, a_3),\; F_2(a_1, a_2, a_3),\; F_3(a_1, a_2, a_3)$ this returns a function that computes the [curl](http://en.wikipedia.org/wiki/Curl_(mathematics)), that is,
+For a function $\mathbf{F}: \mathbb{R}^3 \to \mathbb{R}^3$ with components $F_1(a_1, a_2, a_3),\; F_2(a_1, a_2, a_3),\; F_3(a_1, a_2, a_3)$ this returns a function that computes the [curl](https://en.wikipedia.org/wiki/Curl_(mathematics)), that is,
 
 $$$
   \textrm{curl} \, \mathbf{F} = \nabla \times \mathbf{F} = \left[ \frac{\partial F_3}{\partial a_2} - \frac{\partial F_2}{\partial a_3}, \; \frac{\partial F_1}{\partial a_3} - \frac{\partial F_3}{\partial a_1}, \; \frac{\partial F_2}{\partial a_1} - \frac{\partial F_1}{\partial a_2} \right] \; .
@@ -528,7 +528,7 @@ $$$
 
 Syntax: `public static Func<DV,D> AD.Div(Func<DV,D[]> f)`
 
-For a function $\mathbf{F}: \mathbb{R}^n \to \mathbb{R}^n$ with components $F_1(a_1, \dots, a_n),\; \dots, \; F_n(a_1, \dots, a_n)$, this returns a function that computes the [divergence](http://en.wikipedia.org/wiki/Divergence), that is, the trace of the Jacobian matrix
+For a function $\mathbf{F}: \mathbb{R}^n \to \mathbb{R}^n$ with components $F_1(a_1, \dots, a_n),\; \dots, \; F_n(a_1, \dots, a_n)$, this returns a function that computes the [divergence](https://en.wikipedia.org/wiki/Divergence), that is, the trace of the Jacobian matrix
 
 $$$
   \textrm{div} \, \mathbf{F} = \nabla \cdot \mathbf{F} = \textrm{tr}\left( \mathbf{J}_{\mathbf{F}} \right) = \left( \frac{\partial F_1}{\partial a_1} + \dots + \frac{\partial F_n}{\partial a_n}\right) \; .

--- a/docs/input/download.fsx
+++ b/docs/input/download.fsx
@@ -22,7 +22,7 @@ If you are using F# interactive, you should run it in 64 bit mode. In Visual Stu
     <div class="span1"></div>
     <div class="span7">
     <div class="well well-small" id="nuget">
-        To install <a href="https://www.nuget.org/packages/diffsharp">DiffSharp on NuGet</a>, run the following in the <a href="http://docs.nuget.org/docs/start-here/using-the-package-manager-console">Package Manager Console</a>:
+        To install <a href="https://www.nuget.org/packages/diffsharp">DiffSharp on NuGet</a>, run the following in the <a href="https://docs.nuget.org/docs/start-here/using-the-package-manager-console">Package Manager Console</a>:
         <pre>PM> Install-Package DiffSharp</pre>
     </div>
     </div>
@@ -33,13 +33,13 @@ If you are using F# interactive, you should run it in 64 bit mode. In Visual Stu
 
 Please make sure you have the latest **libopenblas-dev** package installed for OpenBLAS.
 
-You should have a working .NET runtime on your system. [Mono](http://www.mono-project.com/) has been the standard choice for Linux, but the community is in the process of moving to [.NET Core](http://dotnet.github.io/), a new cross-platform implementation of the framework. Please refer to [fsharp.org](http://fsharp.org/) for the latest instructions.
+You should have a working .NET runtime on your system. [Mono](https://www.mono-project.com/) has been the standard choice for Linux, but the community is in the process of moving to [.NET Core](https://dotnet.github.io/), a new cross-platform implementation of the framework. Please refer to [fsharp.org](https://fsharp.org/) for the latest instructions.
 
 If you have a .NET setup where you can use NuGet, once you have the file _libopenblas.so_ in the library search path (e.g. in /usr/lib), you can use the same NuGet package described above.
 
 Alternatively, you can download the Linux-specific pack of binaries of the latest release, which also includes a compatible version of _libopenblas.so_, <a href="https://github.com/DiffSharp/DiffSharp/releases">on GitHub</a>.
 
-You can check out [Ionide](http://ionide.io/), a lightweight editor for F# development on Linux.
+You can check out [Ionide](https://ionide.io/), a lightweight editor for F# development on Linux.
 
 ## FAQ
 
@@ -49,7 +49,7 @@ This is because you have an old version of OpenBLAS on your system. DiffSharp us
 
 On Linux, you can compile the latest OpenBLAS using [these instructions](https://github.com/xianyi/OpenBLAS/wiki/Installation-Guide). We also distribute a compatible version of _libopenblas.so_ in the Linux-specific pack of the latest release <a href="https://github.com/DiffSharp/DiffSharp/releases">on GitHub</a>.
 
-Please make sure you have the latest version of _libopenblas.so_ in the shared library search path. Also see the "Linux shared library search path" section on [this page](http://www.mono-project.com/docs/advanced/pinvoke/).
+Please make sure you have the latest version of _libopenblas.so_ in the shared library search path. Also see the "Linux shared library search path" section on [this page](https://www.mono-project.com/docs/advanced/pinvoke/).
 
 <br>
 
@@ -57,11 +57,11 @@ Please make sure you have the latest version of _libopenblas.so_ in the shared l
 
 This is related with the general behavior of F# Interactive and how it works with native dlls. It is not specific to DiffSharp.
 
-[This post](http://christoph.ruegg.name/blog/loading-native-dlls-in-fsharp-interactive.html) by Christoph Rüegg provides a detailed overview of how to load native libraries for scripts.
+[This post](https://christoph.ruegg.name/blog/loading-native-dlls-in-fsharp-interactive.html) by Christoph Rüegg provides a detailed overview of how to load native libraries for scripts.
 
 In short, you have to make sure that you have the OpenBLAS binaries (_libopenblas.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll_ on Windows, and _libopenblas.so_ on Linux) in a location reachable by the _DiffSharp.dll_ assembly you are loading into your script (e.g., _#r "../DiffSharp.dll"_).
 
-On Linux, make sure that you have _libopenblas.so_ in the shared library search path. Also see the "Linux shared library search path" section on [this page](http://www.mono-project.com/docs/advanced/pinvoke/).
+On Linux, make sure that you have _libopenblas.so_ in the shared library search path. Also see the "Linux shared library search path" section on [this page](https://www.mono-project.com/docs/advanced/pinvoke/).
 
 On Windows, one way of accomplishing this is to put the _DiffSharp.dll_ and OpenBLAS binaries into the same folder with your .fsx script and call
 

--- a/docs/input/examples-gradientdescent.fsx
+++ b/docs/input/examples-gradientdescent.fsx
@@ -5,14 +5,14 @@
 Gradient Descent
 ================
 
-The [gradient descent algorithm](http://en.wikipedia.org/wiki/Gradient_descent) is an optimization algorithm for finding a local minimum of a scalar-valued function near a starting point, taking successive steps in the direction of the negative of the gradient.
+The [gradient descent algorithm](https://en.wikipedia.org/wiki/Gradient_descent) is an optimization algorithm for finding a local minimum of a scalar-valued function near a starting point, taking successive steps in the direction of the negative of the gradient.
 
 For a function $f: \mathbb{R}^n \to \mathbb{R}$, starting from an initial point $\mathbf{x}_0$, the method works by computing successive points in the function domain
 
 $$$
  \mathbf{x}_{n + 1} = \mathbf{x}_n - \eta \left( \nabla f \right)_{\mathbf{x}_n} \; ,
 
-where $\eta > 0$ is a small step size and $\left( \nabla f \right)_{\mathbf{x}_n}$ is the [gradient](http://en.wikipedia.org/wiki/Gradient) of $f$ evaluated at $\mathbf{x}_n$. The successive values of the function 
+where $\eta > 0$ is a small step size and $\left( \nabla f \right)_{\mathbf{x}_n}$ is the [gradient](https://en.wikipedia.org/wiki/Gradient) of $f$ evaluated at $\mathbf{x}_n$. The successive values of the function 
 
 $$$
  f(\mathbf{x}_0) \ge f(\mathbf{x}_1) \ge f(\mathbf{x}_2) \ge \dots
@@ -21,7 +21,7 @@ keep decreasing and the sequence $\mathbf{x}_n$ usually converges to a local min
 
 In practice, using a fixed step size $\eta$ yields suboptimal performance and there are adaptive algorithms that select a locally optimal step size $\eta$ on each iteration.
 
-The following code implements gradient descent with fixed step size, stopping when the [norm](http://en.wikipedia.org/wiki/Norm_(mathematics)#Euclidean_norm) of the gradient falls below a given threshold.
+The following code implements gradient descent with fixed step size, stopping when the [norm](https://en.wikipedia.org/wiki/Norm_(mathematics)#Euclidean_norm) of the gradient falls below a given threshold.
 
 *)
 

--- a/docs/input/examples-hamiltonianmontecarlo.fsx
+++ b/docs/input/examples-hamiltonianmontecarlo.fsx
@@ -6,13 +6,13 @@
 Hamiltonian Monte Carlo
 =======================
 
-[Hamiltonian Monte Carlo](http://en.wikipedia.org/wiki/Hybrid_Monte_Carlo) (HMC) is a type of [Markov chain Monte Carlo](http://en.wikipedia.org/wiki/Markov_chain_Monte_Carlo) (MCMC) algorithm for obtaining random samples from probability distributions for which direct sampling is difficult. HMC makes use of [Hamiltonian mechanics](http://en.wikipedia.org/wiki/Hamiltonian_mechanics) for efficiently exploring target distributions and provides better convergence characteristics that avoid the slow exploration of random sampling (in alternatives such as the [Metropolis-Hastings algorithm](http://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)).
+[Hamiltonian Monte Carlo](https://en.wikipedia.org/wiki/Hybrid_Monte_Carlo) (HMC) is a type of [Markov chain Monte Carlo](https://en.wikipedia.org/wiki/Markov_chain_Monte_Carlo) (MCMC) algorithm for obtaining random samples from probability distributions for which direct sampling is difficult. HMC makes use of [Hamiltonian mechanics](https://en.wikipedia.org/wiki/Hamiltonian_mechanics) for efficiently exploring target distributions and provides better convergence characteristics that avoid the slow exploration of random sampling (in alternatives such as the [Metropolis-Hastings algorithm](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)).
 
 The advantages of HMC come at the cost of evaluating gradients of distribution functions, which need to be worked out and supplied by the user. Using DiffSharp, we can design an HMC algorithm that only needs the target distribution function as its input, which **can be implemented freely using the full expressivity of the programming language including control flow and subprocedures**, computing the needed gradients efficiently through reverse mode AD.
 
 Let's demonstrate how an AD-HMC can be implemented.
 
-First we need a scheme for integrating Hamiltonian dynamics with discretized time. The [Leapfrog algorithm]() is the common choice, due to its [symplectic](http://en.wikipedia.org/wiki/Symplectic_integrator) property and straightforward implementation.
+First we need a scheme for integrating Hamiltonian dynamics with discretized time. The [Leapfrog algorithm]() is the common choice, due to its [symplectic](https://en.wikipedia.org/wiki/Symplectic_integrator) property and straightforward implementation.
 
 Hamiltonian mechanics is a formulation of classical mechanics, describing the time evolution of a system by the equations
 
@@ -57,7 +57,7 @@ let leapFrog (u:DV->D) (k:DV->D) (d:D) steps (x0, p0) =
 
 (**
 
-We define simple functions for generating [uniform](http://en.wikipedia.org/wiki/Uniform_distribution_(continuous)) and [standard normal](http://en.wikipedia.org/wiki/Normal_distribution) random numbers.
+We define simple functions for generating [uniform](https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)) and [standard normal](https://en.wikipedia.org/wiki/Normal_distribution) random numbers.
     
 *)
 
@@ -111,7 +111,7 @@ let hmc n hdelta hsteps (x0:DV) (f:DV->D) =
 
 Whereas the classical HMC requires the user to supply the log-density and also its gradient, in our implementation we need to supply only the target density function. The rest is taken care of by reverse AD. This has two main advantages: (1) AD computes the exact gradient efficiently and (2) it is applicable to complex density functions where closed-form expressions for the gradient cannot be formulated.
 
-Let's now test this HMC algorithm with a [multivariate normal distribution](http://en.wikipedia.org/wiki/Multivariate_normal_distribution), which has the density
+Let's now test this HMC algorithm with a [multivariate normal distribution](https://en.wikipedia.org/wiki/Multivariate_normal_distribution), which has the density
 
 $$$
   f_{\mathbf{x}}(x_1,\dots,x_k) = \frac{1}{\sqrt{(2\pi)^k \left|\mathbf{\Sigma}\right|}} \textrm{exp} \left( -\frac{1}{2} (\mathbf{x} - \mathbf{\mu})^T \mathbf{\Sigma}^{-1} (\mathbf{x} - \mathbf{\mu}) \right)\;,

--- a/docs/input/examples-helmholtzenergyfunction.fsx
+++ b/docs/input/examples-helmholtzenergyfunction.fsx
@@ -6,7 +6,7 @@
 Helmholtz Energy Function
 =========================
 
-The following formula, giving the [Helmholtz free energy](http://en.wikipedia.org/wiki/Helmholtz_free_energy) of a mixed fluid based on the [Peng-Robinson equation of state](http://en.wikipedia.org/wiki/Equation_of_state#Peng-Robinson_equation_of_state), has been used in automatic differentiation literature for benchmarking gradient calculations:
+The following formula, giving the [Helmholtz free energy](https://en.wikipedia.org/wiki/Helmholtz_free_energy) of a mixed fluid based on the [Peng-Robinson equation of state](https://en.wikipedia.org/wiki/Equation_of_state#Peng-Robinson_equation_of_state), has been used in automatic differentiation literature for benchmarking gradient calculations:
 
 $$$
  f(\mathbf{x}) = R \, T \sum_{i = 0}^{n} x_i \log \frac{x_i}{1 - \mathbf{b^T} \mathbf{x}} - \frac{\mathbf{x^T} \mathbf{A} \mathbf{x}}{\sqrt{8} \mathbf{b^T} \mathbf{x}} \log \frac{1 + (1 + \sqrt{2}) \mathbf{b^T} \mathbf{x}}{1 + (1 - \sqrt{2}) \mathbf{b^T} \mathbf{x}} \; ,

--- a/docs/input/examples-inversekinematics.fsx
+++ b/docs/input/examples-inversekinematics.fsx
@@ -7,7 +7,7 @@
 Inverse Kinematics
 ==================
 
-[Inverse kinematics](http://en.wikipedia.org/wiki/Inverse_kinematics) is a technique in robotics, computer graphics, and animation to find physical configurations of a structure that would put an end-effector in a desired position in space. In other words, it answers the question: "given the desired position of a robot's hand, what should be the angles of all the joints in the robot's body, to take the hand to that position?"
+[Inverse kinematics](https://en.wikipedia.org/wiki/Inverse_kinematics) is a technique in robotics, computer graphics, and animation to find physical configurations of a structure that would put an end-effector in a desired position in space. In other words, it answers the question: "given the desired position of a robot's hand, what should be the angles of all the joints in the robot's body, to take the hand to that position?"
 
 For example, take the system drawn below, attached to a stationary structure on the left. This "arm" has two links of length $L_1$ and $L_2$, two joints at points $(0,0)$ and $(x_1,y_1)$, and the end point at $(x_2,y_2)$. 
 

--- a/docs/input/examples-kinematics.fsx
+++ b/docs/input/examples-kinematics.fsx
@@ -6,7 +6,7 @@
 Kinematics
 ==========
 
-Let us use the DiffSharp library for describing the simple [kinematics](http://en.wikipedia.org/wiki/Kinematics) of a point particle moving in one dimension.
+Let us use the DiffSharp library for describing the simple [kinematics](https://en.wikipedia.org/wiki/Kinematics) of a point particle moving in one dimension.
 
 Take the function $ x(t) = t^3 - 6 t^2 + 10t $, giving the position $x$ of a particle at time $t$.
 *)

--- a/docs/input/examples-kmeansclustering.fsx
+++ b/docs/input/examples-kmeansclustering.fsx
@@ -7,7 +7,7 @@
 K-Means Clustering
 ==================
 
-[K-means clustering](http://en.wikipedia.org/wiki/K-means_clustering) is a method in [cluster analysis](http://en.wikipedia.org/wiki/Cluster_analysis) for partitioning a given set of observations into $k$ clusters, where the observations in the same cluster are more similar to each other than to those in other clusters.
+[K-means clustering](https://en.wikipedia.org/wiki/K-means_clustering) is a method in [cluster analysis](https://en.wikipedia.org/wiki/Cluster_analysis) for partitioning a given set of observations into $k$ clusters, where the observations in the same cluster are more similar to each other than to those in other clusters.
 
 Given $d$ observations $\{\mathbf{x}_1,\dots,\mathbf{x}_d\}$, the observations are assigned to $k$ clusters $\mathbf{S} = \{S_1,\dots,S_k\}$ so as to minimize
 
@@ -128,7 +128,7 @@ plotClusters clusters2
     </div>
 </div>
 
-Finally, we can test our algorithm with the [Iris flower data set](http://en.wikipedia.org/wiki/Iris_flower_data_set) that is commonly used for demonstrations. The data set contains four morphological features (_sepal length_, _sepal width_, _petal length_, _petal width_) of Iris flowers belonging to three related species. A version of the data set can be found [here](https://dataminingproject.googlecode.com/svn-history/r44/DataMiningApp/datasets/Iris/iris.csv).
+Finally, we can test our algorithm with the [Iris flower data set](https://en.wikipedia.org/wiki/Iris_flower_data_set) that is commonly used for demonstrations. The data set contains four morphological features (_sepal length_, _sepal width_, _petal length_, _petal width_) of Iris flowers belonging to three related species. A version of the data set can be found [here](https://dataminingproject.googlecode.com/svn-history/r44/DataMiningApp/datasets/Iris/iris.csv).
 
 *)
 
@@ -153,7 +153,7 @@ plotClusters irisClusters
     </div>
 </div>
 
-Our clustering of the _sepal width_ - _petal length_ data correctly predicts the actual assignment of these features to the three flower species, which can be seen below ([image](http://en.wikipedia.org/wiki/Iris_flower_data_set#mediaviewer/File:Anderson%27s_Iris_data_set.png) by user [Indon](http://commons.wikimedia.org/wiki/User:Indon) on Wikimedia Commons, CC BY-SA 3.0).
+Our clustering of the _sepal width_ - _petal length_ data correctly predicts the actual assignment of these features to the three flower species, which can be seen below ([image](https://en.wikipedia.org/wiki/Iris_flower_data_set#mediaviewer/File:Anderson%27s_Iris_data_set.png) by user [Indon](https://commons.wikimedia.org/wiki/User:Indon) on Wikimedia Commons, CC BY-SA 3.0).
 
 <div class="row">
     <div class="span6 offset1">

--- a/docs/input/examples-lhopitalsrule.fsx
+++ b/docs/input/examples-lhopitalsrule.fsx
@@ -6,7 +6,7 @@
 l'Hôpital's Rule
 ================
 
-[l'Hôpital's rule](http://en.wikipedia.org/wiki/L'H%C3%B4pital's_rule) is a method for evaluating [limits](http://en.wikipedia.org/wiki/Limit_of_a_function) involving [indeterminate forms](http://en.wikipedia.org/wiki/Indeterminate_form). The rule states that, under some conditions, the indeterminate limits
+[l'Hôpital's rule](https://en.wikipedia.org/wiki/L'H%C3%B4pital's_rule) is a method for evaluating [limits](https://en.wikipedia.org/wiki/Limit_of_a_function) involving [indeterminate forms](https://en.wikipedia.org/wiki/Indeterminate_form). The rule states that, under some conditions, the indeterminate limits
 
 $$$
  \begin{eqnarray*}
@@ -38,7 +38,7 @@ let g x = x - sin x
 let lim = f 0. / g 0.
 
 (**
-As expected, we get a [nan](http://msdn.microsoft.com/en-us/library/system.double.nan.aspx) as a result, meaning the result of this operations is undefined.
+As expected, we get a [nan](https://msdn.microsoft.com/en-us/library/system.double.nan.aspx) as a result, meaning the result of this operations is undefined.
 *)
 
 (*** hide, define-output: o1 ***)

--- a/docs/input/examples-neuralnetworks.fsx
+++ b/docs/input/examples-neuralnetworks.fsx
@@ -7,7 +7,7 @@
 <div class="row">
     <div class="span9">
     <div class="well well-small" id="nuget" style="background-color:#E0EBEB">
-        <b>Please note:</b> this is an introductory example and therefore the code is kept very simple. More advanced cases, including recurrent and convolutional networks, will be released as part of the <a href="http://hypelib.github.io/Hype/">Hype</a> library built on top of DiffSharp.
+        <b>Please note:</b> this is an introductory example and therefore the code is kept very simple. More advanced cases, including recurrent and convolutional networks, will be released as part of the <a href="https://hypelib.github.io/Hype/">Hype</a> library built on top of DiffSharp.
     </div>
     </div>
 </div>
@@ -15,9 +15,9 @@
 Neural Networks
 ===============
 
-[Artificial neural networks](http://en.wikipedia.org/wiki/Artificial_neural_network) are computational models inspired by biological nervous systems, capable of approximating functions that depend on a large number of inputs. A network is defined by a connectivity structure and a set of weights between interconnected processing units ("neurons"). Neural networks "learn" a given task by tuning the set of weights under an optimization procedure.
+[Artificial neural networks](https://en.wikipedia.org/wiki/Artificial_neural_network) are computational models inspired by biological nervous systems, capable of approximating functions that depend on a large number of inputs. A network is defined by a connectivity structure and a set of weights between interconnected processing units ("neurons"). Neural networks "learn" a given task by tuning the set of weights under an optimization procedure.
 
-Let's create a [feedforward neural network](http://en.wikipedia.org/wiki/Feedforward_neural_network) with DiffSharp and implement the [backpropagation](http://en.wikipedia.org/wiki/Backpropagation) algorithm for training it. As mentioned before, backpropagation is just a special case of reverse mode AD.
+Let's create a [feedforward neural network](https://en.wikipedia.org/wiki/Feedforward_neural_network) with DiffSharp and implement the [backpropagation](https://en.wikipedia.org/wiki/Backpropagation) algorithm for training it. As mentioned before, backpropagation is just a special case of reverse mode AD.
 
 We start by defining our neural network structure.
 
@@ -43,7 +43,7 @@ The network will consist of several layers of neurons. Each neuron works by taki
 $$$
   a = \sigma \left(\sum_{i} w_i x_i + b\right) \; ,
 
-where $w_i$ are synapse weights associated with each input, $b$ is a bias, and $\sigma$ is an [activation function](http://en.wikipedia.org/wiki/Activation_function) representing the rate of [action potential](http://en.wikipedia.org/wiki/Action_potential) firing in the neuron.
+where $w_i$ are synapse weights associated with each input, $b$ is a bias, and $\sigma$ is an [activation function](https://en.wikipedia.org/wiki/Activation_function) representing the rate of [action potential](https://en.wikipedia.org/wiki/Action_potential) firing in the neuron.
 
 <div class="row">
     <div class="span6 offset2">
@@ -51,7 +51,7 @@ where $w_i$ are synapse weights associated with each input, $b$ is a bias, and $
     </div>
 </div>
 
-A conventional choice for the activation function had been the [sigmoid](http://en.wikipedia.org/wiki/Sigmoid_function) $\sigma (z) = 1 / (1 + e^{-z})$ for a long period because of its simple derivative and gain control properties. Recently the hyperbolic tangent $\tanh$ and the [rectified linear unit](https://en.wikipedia.org/wiki/Rectifier_(neural_networks)) $\textrm{ReLU}(z) = \max(0, z)$ have been more popular choices due to their convergence and performance characteristics.
+A conventional choice for the activation function had been the [sigmoid](https://en.wikipedia.org/wiki/Sigmoid_function) $\sigma (z) = 1 / (1 + e^{-z})$ for a long period because of its simple derivative and gain control properties. Recently the hyperbolic tangent $\tanh$ and the [rectified linear unit](https://en.wikipedia.org/wiki/Rectifier_(neural_networks)) $\textrm{ReLU}(z) = \max(0, z)$ have been more popular choices due to their convergence and performance characteristics.
 
 Now let's write the network evaluation code and a function for creating a given network configuration and initializing the weights and biases with small random values. In practice, proper weight initialization has been demonstrated to have an important effect on training convergence and it would depend on the network structure and the type of activation functions used.
 
@@ -152,7 +152,7 @@ Using reverse mode AD here has two big advantages: (1) it makes the backpropagat
 
 We can now test the algorithm by training some networks.
 
-It is known that [linearly separable](http://en.wikipedia.org/wiki/Linear_separability) rules such as [logical disjunction](http://en.wikipedia.org/wiki/Logical_disjunction) can be learned by a single neuron.
+It is known that [linearly separable](https://en.wikipedia.org/wiki/Linear_separability) rules such as [logical disjunction](https://en.wikipedia.org/wiki/Logical_disjunction) can be learned by a single neuron.
 
 *)
 open FSharp.Charting
@@ -187,7 +187,7 @@ Chart.Line train2
     </div>
 </div>
 
-Linearly inseparable problems such as [exclusive or](http://en.wikipedia.org/wiki/Exclusive_or) require one or more hidden layers to learn.
+Linearly inseparable problems such as [exclusive or](https://en.wikipedia.org/wiki/Exclusive_or) require one or more hidden layers to learn.
     
 *)
 
@@ -298,7 +298,7 @@ let backprop' (n:Network') (eta:float) epochs mbsize loss (x:DM) (y:DM) =
 The Obligatory MNIST Example
 ----------------------------
 
-The MNIST database of handwritten digits is commonly used for demonstrating neural network training. The database contains 60,000 training images and 10,000 testing images. More information on the database and downloadable files can be found [here](http://yann.lecun.com/exdb/mnist/).
+The MNIST database of handwritten digits is commonly used for demonstrating neural network training. The database contains 60,000 training images and 10,000 testing images. More information on the database and downloadable files can be found [here](https://yann.lecun.com/exdb/mnist/).
 
 The following code reads the standard MNIST files into matrices.
 *)

--- a/docs/input/examples-newtonsmethod.fsx
+++ b/docs/input/examples-newtonsmethod.fsx
@@ -5,16 +5,16 @@
 Newton's Method
 ===============
 
-In optimization, [Newton's method](http://en.wikipedia.org/wiki/Newton%27s_method_in_optimization) from numerical analysis is used for finding the roots of the derivative of a function and thereby discovering its local extrema.
+In optimization, [Newton's method](https://en.wikipedia.org/wiki/Newton%27s_method_in_optimization) from numerical analysis is used for finding the roots of the derivative of a function and thereby discovering its local extrema.
 
 For a function $f: \mathbb{R}^n \to \mathbb{R}$, starting from an initial point $\mathbf{x}_0$, the method works by computing succsessive points in the function domain
 
 $$$
  \mathbf{x}_{n + 1} = \mathbf{x}_n - \eta \left(\mathbf{H}_f\right)_{\mathbf{x}_n}^{-1} \left( \nabla f \right)_{\mathbf{x}_n} \; ,
 
-where $\eta > 0$ is the step size, $\left(\mathbf{H}_f\right)_{\mathbf{x}_n}^{-1}$ is the inverse of the [Hessian](http://en.wikipedia.org/wiki/Hessian_matrix) of $f$ evaluated at $\mathbf{x}_n$, and $\left( \nabla f \right)_{\mathbf{x}_n}$ is the [gradient](http://en.wikipedia.org/wiki/Gradient) of $f$ evaluated at $\mathbf{x}_n$.
+where $\eta > 0$ is the step size, $\left(\mathbf{H}_f\right)_{\mathbf{x}_n}^{-1}$ is the inverse of the [Hessian](https://en.wikipedia.org/wiki/Hessian_matrix) of $f$ evaluated at $\mathbf{x}_n$, and $\left( \nabla f \right)_{\mathbf{x}_n}$ is the [gradient](https://en.wikipedia.org/wiki/Gradient) of $f$ evaluated at $\mathbf{x}_n$.
 
-Newton's method converges faster than gradient descent, but this comes at the cost of computing the Hessian of the function at each iteration. In practice, the Hessian is usually only approximated from the changes in the gradient, giving rise to [quasi-Netwon methods](http://en.wikipedia.org/wiki/Quasi-Newton_method) such as the [BFGS algorithm](http://en.wikipedia.org/wiki/Broyden%E2%80%93Fletcher%E2%80%93Goldfarb%E2%80%93Shanno_algorithm).
+Newton's method converges faster than gradient descent, but this comes at the cost of computing the Hessian of the function at each iteration. In practice, the Hessian is usually only approximated from the changes in the gradient, giving rise to [quasi-Netwon methods](https://en.wikipedia.org/wiki/Quasi-Newton_method) such as the [BFGS algorithm](https://en.wikipedia.org/wiki/Broyden%E2%80%93Fletcher%E2%80%93Goldfarb%E2%80%93Shanno_algorithm).
 
 Using DiffSharp, we can compute the exact Hessian efficiently via automatic differentiation. The following code implements Newton's method using the **DiffSharp.AD.Float64** module, which provides the **gradhessian** operation returning both the gradient and the Hessian of a function at a given point using forward-on-reverse AD.
 *)

--- a/docs/input/examples-stochasticgradientdescent.fsx
+++ b/docs/input/examples-stochasticgradientdescent.fsx
@@ -6,7 +6,7 @@
 Stochastic Gradient Descent
 ===========================
 
-[Stochastic gradient descent](http://en.wikipedia.org/wiki/Stochastic_gradient_descent) is a [stochastic](http://en.wikipedia.org/wiki/Stochastic) variant of the gradient descent algorithm that is used for minimizing loss functions with the form of a sum
+[Stochastic gradient descent](https://en.wikipedia.org/wiki/Stochastic_gradient_descent) is a [stochastic](https://en.wikipedia.org/wiki/Stochastic) variant of the gradient descent algorithm that is used for minimizing loss functions with the form of a sum
 
 $$$
   Q(\mathbf{w}) = \sum_{i=1}^{d} Q_i(\mathbf{w}) \; ,
@@ -28,7 +28,7 @@ Alternatively, in stochastic gradient descent, $Q$ is minimized using
 $$$
   \mathbf{w}_{t+1} = \mathbf{w}_t - \eta \nabla Q_i (\mathbf{w}_t) \; ,
 
-updating the weights $\mathbf{w}$ in each step using just one sample $i$ randomly chosen from the training set. This is advantageous for big sample sizes, because it makes the evaluation time of each step independent from $d$. Another advantage is that it can process samples on the fly, in an [online learning](http://en.wikipedia.org/wiki/Online_machine_learning) task.
+updating the weights $\mathbf{w}$ in each step using just one sample $i$ randomly chosen from the training set. This is advantageous for big sample sizes, because it makes the evaluation time of each step independent from $d$. Another advantage is that it can process samples on the fly, in an [online learning](https://en.wikipedia.org/wiki/Online_machine_learning) task.
 
 In practice, instead of $\eta$, the algorithm is used with a decreasing sequence of step sizes $\eta_t$, for convergence.
 
@@ -58,7 +58,7 @@ $$$
 
 where $f_{\mathbf{w}} : \mathbb{R}^n \to \mathbb{R}^m$ is a model function for our data (parameterized by $\mathbf{w}$) and $\mathbf{x}_i \in \mathbb{R}^n$ and $\mathbf{y}_i \in \mathbb{R}^m$ are the input–output pair of the $i$-th sample in the training set. Finding the parameters $\mathbf{w}$ minimizing $Q(\mathbf{w}) = \sum_{i=1}^{d} Q_i (\mathbf{w})$ thus fits the model function $f_{\mathbf{w}}$ to our data.
 
-We can test this via [fitting a curve](http://en.wikipedia.org/wiki/Curve_fitting)
+We can test this via [fitting a curve](https://en.wikipedia.org/wiki/Curve_fitting)
 
 $$$
   f_{\mathbf{w}} (x) = w_1 x^2 + w_2 x + w_3

--- a/docs/input/gettingstarted-nestedad.fsx
+++ b/docs/input/gettingstarted-nestedad.fsx
@@ -58,9 +58,9 @@ Correctly nesting AD in a functional framework is achieved through the method of
 
 _Jeffrey Mark Siskind and Barak A. Pearlmutter. Perturbation Confusion and Referential Transparency: Correct Functional Implementation of Forward-Mode AD. In Proceedings of the 17th International Workshop on Implementation and Application of Functional Languages (IFL2005), Dublin, Ireland, Sep. 19-21, 2005._
 
-_Jeffrey Mark Siskind and Barak A. Pearlmutter. Nesting forward-mode AD in a functional framework. Higher Order and Symbolic Computation 21(4):361-76, 2008. [doi:10.1007/s10990-008-9037-1](http://dx.doi.org/10.1007/s10990-008-9037-1) _
+_Jeffrey Mark Siskind and Barak A. Pearlmutter. Nesting forward-mode AD in a functional framework. Higher Order and Symbolic Computation 21(4):361-76, 2008. [doi:10.1007/s10990-008-9037-1](https://dx.doi.org/10.1007/s10990-008-9037-1) _
 
-_Barak A. Pearlmutter and Jeffrey Mark Siskind. Reverse-Mode AD in a functional framework: Lambda the ultimate backpropagator. TOPLAS 30(2):1-36, Mar. 2008. [doi:10.1145/1330017.1330018](http://dx.doi.org/10.1145/1330017.1330018) _
+_Barak A. Pearlmutter and Jeffrey Mark Siskind. Reverse-Mode AD in a functional framework: Lambda the ultimate backpropagator. TOPLAS 30(2):1-36, Mar. 2008. [doi:10.1145/1330017.1330018](https://dx.doi.org/10.1145/1330017.1330018) _
 
 Forward and Reverse AD Operations
 ---------------------------------
@@ -118,9 +118,9 @@ let jh = jacobian h (toDV [2.; 3.])
 Using the Reverse AD Trace
 --------------------------
 
-In addition to the high-level differentiation API that uses reverse AD (such as **grad**, **jacobianTv** ), you can make use of the exposed low-level [trace](http://en.wikipedia.org/wiki/Tracing_%28software%29) functionality. Reverse AD automatically builds a global trace (or "tape", in AD literature) of all executed numeric operations, which allows a subsequent reverse sweep of these operations for propagating adjoint values in reverse. 
+In addition to the high-level differentiation API that uses reverse AD (such as **grad**, **jacobianTv** ), you can make use of the exposed low-level [trace](https://en.wikipedia.org/wiki/Tracing_%28software%29) functionality. Reverse AD automatically builds a global trace (or "tape", in AD literature) of all executed numeric operations, which allows a subsequent reverse sweep of these operations for propagating adjoint values in reverse. 
 
-The technique is equivalent to the [backpropagation](http://en.wikipedia.org/wiki/Backpropagation) method commonly used for training artificial neural networks, which is essentially just a special case of reverse AD. (You can see an implementation of the backpropagation algorithm using reverse AD in the [neural networks example](examples-neuralnetworks.html).)
+The technique is equivalent to the [backpropagation](https://en.wikipedia.org/wiki/Backpropagation) method commonly used for training artificial neural networks, which is essentially just a special case of reverse AD. (You can see an implementation of the backpropagation algorithm using reverse AD in the [neural networks example](examples-neuralnetworks.html).)
 
 For example, consider the computation
 

--- a/docs/input/gettingstarted-numericaldifferentiation.fsx
+++ b/docs/input/gettingstarted-numericaldifferentiation.fsx
@@ -5,7 +5,7 @@
 Numerical Differentiation
 =========================
 
-In addition to AD, DiffSharp also implements [numerical differentiation](http://en.wikipedia.org/wiki/Numerical_differentiation).
+In addition to AD, DiffSharp also implements [numerical differentiation](https://en.wikipedia.org/wiki/Numerical_differentiation).
 
 Numerical differentiation is based on finite difference approximations of derivative values, using values of the original function evaluated at some sample points. Unlike AD, numerical differentiation gives only approximate results and is unstable due to truncation and roundoff errors.
 

--- a/docs/input/gettingstarted-symbolicdifferentiation.fsx
+++ b/docs/input/gettingstarted-symbolicdifferentiation.fsx
@@ -5,14 +5,14 @@
 Symbolic Differentiation
 ========================
 
-In addition to AD, the DiffSharp library also implements [symbolic differentiation](http://en.wikipedia.org/wiki/Symbolic_computation), which works by the symbolic manipulation of closed-form expressions using rules of differential calculus.
+In addition to AD, the DiffSharp library also implements [symbolic differentiation](https://en.wikipedia.org/wiki/Symbolic_computation), which works by the symbolic manipulation of closed-form expressions using rules of differential calculus.
 
 For a complete list of the available differentiation operations, please refer to [API Overview](api-overview.html) and [API Reference](reference/index.html).
 
 DiffSharp.Symbolic
 ------------------
 
-This is a symbolic differentiation module, used with the [**Expr**](http://msdn.microsoft.com/en-us/library/ee370577.aspx) type representing F# code expressions. A common way of generating F# code expressions is to use [code quotations](http://msdn.microsoft.com/en-us/library/dd233212.aspx), with the <@ and @> symbols delimiting an expression.
+This is a symbolic differentiation module, used with the [**Expr**](https://msdn.microsoft.com/en-us/library/ee370577.aspx) type representing F# code expressions. A common way of generating F# code expressions is to use [code quotations](https://msdn.microsoft.com/en-us/library/dd233212.aspx), with the <@ and @> symbols delimiting an expression.
 
 Symbolic differentiation operators construct the wanted derivative as a new expression and return this as a compiled function that can be used subsequently for evaluating the derivative. Once the derivative expression is compiled and returned, it is significantly faster to run it with specific numerical arguments, compared to the initial time it takes to compile the function. You can see example compilation and running times on the [Benchmarks](benchmarks.html) page.
 *)
@@ -27,7 +27,7 @@ let d = diff <@ fun x -> sin (3. * sqrt x) @>
 let d2 = d 2.
 
 (**
-Function definitions should be marked with the [**ReflectedDefinition**](http://msdn.microsoft.com/en-us/library/ee353643.aspx) attribute for allowing access to quotation expressions at runtime.
+Function definitions should be marked with the [**ReflectedDefinition**](https://msdn.microsoft.com/en-us/library/ee353643.aspx) attribute for allowing access to quotation expressions at runtime.
 *)
 
 // f: float -> float

--- a/docs/input/gettingstarted-typeinference.fsx
+++ b/docs/input/gettingstarted-typeinference.fsx
@@ -7,7 +7,7 @@ Type Inference
 
 Differentiation can be applied to functions using the **D**, **DV**, and **DM** types respectively for scalar, vector, and matrix values. 32- and 64-bit floating point varieties of these types are provided by the **DiffSharp.AD.Float32** and **DiffSharp.AD.Float64** modules. On many current systems, 32-bit (single) precision floating point operations run significantly faster than 64-bit (double) precision. It is therefore recommended to use the 32-bit module if this precision is sufficient for your usage case.
 
-The library automatically instantiates [dual numbers](http://en.wikipedia.org/wiki/Dual_number) (for forward AD) and/or [adjoints](http://en.wikipedia.org/wiki/Adjoint) (for reverse AD) as needed, using the best one for a given differentiation operation.
+The library automatically instantiates [dual numbers](https://en.wikipedia.org/wiki/Dual_number) (for forward AD) and/or [adjoints](https://en.wikipedia.org/wiki/Adjoint) (for reverse AD) as needed, using the best one for a given differentiation operation.
 
 DiffSharp supports nested AD, which means that you can evaluate derivatives of functions that may themselves be internally using derivatives, up to arbitrary level. All emerging higher-order derivatives are automatically handled by the library and computed exactly and efficiently.
 
@@ -41,7 +41,7 @@ There are several ways the type inference system can work together with DiffShar
 
 ### Lambda Expressions
 
-The simplest and easiest way is to define functions using [lambda expressions](http://msdn.microsoft.com/en-us/library/dd233201.aspx) after differentiation operators. The expression will automatically assume the required signature.
+The simplest and easiest way is to define functions using [lambda expressions](https://msdn.microsoft.com/en-us/library/dd233201.aspx) after differentiation operators. The expression will automatically assume the required signature.
 
 (You can hover the pointer over the examples to check their types.)
 *)
@@ -90,7 +90,7 @@ let df4 = diff f4
 (**
 ### Generic Functions
 
-In the previous example, **f4** assumes the **D -> D** type and therefore cannot be used with other types, for example **float**. We can get around this by defining [generic numeric functions](http://tomasp.net/blog/fsharp-generic-numeric.aspx/) that can work with multiple types, by using **inline**.
+In the previous example, **f4** assumes the **D -> D** type and therefore cannot be used with other types, for example **float**. We can get around this by defining [generic numeric functions](https://tomasp.net/blog/fsharp-generic-numeric.aspx/) that can work with multiple types, by using **inline**.
 
 *)
 // f5 is the generic version of f4

--- a/docs/input/index.fsx
+++ b/docs/input/index.fsx
@@ -5,15 +5,15 @@
 DiffSharp: Differentiable Functional Programming
 ================================================
 
-DiffSharp is a functional [automatic differentiation](http://en.wikipedia.org/wiki/Automatic_differentiation) (AD) library.
+DiffSharp is a functional [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation) (AD) library.
 
-AD allows exact and efficient calculation of derivatives, by systematically invoking the chain rule of calculus at the elementary operator level during program execution. AD is different from [numerical differentiation](http://en.wikipedia.org/wiki/Numerical_differentiation), which is prone to truncation and round-off errors, and [symbolic differentiation](http://en.wikipedia.org/wiki/Symbolic_computation), which is affected by expression swell and cannot fully handle algorithmic control flow.
+AD allows exact and efficient calculation of derivatives, by systematically invoking the chain rule of calculus at the elementary operator level during program execution. AD is different from [numerical differentiation](https://en.wikipedia.org/wiki/Numerical_differentiation), which is prone to truncation and round-off errors, and [symbolic differentiation](https://en.wikipedia.org/wiki/Symbolic_computation), which is affected by expression swell and cannot fully handle algorithmic control flow.
 
 Using the DiffSharp library, differentiation (gradients, Hessians, Jacobians, directional derivatives, and matrix-free Hessian- and Jacobian-vector products) is applied using higher-order functions, that is, functions which take other functions as arguments. Your functions can use the full expressive capability of the language including control flow. DiffSharp allows composition of differentiation using nested forward and reverse AD up to any level, meaning that you can compute exact higher-order derivatives or differentiate functions that are internally making use of differentiation. Please see the [API Overview](api-overview.html) page for a list of available operations.
 
-The library is developed by [Atılım Güneş Baydin](http://www.cs.nuim.ie/~gunes/) and [Barak A. Pearlmutter](http://bcl.hamilton.ie/~barak/) mainly for research applications in machine learning, as part of their work at the [Brain and Computation Lab](http://www.bcl.hamilton.ie/), Hamilton Institute, National University of Ireland Maynooth.
+The library is developed by [Atılım Güneş Baydin](https://www.cs.nuim.ie/~gunes/) and [Barak A. Pearlmutter](http://bcl.hamilton.ie/~barak/) mainly for research applications in machine learning, as part of their work at the [Brain and Computation Lab](http://www.bcl.hamilton.ie/), Hamilton Institute, National University of Ireland Maynooth.
 
-DiffSharp is implemented in the F# language and [can be used from C#](csharp.html) and the [other languages](http://en.wikipedia.org/wiki/List_of_CLI_languages) running on Mono, [.NET Core](http://dotnet.github.io/), or the .Net Framework, targeting the 64 bit platform. It is tested on Linux and Windows. We are working on interfaces/ports to other languages.
+DiffSharp is implemented in the F# language and [can be used from C#](csharp.html) and the [other languages](https://en.wikipedia.org/wiki/List_of_CLI_languages) running on Mono, [.NET Core](https://dotnet.github.io/), or the .Net Framework, targeting the 64 bit platform. It is tested on Linux and Windows. We are working on interfaces/ports to other languages.
 
 <div class="row">
     <div class="span9">
@@ -75,19 +75,19 @@ let hg = hessian g
 More Info and How to Cite
 -------------------------
 
-If you are using DiffSharp, we would be very happy to hear about it! Please get in touch with us using email or raise any issues you might have [on GitHub](http://github.com/DiffSharp/DiffSharp). We also have a [Gitter chat room](https://gitter.im/DiffSharp/DiffSharp) that we follow.
+If you are using DiffSharp, we would be very happy to hear about it! Please get in touch with us using email or raise any issues you might have [on GitHub](https://github.com/DiffSharp/DiffSharp). We also have a [Gitter chat room](https://gitter.im/DiffSharp/DiffSharp) that we follow.
 
 If you would like to cite this library, please use the following information:
 
-_Atılım Güneş Baydin, Barak A. Pearlmutter, Alexey Andreyevich Radul, Jeffrey Mark Siskind (2015) Automatic differentiation and machine learning: a survey. arXiv preprint. arXiv:1502.05767_ ([link](http://arxiv.org/abs/1502.05767)) ([BibTeX](misc/adml2015.bib))
+_Atılım Güneş Baydin, Barak A. Pearlmutter, Alexey Andreyevich Radul, Jeffrey Mark Siskind (2015) Automatic differentiation and machine learning: a survey. arXiv preprint. arXiv:1502.05767_ ([link](https://arxiv.org/abs/1502.05767)) ([BibTeX](misc/adml2015.bib))
 
-You can also check our [**recent poster**](http://www.cs.nuim.ie/~gunes/files/ICML2015-MLOSS-Poster-A0.pdf) for the [Machine Learning Open Source Software Workshop](http://mloss.org/workshop/icml15/) at the International Conference on Machine Learning 2015. For in-depth material, you can check our [publications page](http://www.bcl.hamilton.ie/publications/) and the [autodiff.org](http://www.autodiff.org/) website. 
+You can also check our [**recent poster**](https://www.cs.nuim.ie/~gunes/files/ICML2015-MLOSS-Poster-A0.pdf) for the [Machine Learning Open Source Software Workshop](https://mloss.org/workshop/icml15/) at the International Conference on Machine Learning 2015. For in-depth material, you can check our [publications page](http://www.bcl.hamilton.ie/publications/) and the [autodiff.org](https://www.autodiff.org/) website. 
 
 Other sources:
 
-- [Introduction to Automatic Differentiation](http://alexey.radul.name/ideas/2013/introduction-to-automatic-differentiation/) by Alexey Radul
+- [Introduction to Automatic Differentiation](https://alexey.radul.name/ideas/2013/introduction-to-automatic-differentiation/) by Alexey Radul
 - [Automatic Differentiation: The most criminally underused tool in the potential machine learning toolbox?](https://justindomke.wordpress.com/2009/02/17/automatic-differentiation-the-most-criminally-underused-tool-in-the-potential-machine-learning-toolbox/) by Justin Domke
-- [Differentiable Programming](http://edge.org/response-detail/26794) by David Dalrymple
-- [Neural Networks, Types, and Functional Programming](http://colah.github.io/posts/2015-09-NN-Types-FP/) by Christopher Olah
+- [Differentiable Programming](https://edge.org/response-detail/26794) by David Dalrymple
+- [Neural Networks, Types, and Functional Programming](https://colah.github.io/posts/2015-09-NN-Types-FP/) by Christopher Olah
 
 *)

--- a/docs/input/templates/template.cshtml
+++ b/docs/input/templates/template.cshtml
@@ -11,7 +11,7 @@
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
 
     <link type="text/css" rel="stylesheet" href="../misc/style.css" />
@@ -30,7 +30,7 @@
     <div class="container">
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
-          <li><a href="http://fsharp.org">fsharp.org</a></li>
+          <li><a href="https://fsharp.org">fsharp.org</a></li>
         </ul>
         <h3 class="muted">@Properties["project-name"]</h3>
       </div>
@@ -92,7 +92,7 @@
 
             <li class="nav-header">Makers</li>
             <li class="divider"></li>
-            <li><a href="http://www.cs.nuim.ie/~gunes/">Atılım Güneş Baydin</a></li>
+            <li><a href="https://www.cs.nuim.ie/~gunes/">Atılım Güneş Baydin</a></li>
             <li><a href="http://www.bcl.hamilton.ie/~barak/">Barak A. Pearlmutter</a></li>
             <li><a href="http://www.bcl.hamilton.ie/">Brain and Computation Lab</a></li>
           </ul>
@@ -111,9 +111,9 @@
     "statcounter.com/counter/counter.js'></"+"script>");
     </script>
     <noscript><div class="statcounter"><a title="web stats"
-    href="http://statcounter.com/free-web-stats/"
+    href="https://statcounter.com/free-web-stats/"
     target="_blank"><img class="statcounter"
-    src="http://c.statcounter.com/10059115/0/92275ee1/1/"
+    src="https://c.statcounter.com/10059115/0/92275ee1/1/"
     alt="web stats"></a></div></noscript>
     <!-- End of StatCounter Code for Default Guide -->
   </body>

--- a/docs/input/templates/template.cshtml
+++ b/docs/input/templates/template.cshtml
@@ -11,7 +11,7 @@
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
 
     <link type="text/css" rel="stylesheet" href="../misc/style.css" />

--- a/docs/input/templates/template.cshtml
+++ b/docs/input/templates/template.cshtml
@@ -16,10 +16,6 @@
 
     <link type="text/css" rel="stylesheet" href="../misc/style.css" />
     <script type="text/javascript" src="../misc/tips.js"></script>
-    <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/docs/input/templates/template.html
+++ b/docs/input/templates/template.html
@@ -16,7 +16,7 @@
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
     
     <link type="text/css" rel="stylesheet" href="misc/style.css" />

--- a/docs/input/templates/template.html
+++ b/docs/input/templates/template.html
@@ -16,7 +16,7 @@
     <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
     <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
     <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
     
     <link type="text/css" rel="stylesheet" href="misc/style.css" />
@@ -35,7 +35,7 @@
     <div class="container">
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
-          <li><a href="http://fsharp.org">fsharp.org</a></li>
+          <li><a href="https://fsharp.org">fsharp.org</a></li>
         </ul>
         <h3 class="muted">{project-name}</h3>
       </div>
@@ -97,7 +97,7 @@
 
             <li class="nav-header">Makers</li>
             <li class="divider"></li>
-            <li><a href="http://www.cs.nuim.ie/~gunes/">Atılım Güneş Baydin</a></li>
+            <li><a href="https://www.cs.nuim.ie/~gunes/">Atılım Güneş Baydin</a></li>
             <li><a href="http://www.bcl.hamilton.ie/~barak/">Barak A. Pearlmutter</a></li>
             <li><a href="http://www.bcl.hamilton.ie/">Brain and Computation Lab</a></li>
           </ul>
@@ -116,9 +116,9 @@
     "statcounter.com/counter/counter.js'></"+"script>");
     </script>
     <noscript><div class="statcounter"><a title="web stats"
-    href="http://statcounter.com/free-web-stats/"
+    href="https://statcounter.com/free-web-stats/"
     target="_blank"><img class="statcounter"
-    src="http://c.statcounter.com/10059115/0/92275ee1/1/"
+    src="https://c.statcounter.com/10059115/0/92275ee1/1/"
     alt="web stats"></a></div></noscript>
     <!-- End of StatCounter Code for Default Guide -->
   </body>

--- a/docs/input/templates/template.html
+++ b/docs/input/templates/template.html
@@ -21,10 +21,6 @@
     
     <link type="text/css" rel="stylesheet" href="misc/style.css" />
     <script src="misc/tips.js" type="text/javascript"></script>
-    <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/src/DiffSharp/AD.Float32.fs
+++ b/src/DiffSharp/AD.Float32.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/AD.Float64.fs
+++ b/src/DiffSharp/AD.Float64.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/Backend.OpenBLAS.fs
+++ b/src/DiffSharp/Backend.OpenBLAS.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/Backend.fs
+++ b/src/DiffSharp/Backend.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/Config.fs
+++ b/src/DiffSharp/Config.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/Interop.Float32.fs
+++ b/src/DiffSharp/Interop.Float32.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/Interop.Float64.fs
+++ b/src/DiffSharp/Interop.Float64.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/Numerical.Float32.fs
+++ b/src/DiffSharp/Numerical.Float32.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/Numerical.Float64.fs
+++ b/src/DiffSharp/Numerical.Float64.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/Symbolic.Float32.fs
+++ b/src/DiffSharp/Symbolic.Float32.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/Symbolic.Float64.fs
+++ b/src/DiffSharp/Symbolic.Float64.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/src/DiffSharp/Util.fs
+++ b/src/DiffSharp/Util.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/tests/DiffSharp.Tests/AD.Float32.fs
+++ b/tests/DiffSharp.Tests/AD.Float32.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/tests/DiffSharp.Tests/Backend.OpenBLAS.fs
+++ b/tests/DiffSharp.Tests/Backend.OpenBLAS.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/tests/DiffSharp.Tests/MathematicaTests.nb
+++ b/tests/DiffSharp.Tests/MathematicaTests.nb
@@ -1,7 +1,7 @@
 (* Content-type: application/vnd.wolfram.mathematica *)
 
 (*** Wolfram Notebook File ***)
-(* http://www.wolfram.com/nb *)
+(* https://www.wolfram.com/nb *)
 
 (* CreatedBy='Mathematica 10.0' *)
 

--- a/tests/DiffSharp.Tests/Tests.fs
+++ b/tests/DiffSharp.Tests/Tests.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)

--- a/tests/Dsbench/Program.fs
+++ b/tests/Dsbench/Program.fs
@@ -1,4 +1,4 @@
-﻿// This file is part of DiffSharp: Differentiable Functional Programming - http://diffsharp.github.io
+﻿// This file is part of DiffSharp: Differentiable Functional Programming - https://diffsharp.github.io
 // Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
 // Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme <dsyme@microsoft.com>)
 // Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter <barak@pearlmutter.net>)


### PR DESCRIPTION
This adds the changes from #48 into the docs codegen [as requested here](https://github.com/DiffSharp/DiffSharp/pull/48#issuecomment-472955002)

There are a couple additional changes here that were not done in that branch, but could be. (Updating the MathJax CDN, a couple function name fixes).

Unfortunately, I've too much trouble getting the doc gen script to actually work due to dependency issues, along with my own unfamiliarity with the F# ecosystem. Hopefully someone else is better positioned to help properly regenerate the docs!