### PR TITLE
test conv1d with batchsize 1

### DIFF
--- a/src/DiffSharp.Tests/TestTensor.fs
+++ b/src/DiffSharp.Tests/TestTensor.fs
@@ -384,7 +384,13 @@ type TestTensor () =
 
                                             [[0.3165; 2.9038; 0.5275];
                                              [0.3861; 2.9444; 0.7428]]])
+        
+        let t3b1 = Tensor.Conv1D(t1.[0,*,*].Unsqueeze(0) , t2)
+        let t3b1correct = t3Correct.[0,*,*].Unsqueeze(0)
 
+        let t3b1s2 = Tensor.Conv1D(t1.[0,*,*].Unsqueeze(0) , t2, stride = 2)
+        let t3b1s2correct = t3s2Correct.[0,*,*].Unsqueeze(0)
+        
         Assert.True(t3.ApproximatelyEqual(t3Correct))
         Assert.True(t3p1.ApproximatelyEqual(t3p1Correct))
         Assert.True(t3p2.ApproximatelyEqual(t3p2Correct))
@@ -392,6 +398,8 @@ type TestTensor () =
         Assert.True(t3s3.ApproximatelyEqual(t3s3Correct))
         Assert.True(t3p1s2.ApproximatelyEqual(t3p1s2Correct))
         Assert.True(t3p2s3.ApproximatelyEqual(t3p2s3Correct))
+        Assert.True(t3b1.ApproximatelyEqual(t3b1correct))
+        Assert.True(t3b1s2.ApproximatelyEqual(t3b1s2correct))
 
     [<Test>]
     member this.TestTensorNegT () =


### PR DESCRIPTION
Adds an additional check on conv1d.  Conv1d with stride > 1 assumes `GetSlice` only drops one dim.