### PR TITLE
Unused variable warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <OtherFlags>--warnon:1182 $(OtherFlags)</OtherFlags>
+  </PropertyGroup>
+
+</Project>

--- a/src/DiffSharp.Backend.None/RawTensorCPU.fs
+++ b/src/DiffSharp.Backend.None/RawTensorCPU.fs
@@ -79,7 +79,7 @@ type RawTensorFloat32CPU(values: float32[], shape:int[]) =
         if probs.Dim < 1 || probs.Dim > 2 then failwithf "Expecting 1d or 2d probs, received shape %A" probs.Shape
         if probs.Dim = 1 then
             let p = probs.Values |> Array.map float
-            let result = [|for i=0 to numSamples-1 do yield float32 (Random.ChoiceIndex(p))|]
+            let result = Array.init numSamples (fun _ -> float32 (Random.ChoiceIndex(p)))
             upcast RawTensorFloat32CPU(result, [|numSamples|])
         else
             let p = probs.ToArray() :?> float32[,] |> Array2D.map float

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -2,6 +2,8 @@
 open DiffSharp.Backend
 open DiffSharp.Util
 
+#nowarn "1182" // turn off compiler-generated unused variable warnings in this file only
+
 [<CustomEquality; CustomComparison>]
 type Tensor = 
     | Tensor of RawTensor

--- a/src/Test/Program.fs
+++ b/src/Test/Program.fs
@@ -20,7 +20,7 @@ open DiffSharp.Backend.None
 
 
 [<EntryPoint>]
-let main argv =
+let main _argv =
     printfn "Hello World from F#!"
 
     DiffSharp.Seed(12)


### PR DESCRIPTION
This enables unused variable warnings. This consistently results in fewer bugs so we should enable it now

@gbaydin The variable is is an unused variable here, this is a bug or a mistake

            let is:int[] = value.ToArray() :?> obj[] |> Array.map toInt
            Seq.init d.BatchShape.[0] (fun i -> d.Probs.[i]) |> Tensor.Stack |> Tensor.Log
