### PR TITLE
Simplify RawTensor API and RawTensorFloat32CPU

### DIFF
--- a/src/DiffSharp.Backend.None/RawTensorFloat32CPU.fs
+++ b/src/DiffSharp.Backend.None/RawTensorFloat32CPU.fs
@@ -443,13 +443,13 @@ type RawTensorFloat32CPU(values: float32[], shape:int[]) =
         let result = t.Values |> Array.map abs
         upcast RawTensorFloat32CPU(result, t.Shape)
 
-    override t1.ReluT() =
-        let result = t1.Values |> Array.map (max 0.f) 
-        upcast RawTensorFloat32CPU(result, t1.Shape)
+    override t.ReluT() =
+        let result = t.Values |> Array.map (max 0.f) 
+        upcast RawTensorFloat32CPU(result, t.Shape)
 
-    override t1.SigmoidT() =
-        let result = t1.Values |> Array.map (fun v -> 1.f / (1.f + exp -v))
-        upcast RawTensorFloat32CPU(result, t1.Shape)
+    override t.SigmoidT() =
+        let result = t.Values |> Array.map (fun v -> 1.f / (1.f + exp -v))
+        upcast RawTensorFloat32CPU(result, t.Shape)
 
     override t.ExpT() =
         let result = t.Values |> Array.map exp

--- a/src/DiffSharp.Backend.None/RawTensorFloat32CPU.fs
+++ b/src/DiffSharp.Backend.None/RawTensorFloat32CPU.fs
@@ -4,8 +4,49 @@ open DiffSharp.Backend
 open DiffSharp.Util
 open System
 
-type RawTensorFloat32CPU(value: float32[], shape:int[]) =
-    inherit RawTensor(value, shape, Float32, CPU, DiffSharp.Backend.Backend.None)
+type RawTensorFloat32CPU(values: float32[], shape:int[]) =
+    inherit RawTensor(shape, Float32, CPU, DiffSharp.Backend.Backend.None)
+
+    member __.Value = values
+
+    static member Zero() =
+        let values = [|0.f|]
+        RawTensorFloat32CPU(values, [||])
+
+    static member One() =
+        let values = [|1.f|]
+        RawTensorFloat32CPU(values, [||])
+    
+    static member Zeros(shape:int[]) =
+        let values = Array.create (shapeLength shape) 0.f
+        RawTensorFloat32CPU(values, shape)
+
+    static member Ones(shape:int[]) =
+        let values = Array.create (shapeLength shape) 1.f
+        RawTensorFloat32CPU(values, shape)
+
+    static member Random(shape:int[])  =
+        let values = Array.init (shapeLength shape) (fun _ -> float32 (Random.Uniform()))
+        RawTensorFloat32CPU(values, shape)
+
+    static member RandomNormal(shape:int[]) =
+        let values = Array.init (shapeLength shape) (fun _ -> float32 (Random.Normal()))
+        RawTensorFloat32CPU(values, shape)
+
+    static member Create(value:obj) = 
+        let array, shape = value |> flatArrayAndShape<float32>
+        if notNull array then 
+            RawTensorFloat32CPU(array, shape)
+        else 
+            let array, shape = value |> flatArrayAndShape<double>
+            if notNull array then 
+                RawTensorFloat32CPU(array |> Array.map float32, shape)
+            else
+                let array, shape = value |> flatArrayAndShape<int>
+                if notNull array then 
+                    RawTensorFloat32CPU(array |> Array.map float32, shape)
+                else
+                    invalidArg "value" "Cannot convert value to RawTensorFloat32CPU"
 
     member private t.IndexToFlatIndex(index:int[]) =
         let mutable flatIndex = 0
@@ -27,14 +68,12 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
     member t.Item
         with get ([<System.ParamArray>] index:int[]) =
             if index.Length <> t.Dim then invalidArg "index" (sprintf "Expecting a %id index" t.Dim)
-            let tvalue = t.Value:?>float32[]
-            tvalue.[t.IndexToFlatIndex(index)]
-        and set ([<System.ParamArray>] index:int[]) value =
+            values.[t.IndexToFlatIndex(index)]
+        and set ([<System.ParamArray>] index:int[]) v =
             if index.Length <> t.Dim then invalidArg "index" (sprintf "Expecting a %id index" t.Dim)
