### PR TITLE
Add set-up of Mul_DMCons_DM for adjoint calculation

### DIFF
--- a/src/DiffSharp/AD.Float32.fs
+++ b/src/DiffSharp/AD.Float32.fs
@@ -3480,6 +3480,7 @@ module DOps =
                             | Sub_DMCons_DM(a) -> resetRec (bxd a :: t)
                             | Mul_DM_DM(a, b) -> resetRec (bxd a :: bxd b :: t)
                             | Mul_DM_DMCons(a, _) -> resetRec (bxd a :: t)
+                            | Mul_DMCons_DM(_, b) -> resetRec (bxd b :: t)
                             | Mul_Had_DM_DM(a, b) -> resetRec (bxd a :: bxd b :: t)
                             | Mul_Had_DM_DMCons(a, _) -> resetRec (bxd a :: t)
                             | Mul_DM_D(a, b) -> resetRec (bxd a :: bxd b :: t)

--- a/src/DiffSharp/AD.Float64.fs
+++ b/src/DiffSharp/AD.Float64.fs
@@ -3480,6 +3480,7 @@ module DOps =
                             | Sub_DMCons_DM(a) -> resetRec (bxd a :: t)
                             | Mul_DM_DM(a, b) -> resetRec (bxd a :: bxd b :: t)
                             | Mul_DM_DMCons(a, _) -> resetRec (bxd a :: t)
+                            | Mul_DMCons_DM(_, b) -> resetRec (bxd b :: t)
                             | Mul_Had_DM_DM(a, b) -> resetRec (bxd a :: bxd b :: t)
                             | Mul_Had_DM_DMCons(a, _) -> resetRec (bxd a :: t)
                             | Mul_DM_D(a, b) -> resetRec (bxd a :: bxd b :: t)

--- a/tests/DiffSharp.Tests/AD.Float32.fs
+++ b/tests/DiffSharp.Tests/AD.Float32.fs
@@ -37,3 +37,22 @@ let ``Compute Adjoint``() =
     let A = computeAdjoints L //Smoke test computeAdjoints, was an issue with single precision
 
     ()
+
+[<Property>]
+let ``Gradient descent``() =
+
+    let minimize (f:DV->D) (x0:DV) = 
+        let eta = 1e-2f
+        let mutable W = x0
+        for _ in [0..10] do
+            let L,g = grad' f W
+            printfn "%f" (float32 L)
+            W <- W - eta*g
+
+    let lossFunction (w:DV) =
+        let x = toDM [[1.0; 0.0]]
+        let Wg = w.[0..3] |> DM.ofDV 2
+        let g = (x*Wg)
+        cos g.[0,0]
+
+    minimize lossFunction (DV.create 5 1.0f) //Smoke test

--- a/tests/DiffSharp.Tests/AD.Float32.fs
+++ b/tests/DiffSharp.Tests/AD.Float32.fs
@@ -46,7 +46,6 @@ let ``Gradient descent``() =
         let mutable W = x0
         for _ in [0..10] do
             let L,g = grad' f W
-            printfn "%f" (float32 L)
             W <- W - eta*g
 
     let lossFunction (w:DV) =


### PR DESCRIPTION
Fixes an initialisation issue with constant matrix * matrix

Added a simple gradient descent test, perhaps need to separate out these smoke tests or start controlling the randomness and check results.