### PR TITLE
Correction to matrix slicing for start point of AddSubMatrix

### DIFF
--- a/src/DiffSharp/AD.Float32.fs
+++ b/src/DiffSharp/AD.Float32.fs
@@ -1474,7 +1474,7 @@ and DM =
         match d with
         | DM(ap) -> DM(ap.[rowStart..rowFinish, colStart..colFinish])
         | DMF(ap, at, ai) -> DMF(ap.[rowStart..rowFinish, colStart..colFinish], at.[rowStart..rowFinish, colStart..colFinish], ai)
-        | DMR(ap, _, ai, _) -> let cp = ap.[rowStart..rowFinish, colStart..colFinish] in DM.R(cp, Slice_DM(d, rowStart, rowFinish), ai)
+        | DMR(ap, _, ai, _) -> let cp = ap.[rowStart..rowFinish, colStart..colFinish] in DM.R(cp, Slice_DM(d, rowStart, colStart), ai)
 
     member d.GetSlice(row, colStart, colFinish) =
         let colStart = defaultArg colStart 0

--- a/src/DiffSharp/AD.Float64.fs
+++ b/src/DiffSharp/AD.Float64.fs
@@ -1474,7 +1474,7 @@ and DM =
         match d with
         | DM(ap) -> DM(ap.[rowStart..rowFinish, colStart..colFinish])
         | DMF(ap, at, ai) -> DMF(ap.[rowStart..rowFinish, colStart..colFinish], at.[rowStart..rowFinish, colStart..colFinish], ai)
-        | DMR(ap, _, ai, _) -> let cp = ap.[rowStart..rowFinish, colStart..colFinish] in DM.R(cp, Slice_DM(d, rowStart, rowFinish), ai)
+        | DMR(ap, _, ai, _) -> let cp = ap.[rowStart..rowFinish, colStart..colFinish] in DM.R(cp, Slice_DM(d, rowStart, colStart), ai)
 
     member d.GetSlice(row, colStart, colFinish) =
         let colStart = defaultArg colStart 0

--- a/tests/DiffSharp.Tests/AD.Float32.fs
+++ b/tests/DiffSharp.Tests/AD.Float32.fs
@@ -55,3 +55,22 @@ let ``Gradient descent``() =
         cos g.[0,0]
 
     minimize lossFunction (DV.create 5 1.0f) //Smoke test
+
+
+[<Property>]
+let ``Gradient descent (with arrays)``() =
+
+    let minimize (f:DV->D) (x0:DV) = 
+        let eta = 1e-2f
+        let mutable W = x0
+        for _ in [0..10] do
+            let L,g = grad' f W
+            W <- W - eta*g
+
+    let n = 5
+    let lossFunction (w:DV) =
+        let x = DM.init n n (fun i j -> w.[n*i+j])
+        let x' = x.GetSlice(None, None, None, None)
+        cos x'.[0,0]
+
+    minimize lossFunction (DV.create (n*n) 1.0f) //Smoke test


### PR DESCRIPTION
I've traced through an issue we hit with array slicing. I believe it's supplying "row finish" rather than "column start" which doesn't match how it's used:

https://github.com/DiffSharp/DiffSharp/blob/855b1926d422744ac38d8750c57957e675dc2046/src/DiffSharp/AD.Float32.fs#L2358-L2359

Smoke test demonstrating index out of bounds.