-            let tvalue = t.Value:?>float32[]
-            tvalue.[t.IndexToFlatIndex(index)] <- value
+            values.[t.IndexToFlatIndex(index)] <- v
 
-    override t.GetItem(index:int[]) = RawTensorFloat32CPU.Create(t.[index])
+    override t.GetItem(index:int[]) = upcast RawTensorFloat32CPU.Create(t.[index])
     
     override t.GetSlice(bounds:int[,]) =
         // if bounds.GetLength(0) <> t.Dim then invalidArg "bounds" (sprintf "Expecting %i-by-2 bounds" t.Dim)
@@ -60,36 +99,35 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
     override t1.CompareTo(t2) =
         compare (t1.ToValue():?>float32) (t2.ToValue():?>float32)
     
-    override t.Create(value) = RawTensorFloat32CPU.Create(value)
-    override t.Create(value, shape) =
+    override t.CreateFromScalar(value, shape) =
         let value = value:?>float32
         match shape.Length with
         | 0 -> upcast RawTensorFloat32CPU([|value|], [||])
         | _ -> upcast RawTensorFloat32CPU(Array.create (shapeLength shape) value, shape)
 
-    override t.Zero() = upcast RawTensorFloat32CPU([|0.f|], [||])
-    override t.Zeros(shape) = RawTensorFloat32CPU.Zeros(shape)
+    override t.Create(values) = upcast RawTensorFloat32CPU.Create(values)
+    override t.Zero() = upcast RawTensorFloat32CPU.Zero()
+    override t.Zeros(shape) = upcast RawTensorFloat32CPU.Zeros(shape)
     override t.One() = upcast RawTensorFloat32CPU([|1.f|], [||])
-    override t.Ones(shape) = RawTensorFloat32CPU.Ones(shape)
-    override t.Random(shape) = RawTensorFloat32CPU.Random(shape)
-    override t.RandomNormal(shape) = RawTensorFloat32CPU.RandomNormal(shape)
-    override t.RandomMultinomial(numSamples) = RawTensorFloat32CPU.RandomMultinomial(t, numSamples)
+    override t.Ones(shape) = upcast RawTensorFloat32CPU.Ones(shape)
+    override t.Random(shape) = upcast RawTensorFloat32CPU.Random(shape)
+    override t.RandomNormal(shape) = upcast RawTensorFloat32CPU.RandomNormal(shape)
 
-    static member RandomMultinomial(probs:RawTensor, numSamples:int):RawTensor =
+    override probs.RandomMultinomial(numSamples) =
         if probs.Dim < 1 || probs.Dim > 2 then failwithf "Expecting 1d or 2d probs, received shape %A" probs.Shape
         if probs.Dim = 1 then
-            let p = probs.Value :?> float32[] |> Array.map float
+            let p = probs.Value |> Array.map float
             let result = [|for i=0 to numSamples-1 do yield float32 (Random.ChoiceIndex(p))|]
             upcast RawTensorFloat32CPU(result, [|numSamples|])
         else
             let p = probs.ToArray() :?> float32[,] |> Array2D.map float
             let result = Array2D.init (p.GetLength(0)) numSamples (fun i _ -> Random.ChoiceIndex(p.[i,*]))
-            RawTensorFloat32CPU.Create(result)
+            upcast RawTensorFloat32CPU.Create(result)
 
     override t.GetString() =
         // sprintf "RawTensor(Value=%A, Shape=%A, Dim=%A, Length=%A)" t.Value t.Shape t.Dim t.Length
         match t.Dim with
-        | 0 -> sprintf "%A" (t.Value:?>float32[]).[0]
+        | 0 -> sprintf "%A" values.[0]
         | _ ->
             let sb = System.Text.StringBuilder()
             let rec print (shape:int[]) externalCoords = 
@@ -115,7 +153,7 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
 
     override t.ToValue() =
         match t.Dim with
-        | 0 -> upcast (t.Value:?>float32[]).[0]
+        | 0 -> upcast values.[0]
         | _ -> invalidOp (sprintf "Cannot convert %Ad Tensor to scalar" t.Dim)
 
     override t.ToArray() =
@@ -129,18 +167,18 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
 
     override t1.Equals(t2:RawTensor) = 
         match t2 with
