### PR TITLE
WIP: .NET Standard NuGet release

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,3 +3,4 @@ cls
 dotnet --version
 dotnet build DiffSharp.sln -c release -v:n
 dotnet test tests/DiffSharp.Tests  -c release -v:n
+dotnet pack DiffSharp.sln -c release

--- a/src/DiffSharp/DiffSharp.fsproj
+++ b/src/DiffSharp/DiffSharp.fsproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <OtherFlags>/warnon:1182</OtherFlags>
     <PlatformTarget>x64</PlatformTarget>
+    <Version>0.8.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
@@ -19,21 +20,37 @@
     <Compile Include="Interop.Float32.fs" />
     <Compile Include="Interop.Float64.fs" />
     <None Include="..\..\lib\OpenBLAS-v0.2.15-Win64-int32\libgcc_s_seh-1.dll">
+      <Pack>true</Pack>
+      <PackagePath>build\</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\..\lib\OpenBLAS-v0.2.15-Win64-int32\libgfortran-3.dll">
+      <Pack>true</Pack>
+      <PackagePath>build\</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\..\lib\OpenBLAS-v0.2.15-Win64-int32\libopenblas.dll">
+      <Pack>true</Pack>
+      <PackagePath>build\</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\..\lib\OpenBLAS-v0.2.15-Win64-int32\libquadmath-0.dll">
+      <Pack>true</Pack>
+      <PackagePath>build\</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\..\lib\OpenBLAS-v0.3.5-macOS-x86_64\libopenblas.dylib">
+      <Pack>true</Pack>
+      <PackagePath>build\</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\..\README.md">
+      <Pack>true</Pack>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="DiffSharp.targets">
+      <Pack>true</Pack>
+      <PackagePath>build\</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/DiffSharp/DiffSharp.fsproj
+++ b/src/DiffSharp/DiffSharp.fsproj
@@ -4,6 +4,29 @@
     <OtherFlags>/warnon:1182</OtherFlags>
     <PlatformTarget>x64</PlatformTarget>
     <Version>0.8.0</Version>
+    <Authors>Atılım Güneş Baydin,Barak A. Pearlmutter</Authors>
+    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
+    <PackageIconUrl>http://diffsharp.github.io/DiffSharp/img/diffsharp-logo.png</PackageIconUrl>
+    <PackageDescription>DiffSharp is an automatic differentiation (AD) library.
+
+AD allows exact and efficient calculation of derivatives, by systematically invoking the chain rule of calculus at the elementary operator level during program execution. AD is different from numerical differentiation, which is prone to truncation and round-off errors, and symbolic differentiation, which is affected by expression swell and cannot fully handle algorithmic control flow.
+
+Using the DiffSharp library, derivative calculations (gradients, Hessians, Jacobians, directional derivatives, and matrix-free Hessian- and Jacobian-vector products) can be incorporated with minimal change into existing algorithms. Diffsharp supports nested forward and reverse AD up to any level, meaning that you can compute exact higher-order derivatives or differentiate functions that are internally making use of differentiation. Please see the API Overview page for a list of available operations.
+
+The library is under active development by Atılım Güneş Baydin and Barak A. Pearlmutter mainly for research applications in machine learning, as part of their work at the Brain and Computation Lab, Hamilton Institute, National University of Ireland Maynooth.
+
+DiffSharp is implemented in the F# language and can be used from C# and the other languages running on .NET Core, Mono, or the .NET Framework; targeting the 64 bit platform. It is tested on Linux and Windows. We are working on interfaces/ports to other languages.</PackageDescription>
+    <PackageReleaseNotes>Please visit
+
+https://github.com/DiffSharp/DiffSharp/releases
+
+for the latest release notes.</PackageReleaseNotes>
+    <Copyright>Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin)
+Copyright (c) 2017-     Microsoft Research, Cambridge, UK (Don Syme)
+Copyright (c) 2014-     National University of Ireland Maynooth (Barak A. Pearlmutter)
+Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Baydin)</Copyright>
+    <PackageTags>Differentiation;Automatic;Symbolic;Numerical;Optimization;Machine Learning;FSharp;F#</PackageTags>
+
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/src/DiffSharp/DiffSharp.targets
+++ b/src/DiffSharp/DiffSharp.targets
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="'$(MSBuildThisFileDirectory)' != '' And HasTrailingSlash('$(MSBuildThisFileDirectory)')">
+    <NativeLibs Include="$(MSBuildThisFileDirectory)**\*.dll" />
+    <Content Include="@(NativeLibs)">
+      <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
#52 

I've added the metadata from the previous NuGet 0.7.7, with some updates. I put the packing information for the native libraries.

@erydo I saw you've been helping out with the macOS builds. Currently the targets file https://github.com/DiffSharp/DiffSharp/blob/3bf7a97f6d7dbab7c85c9131467df480465e54a8/src/DiffSharp/DiffSharp.targets is from the previous NuGet. Given it auto-references specifically the dlls that'll be annoying on macOS. Does it make sense to conditionally get the dylib you added?

@gbaydin & @dsyme any adjustments that we should make before releasing?
