### PR TITLE
Native dependencies, better behaviour on non-Windows

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 case "$(uname -s)" in
 
    Darwin)
-     brew install homebrew/science/openblas
+     brew install openblas
      ;;
 
    CYGWIN*|MINGW32*|MSYS*|Linux)
@@ -25,7 +25,9 @@ if [ -d "MONO" ]; then
    # not currently testing on mono
    # mono ./packages/NUnit.Runners/tools/nunit-console.exe ./tests/DiffSharp.Tests/bin/Release/DiffSharp.Tests.dll
 else
+   dotnet --version
    dotnet build DiffSharp.sln -c debug 
    dotnet test tests/DiffSharp.Tests  -c release -f netcoreapp2.0
+   dotnet pack DiffSharp.sln -c release
 fi
 

--- a/src/DiffSharp/DiffSharp.fsproj
+++ b/src/DiffSharp/DiffSharp.fsproj
@@ -63,8 +63,6 @@ Copyright (c) 2014-2016 National University of Ireland Maynooth (Atilim Gunes Ba
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\..\lib\OpenBLAS-v0.3.5-macOS-x86_64\libopenblas.dylib">
-      <Pack>true</Pack>
-      <PackagePath>build\</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\..\README.md">

--- a/src/DiffSharp/DiffSharp.targets
+++ b/src/DiffSharp/DiffSharp.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Condition="'$(MSBuildThisFileDirectory)' != '' And HasTrailingSlash('$(MSBuildThisFileDirectory)')">
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT' And '$(MSBuildThisFileDirectory)' != '' And HasTrailingSlash('$(MSBuildThisFileDirectory)')">
     <NativeLibs Include="$(MSBuildThisFileDirectory)**\*.dll" />
     <Content Include="@(NativeLibs)">
       <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>


### PR DESCRIPTION
Only copy the Windows native dlls when on Windows
Adjust the Homebrew command for where openblas is now