-        | :? RawTensorFloat32CPU as t2 -> t1.Shape = t2.Shape && (t1.Value:?>float32[]) = (t2.Value:?>float32[])
+        | :? RawTensorFloat32CPU as t2 -> t1.Shape = t2.Shape && t1.Value = t2.Value
         | _ -> failwith <| sprintf "Cannot compare RawTensors of different types. t1:%A, t2:%A" t1 t2
 
     override t1.ApproximatelyEquals(t2:RawTensor, tolerance) =
         let tolerance = float32 <| tolerance
         match t2 with
-        | :? RawTensorFloat32CPU as t2 -> t1.Shape = t2.Shape && arraysApproximatelyEqual tolerance (t1.Value:?>float32[]) (t2.Value:?>float32[])
+        | :? RawTensorFloat32CPU as t2 -> t1.Shape = t2.Shape && arraysApproximatelyEqual tolerance t1.Value t2.Value
         | _ -> failwith <| sprintf "Cannot compare RawTensors of different types. t1:%A, t2:%A" t1 t2
 
     override __.StackTs(tensors) =
         let tensors = tensors |> Seq.toList
-        let values, shapes = tensors |> List.map (fun t -> t.Value:?>float32[], t.Shape) |> List.unzip
+        let values, shapes = tensors |> List.map (fun t -> (t :?> RawTensorFloat32CPU).Value, t.Shape) |> List.unzip
         if not (allEqual shapes) then invalidArg "tensors" "Expecting Tensors with same shape"
         let n = tensors |> List.length
         let m = shapeLength shapes.[0]
@@ -152,60 +190,57 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
 
     override t.UnstackT() =
         if t.Dim < 1 then invalidOp "Cannot unstack scalar Tensor (dim < 1)"
-        let tvalue = t.Value:?>float32[]
         let n = t.Shape.[0]
         let unstackedShape = if t.Dim = 1 then [||] else t.Shape |> Array.skip 1
         let unstackedLength = shapeLength unstackedShape
