### PR TITLE
Fix for single precision adjoint calculation

### DIFF
--- a/src/DiffSharp/Backend.OpenBLAS.fs
+++ b/src/DiffSharp/Backend.OpenBLAS.fs
@@ -715,7 +715,8 @@ module OpenBLAS =
                 let xl2 = Array2D.length2 x
                 let yl1 = Array2D.length1 y
                 let yl2 = Array2D.length2 y
-                if (xl1 <> yl1) || (xl2 <> yl2) then
+                if xl1 * xl2 = 0 then ()
+                elif (xl1 <> yl1) || (xl2 <> yl2) then
                     ErrorMessages.InvalidArgMM()
                 else
                     Stats.InplaceOp(yl1 * yl2)

--- a/tests/DiffSharp.Tests/AD.Float32.fs
+++ b/tests/DiffSharp.Tests/AD.Float32.fs
@@ -24,3 +24,16 @@ let ``AD.32.R.D.FixedPoint``() =
     let g (a:D) (b:D) = (a + b / a) / (D 2.f)
     let p, t = jacobianTv' (D.FixedPoint g (D 1.2f)) (D 25.f) (D 1.f)
     Util.(=~)(p, D 5.f) && Util.(=~)(t, D 0.1f)
+
+[<Property>]
+let ``Compute Adjoint``() =
+    let tag = DiffSharp.Util.GlobalTagger.Next        
+    
+    let Wt = toDM [[0.0f; 1.0f]]
+    let Wt' = Wt |> makeReverse tag   
+    let loss (weights:DM) : D = cos (weights.Item(0,0))
+    
+    let L = loss Wt'
+    let A = computeAdjoints L //Smoke test computeAdjoints, was an issue with single precision
+
+    ()


### PR DESCRIPTION
Take extra check from double precision addition and apply it to single precision case
Added a smoke test, could expand this to check calculation