-        Seq.init n (fun i -> Array.init unstackedLength (fun j -> tvalue.[i*unstackedLength+j]))
+        Seq.init n (fun i -> Array.init unstackedLength (fun j -> values.[i*unstackedLength+j]))
         |> Seq.map (fun v -> upcast RawTensorFloat32CPU(v, unstackedShape))
 
     override t1.LtTT(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map2 (fun t1 t2 -> if t1 < t2 then 1.f else 0.f) t1value t2value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.GtTT(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map2 (fun t1 t2 -> if t1 > t2 then 1.f else 0.f) t1value t2value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.LeTT(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map2 (fun t1 t2 -> if t1 <= t2 then 1.f else 0.f) t1value t2value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.GeTT(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map2 (fun t1 t2 -> if t1 >= t2 then 1.f else 0.f) t1value t2value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t.MaxIndexT() =
-        let tvalue = t.Value:?>float32[]
-        t.FlatIndexToIndex(maxIndex tvalue)
+        t.FlatIndexToIndex(maxIndex values)
 
     override t.MinIndexT() =
-        let tvalue = t.Value:?>float32[]
-        t.FlatIndexToIndex(minIndex tvalue)
+        t.FlatIndexToIndex(minIndex values)
 
     override t1.AddTT(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map2 (+) t1value t2value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.AddTT0(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = (t2.Value:?>float32[]).[0]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value.[0]
         let result = Array.map ((+) t2value) t1value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.AddT2T1(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.copy t1value
         for i=0 to t1.Shape.[0]-1 do
             for j=0 to t1.Shape.[1]-1 do
@@ -215,7 +250,7 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
 
     override t1.AddTTSlice(location:int[], t2) =
         if not (shapeContains t1.Shape t2.Shape) then failwithf "Expecting t1.Shape to contain t2.Shape, received %A, %A" t1.Shape t2.Shape
-        let t1value = t1.Value:?>float32[]
+        let t1value = t1.Value
         let t2 = t2 :?> RawTensorFloat32CPU
         let result = Array.copy t1value
         let shape2 = shapeUnsqueezeAs t2.Shape t1.Shape
@@ -233,68 +268,68 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.SubTT(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map2 (-) t1value t2value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.SubT0T(t2) =
-        let t1value = (t1.Value:?>float32[]).[0]
-        let t2value = (t2.Value:?>float32[])
+        let t1value = t1.Value.[0]
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map ((-) t1value) t2value
         upcast RawTensorFloat32CPU(result, t2.Shape)
 
     override t1.SubTT0(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = (t2.Value:?>float32[]).[0]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value.[0]
         let result = Array.map (fun t -> t - t2value) t1value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.MulTT(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map2 (*) t1value t2value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.MulTT0(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = (t2.Value:?>float32[]).[0]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value.[0]
         let result = Array.map ((*) t2value) t1value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.DivTT(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map2 (/) t1value t2value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.DivT0T(t2) =
-        let t1value = (t1.Value:?>float32[]).[0]
-        let t2value = (t2.Value:?>float32[])
+        let t1value = t1.Value.[0]
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map ((/) t1value) t2value
         upcast RawTensorFloat32CPU(result, t2.Shape)
 
     override t1.DivTT0(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = (t2.Value:?>float32[]).[0]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value.[0]
         let result = Array.map (fun t -> t / t2value) t1value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.PowTT(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map2 ( ** ) t1value t2value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.PowT0T(t2) =
-        let t1value = (t1.Value:?>float32[]).[0]
-        let t2value = (t2.Value:?>float32[])
+        let t1value = t1.Value.[0]
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value
         let result = Array.map (fun t -> t1value ** t) t2value
         upcast RawTensorFloat32CPU(result, t2.Shape)
 
     override t1.PowTT0(t2) =
-        let t1value = t1.Value:?>float32[]
-        let t2value = (t2.Value:?>float32[]).[0]
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value.[0]
         let result = Array.map (fun t -> t ** t2value) t1value
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
@@ -303,10 +338,10 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
         let t1rows, t1cols = t1.Shape.[0], t1.Shape.[1]
         let t2rows, t2cols = t2.Shape.[0], t2.Shape.[1]
         if t1cols <> t2rows then invalidOp <| sprintf "Cannot multiply Tensors with shapes %A, %A" t1.Shape t2.Shape
-        let t1value = t1.Value:?>float32[]
-        let t2value = t2.Value:?>float32[]        
+        let t1value = t1.Value
+        let t2value = (t2 :?> RawTensorFloat32CPU).Value        
         let result = Array2D.init t1rows t2cols (fun i j -> Array.sumBy (fun k -> t1value.[i*t1cols + k] * t2value.[k*t2cols + j]) [|0..(t2rows-1)|] )
-        RawTensorFloat32CPU.Create(result)
+        upcast RawTensorFloat32CPU.Create(result)
     
     override t1.Conv1D(t2, stride, padding) =
         // t1: input, NxCxI (batchSize x inputChannels, inputLength)
@@ -331,7 +366,7 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
         if kernelLength > inputLength then invalidOp <| sprintf "Expecting kernelLength <= inputLength, received %A, %A" kernelLength inputLength
         let outputLength = inputLength - kernelLength + 1
         let outputShape = [|batchSize; outputChannels; outputLength|]
-        let result = RawTensorFloat32CPU.Zeros(outputShape) :?> RawTensorFloat32CPU
+        let result = RawTensorFloat32CPU.Zeros(outputShape)
         let t2 = t2 :?> RawTensorFloat32CPU
         for n=0 to batchSize-1 do
             for k=0 to outputChannels-1 do
@@ -346,7 +381,7 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
         elif stride > 1 then
             let outputLength = (float outputLength) / (float stride) |> ceil |> int
             let outputShape = [|batchSize; outputChannels; outputLength|]
-            let mutable sresult = RawTensorFloat32CPU.Zeros(outputShape) :?> RawTensorFloat32CPU
+            let mutable sresult = RawTensorFloat32CPU.Zeros(outputShape)
             for v=0 to outputLength-1 do
                 let sliceBounds = array2D [[0; batchSize-1]; [0; outputChannels-1]; [v * stride; v * stride]]
                 let slice = result.GetSlice(sliceBounds).UnsqueezeT(2)
@@ -356,169 +391,128 @@ type RawTensorFloat32CPU(value: float32[], shape:int[]) =
             invalidOp <| sprintf "Expecting stride >= 1, received %A" stride
 
     override t.NegT() =
-        let tvalue = t.Value:?>float32[]
-        let result = Array.map (~-) tvalue
+        let result = Array.map (~-) values
         upcast RawTensorFloat32CPU(result, t.Shape)
 
     override t.SumT() =
-        let tvalue = t.Value:?>float32[]
-        let result = Array.reduce (+) tvalue
+        let result = Array.reduce (+) values
         upcast RawTensorFloat32CPU([|result|], [||])
     
     override t.SumT2Dim0() =
         if t.Dim <> 2 then invalidOp "Expecting a 2d Tensor"
-        let tvalue = t.Value:?>float32[]
-        let result = Array.init t.Shape.[1] (fun j -> Array.init t.Shape.[0] (fun i -> tvalue.[i * t.Shape.[1] + j]) |> Array.reduce (+))
+        let result = Array.init t.Shape.[1] (fun j -> Array.init t.Shape.[0] (fun i -> values.[i * t.Shape.[1] + j]) |> Array.reduce (+))
         let resultShape = [|t.Shape.[1]|]
         upcast RawTensorFloat32CPU(result, resultShape)
 
     override t.TransposeT2() =
         if t.Dim <> 2 then invalidOp "Expecting a 2d Tensor"
-        let tvalue = t.Value:?>float32[]
         let tcols = t.Shape.[1]
-        let result = Array2D.init t.Shape.[1] t.Shape.[0] (fun i j -> tvalue.[j*tcols + i])
-        RawTensorFloat32CPU.Create(result)
+        let result = Array2D.init t.Shape.[1] t.Shape.[0] (fun i j -> values.[j*tcols + i])
+        upcast RawTensorFloat32CPU.Create(result)
 
     override t.SqueezeT(dim) =
-        let tvalue = t.Value:?>float32[]
-        let result = Array.copy tvalue
+        let result = Array.copy values
         upcast RawTensorFloat32CPU(result, shapeSqueeze dim t.Shape)
 
     override t.UnsqueezeT(dim) =
-        let tvalue = t.Value:?>float32[]
-        let result = Array.copy tvalue
+        let result = Array.copy values
         upcast RawTensorFloat32CPU(result, shapeUnsqueeze dim t.Shape)
 
     override t.ViewT(shape:int[]) =
         if shapeLength t.Shape <> shapeLength shape then invalidOp <| sprintf "Cannot view Tensor of shape %A as shape %A" t.Shape shape
-        let tvalue = t.Value:?>float32[]
-        let result = Array.copy tvalue
+        let result = Array.copy values
         upcast RawTensorFloat32CPU(result, shape)
 
     override t.SignT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map (sign >> float32)
+        let result = values |> Array.map (sign >> float32)
         upcast RawTensorFloat32CPU(result, t.Shape)
 
     override t.FloorT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map floor
+        let result = values |> Array.map floor
         upcast RawTensorFloat32CPU(result, t.Shape)
 
     override t.CeilT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map ceil
+        let result = values |> Array.map ceil
         upcast RawTensorFloat32CPU(result, t.Shape)
 
     override t.RoundT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map round
+        let result = values |> Array.map round
         upcast RawTensorFloat32CPU(result, t.Shape)
 
     override t.AbsT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map abs
+        let result = values |> Array.map abs
         upcast RawTensorFloat32CPU(result, t.Shape)
 
     override t1.ReluT() =
-        let t1value = t1.Value:?>float32[]
-        let result = t1value |> Array.map (max 0.f) 
+        let result = t1.Value |> Array.map (max 0.f) 
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t1.SigmoidT() =
-        let t1value = t1.Value:?>float32[]
-        let result = t1value |> Array.map (fun v -> 1.f / (1.f + exp -v))
+        let result = t1.Value |> Array.map (fun v -> 1.f / (1.f + exp -v))
         upcast RawTensorFloat32CPU(result, t1.Shape)
 
     override t.ExpT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map exp
+        let result = values |> Array.map exp
         upcast RawTensorFloat32CPU(result, t.Shape)
 
     override t.LogT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map log
+        let result = values |> Array.map log
         upcast RawTensorFloat32CPU(result, t.Shape)
 
     override t.Log10T() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map log10
+        let result = values |> Array.map log10
         upcast RawTensorFloat32CPU(result, t.Shape)
         
     override t.SqrtT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map sqrt
+        let result = values |> Array.map sqrt
         upcast RawTensorFloat32CPU(result, t.Shape)
         
     override t.SinT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map sin
+        let result = values |> Array.map sin
         upcast RawTensorFloat32CPU(result, t.Shape)
         
     override t.CosT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map cos
+        let result = values |> Array.map cos
         upcast RawTensorFloat32CPU(result, t.Shape)                
         
     override t.TanT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map tan
+        let result = values |> Array.map tan
         upcast RawTensorFloat32CPU(result, t.Shape)
         
     override t.SinhT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map sinh
+        let result = values |> Array.map sinh
         upcast RawTensorFloat32CPU(result, t.Shape)
         
     override t.CoshT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map cosh
+        let result = values |> Array.map cosh
         upcast RawTensorFloat32CPU(result, t.Shape)                
         
     override t.TanhT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map tanh
+        let result = values |> Array.map tanh
         upcast RawTensorFloat32CPU(result, t.Shape)
 
     override t.AsinT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map asin
+        let result = values |> Array.map asin
         upcast RawTensorFloat32CPU(result, t.Shape)
         
     override t.AcosT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map acos
+        let result = values |> Array.map acos
         upcast RawTensorFloat32CPU(result, t.Shape)                
         
     override t.AtanT() =
-        let tvalue = t.Value:?>float32[]
-        let result = tvalue |> Array.map atan
+        let result = values |> Array.map atan
         upcast RawTensorFloat32CPU(result, t.Shape)
-
+        
 and RawTensorFloat32CPUStatics() = 
 
     inherit RawTensorStatics()
 
-    override __.Zeros(shape:int[]):RawTensor = upcast RawTensorFloat32CPU(Array.create (shapeLength shape) 0.f, shape)
+    override __.Zero = upcast RawTensorFloat32CPU.Zero()
+    override __.One = upcast RawTensorFloat32CPU.One()
+    override __.Zeros(shape:int[]) = upcast RawTensorFloat32CPU.Zeros(shape)
+    override __.Ones(shape:int[]) = upcast RawTensorFloat32CPU.Ones(shape)
+    override __.Random(shape:int[]) = upcast RawTensorFloat32CPU.Random(shape)
+    override __.RandomNormal(shape:int[]) = upcast RawTensorFloat32CPU.RandomNormal(shape)
+    override __.Create(values:obj) : RawTensor = upcast RawTensorFloat32CPU.Create(values)
 
-    override __.Ones(shape:int[]):RawTensor = upcast RawTensorFloat32CPU(Array.create (shapeLength shape) 1.f, shape)
-
-    override __.Random(shape:int[]):RawTensor = upcast RawTensorFloat32CPU(Array.init (shapeLength shape) (fun _ -> float32 (Random.Uniform())), shape)
-
-    override __.RandomNormal(shape:int[]):RawTensor = upcast RawTensorFloat32CPU(Array.init (shapeLength shape) (fun _ -> float32 (Random.Normal())), shape)
-
-    override __.Create(value:obj) : RawTensor = 
-        let array, shape = value |> flatArrayAndShape<float32>
-        if notNull array then 
-            upcast RawTensorFloat32CPU(array, shape)
-        else 
-            let array, shape = value |> flatArrayAndShape<double>
-            if notNull array then 
-                upcast RawTensorFloat32CPU(array |> Array.map float32, shape)
-            else
-                let array, shape = value |> flatArrayAndShape<int>
-                if notNull array then 
-                    upcast RawTensorFloat32CPU(array |> Array.map float32, shape)
-                else
-                    invalidArg "value" "Cannot convert value to RawTensorFloat32CPU"
     

--- a/src/DiffSharp.Backend.None/RawTensorFloat32CPU.fs
+++ b/src/DiffSharp.Backend.None/RawTensorFloat32CPU.fs
@@ -1,8 +1,8 @@
 namespace DiffSharp.Backend.None
+
 open DiffSharp
 open DiffSharp.Backend
 open DiffSharp.Util
-open System
 
 type RawTensorFloat32CPU(values: float32[], shape:int[]) =
     inherit RawTensor(shape, Float32, CPU, DiffSharp.Backend.Backend.None)


### PR DESCRIPTION

@gbaydin This ssimplifies the `RawTensorFloat32CPU` so you don't get that weirdness of going through the statics thunk thing jsut for simple `RawTensorFloat32CPU` coding. 

There are now also far fewer casts needed in `RawTensorFloat32CPU.fs`