### PR TITLE
Differentiation ops

### DIFF
--- a/src/DiffSharp.Core/DiffSharp.fs
+++ b/src/DiffSharp.Core/DiffSharp.fs
@@ -319,13 +319,17 @@ type DiffSharp with
     static member g f x = DiffSharp.grad f x
     static member hvp f x v = DiffSharp.hessianv f x v
     static member h f x = DiffSharp.hessian f x
+    static member gh f x = DiffSharp.gradhessian f x
+    static member ghvp f x v = DiffSharp.gradhessianv f x v
     static member jvp f x v = DiffSharp.jacobianv f x v
     static member vjp f x v = DiffSharp.jacobianTv f x v
     static member j f x = DiffSharp.jacobian f x
     static member fgvp f x v = DiffSharp.fgradv f x v
     static member fg f x = DiffSharp.fgrad f x
+    static member fgh f x = DiffSharp.fgradhessian f x
     static member fhvp f x v = DiffSharp.fhessianv f x v
     static member fh f x = DiffSharp.fhessian f x
+    static member fghvp f x v = DiffSharp.fgradhessianv f x v
     static member fjvp f x v = DiffSharp.fjacobianv f x v
     static member fvjp f x v = DiffSharp.fjacobianTv f x v
     static member fj f x = DiffSharp.fjacobian f x    
@@ -413,12 +417,14 @@ type DiffSharp with
     static member numg f x = DiffSharp.numgrad f x
     static member numhvp f x v = DiffSharp.numhessianv f x v
     static member numh f x = DiffSharp.numhessian f x
+    static member numgh f x = DiffSharp.numgradhessian f x
     static member numjvp f x v = DiffSharp.numjacobianv f x v
     static member numj f x = DiffSharp.numjacobian f x
     static member numfgvp f x v = DiffSharp.numfgradv f x v
     static member numfg f x = DiffSharp.numfgrad f x
     static member numfhvp f x v = DiffSharp.numfhessianv f x v
     static member numfh f x = DiffSharp.numfhessian f x
+    static member numfgh f x = DiffSharp.numfgradhessian f x
     static member numfjvp f x v = DiffSharp.numfjacobianv f x v
     static member numfj f x = DiffSharp.numfjacobian f x    
 

--- a/src/DiffSharp.Core/DiffSharp.fs
+++ b/src/DiffSharp.Core/DiffSharp.fs
@@ -225,92 +225,110 @@ type DiffSharp with
                 fx <- fx.primal
                 d
                 |] |> Array.rev |> Array.append [|fx|]
-    static member pjacobianv f (x:Tensor) (v:Tensor) = 
+    static member fjacobianv f (x:Tensor) (v:Tensor) = 
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let fx, d = DiffSharp.evalForwardDiff f x v
         if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, d
-    static member jacobianv f x v = DiffSharp.pjacobianv f x v |> snd
-    static member pgradv f (x:Tensor) (v:Tensor) =
+    static member jacobianv f x v = DiffSharp.fjacobianv f x v |> snd
+    static member fgradv f (x:Tensor) (v:Tensor) =
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let fx, d = DiffSharp.evalForwardDiff f x v
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, d
-    static member gradv f x v = DiffSharp.pgradv f x v |> snd
-    static member pdiff f (x:Tensor) =
+    static member gradv f x v = DiffSharp.fgradv f x v |> snd
+    static member fdiff f (x:Tensor) =
         let fx, d = DiffSharp.evalForwardDiff f x (x.onesLike())
         if x.dim <> 0 then failwithf "f must be a function of a scalar, encountered f:%A->%A" x.shape fx.shape
         fx, d
-    static member diff f x = DiffSharp.pdiff f x |> snd
-    static member ppdiffn (n:int) (f:Tensor->Tensor) (x:Tensor) =
+    static member diff f x = DiffSharp.fdiff f x |> snd
+    static member ffdiffn (n:int) (f:Tensor->Tensor) (x:Tensor) =
         if n < 0 then failwith "Differentiation order n must be >= 0"
         if x.dim <> 0 then failwithf "f must be a function of a scalar"
         DiffSharp.evalForwardDiffs f x (Array.create n (x.onesLike()))
-    static member pdiffn n f x = let a = DiffSharp.ppdiffn n f x in a |> Array.head, a |> Array.last
-    static member diffn n f x = DiffSharp.pdiffn n f x |> snd
-    static member pdiff2 f x = DiffSharp.pdiffn 2 f x
+    static member fdiffn n f x = let a = DiffSharp.ffdiffn n f x in a |> Array.head, a |> Array.last
+    static member diffn n f x = DiffSharp.fdiffn n f x |> snd
+    static member fdiff2 f x = DiffSharp.fdiffn 2 f x
     static member diff2 f x = DiffSharp.diffn 2 f x
-    static member pjacobianTv f x (v:Tensor) =
+    static member fjacobianTv f x (v:Tensor) =
         let fx, r = DiffSharp.evalReverseDiff f x
         if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         if fx.nelement <> v.nelement then failwithf "(f x) and v must have the same number of elements"
         fx, r v
-    static member jacobianTv f x v = DiffSharp.pjacobianTv f x v |> snd
-    static member pjacobian (f:Tensor->Tensor) x =
+    static member jacobianTv f x v = DiffSharp.fjacobianTv f x v |> snd
+    static member fjacobian (f:Tensor->Tensor) x =
         let fx, r = DiffSharp.evalReverseDiff f x
         if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         if x.nelement > fx.nelement then
             fx, DiffSharp.stack(Array.init fx.nelement (fun i -> r (x.onehotLike(fx.nelement, i))), 0)
         else
             fx, DiffSharp.stack(Array.init x.nelement (fun j -> DiffSharp.jacobianv f x (x.onehotLike(x.nelement, j))), 1)
-    static member jacobian f x = DiffSharp.pjacobian f x |> snd
-    static member pgrad f x =
+    static member jacobian f x = DiffSharp.fjacobian f x |> snd
+    static member fgrad f x =
         let fx, r = DiffSharp.evalReverseDiff f x
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, r (fx.onesLike())
-    static member grad f x = DiffSharp.pgrad f x |> snd
-    static member pgradhessianv f (x:Tensor) (v:Tensor) =
+    static member grad f x = DiffSharp.fgrad f x |> snd
+    static member fgradhessianv f (x:Tensor) (v:Tensor) =
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let x = x |> DiffSharp.reverseDiff (GlobalNestingLevel.Next())
-        let fx, gv = DiffSharp.pgradv f x v
+        let fx, gv = DiffSharp.fgradv f x v
         gv.reverse()
         fx.primal, gv.primal, x.derivative
-    static member gradhessianv f x v = let _, gv, hv = DiffSharp.pgradhessianv f x v in gv, hv
-    static member phessianv f x v = let fx, _, hv = DiffSharp.pgradhessianv f x v in fx, hv
-    static member hessianv f x v = DiffSharp.phessianv f x v |> snd
-    static member pgradhessian (f:Tensor->Tensor) (x:Tensor) =
+    static member gradhessianv f x v = let _, gv, hv = DiffSharp.fgradhessianv f x v in gv, hv
+    static member fhessianv f x v = let fx, _, hv = DiffSharp.fgradhessianv f x v in fx, hv
+    static member hessianv f x v = DiffSharp.fhessianv f x v |> snd
+    static member fgradhessian (f:Tensor->Tensor) (x:Tensor) =
         let mutable fx = DiffSharp.zero()
-        let gvs, hvs = Array.init x.nelement (fun j -> let ffxx, gv, hv = DiffSharp.pgradhessianv f x (x.onehotLike(x.nelement, j)) in fx <- ffxx; gv, hv) |> Array.unzip
+        let gvs, hvs = Array.init x.nelement (fun j -> let ffxx, gv, hv = DiffSharp.fgradhessianv f x (x.onehotLike(x.nelement, j)) in fx <- ffxx; gv, hv) |> Array.unzip
         let h = DiffSharp.stack(hvs, 1)
         let g = DiffSharp.stack(gvs)
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, g, h
-    static member gradhessian f x = let _, g, h = DiffSharp.pgradhessian f x in g, h
-    static member phessian (f:Tensor->Tensor) (x:Tensor) =
+    static member gradhessian f x = let _, g, h = DiffSharp.fgradhessian f x in g, h
+    static member fhessian (f:Tensor->Tensor) (x:Tensor) =
         let mutable fx = DiffSharp.zero()
-        let h = DiffSharp.stack(Array.init x.nelement (fun j -> let ffxx, hv = DiffSharp.phessianv f x (x.onehotLike(x.nelement, j)) in fx <- ffxx; hv), 1)
+        let h = DiffSharp.stack(Array.init x.nelement (fun j -> let ffxx, hv = DiffSharp.fhessianv f x (x.onehotLike(x.nelement, j)) in fx <- ffxx; hv), 1)
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, h
-    static member hessian f x = DiffSharp.phessian f x |> snd
-    static member plaplacian f x =
-        let fx, h = DiffSharp.phessian f x
+    static member hessian f x = DiffSharp.fhessian f x |> snd
+    static member flaplacian f x =
+        let fx, h = DiffSharp.fhessian f x
         fx, h.trace()
-    static member laplacian f x = DiffSharp.plaplacian f x |> snd
-    static member pcurl f x =
-        let fx, j = DiffSharp.pjacobian f x
+    static member laplacian f x = DiffSharp.flaplacian f x |> snd
+    static member fcurl f x =
+        let fx, j = DiffSharp.fjacobian f x
         if j.shape <> [|3; 3|] then failwithf "f must be a function with a three-by-three Jacobian"
         fx, DiffSharp.stack([j.[2, 1] - j.[1, 2]; j.[0, 2] - j.[2, 0]; j.[1, 0] - j.[0, 1]])
-    static member curl f x = DiffSharp.pcurl f x |> snd
-    static member pdivergence f x =
-        let fx, j = DiffSharp.pjacobian f x
+    static member curl f x = DiffSharp.fcurl f x |> snd
+    static member fdivergence f x =
+        let fx, j = DiffSharp.fjacobian f x
         if j.shape.[0] <> j.shape.[1] then failwithf "f must have a square Jacobian"
         fx, j.trace()
-    static member divergence f x = DiffSharp.pdivergence f x |> snd
-    static member pcurldivergence f x =
-        let fx, j = DiffSharp.pjacobian f x
+    static member divergence f x = DiffSharp.fdivergence f x |> snd
+    static member fcurldivergence f x =
+        let fx, j = DiffSharp.fjacobian f x
         if j.shape <> [|3; 3|] then failwithf "f must be a function with a three-by-three Jacobian"
         fx, DiffSharp.stack([j.[2, 1] - j.[1, 2]; j.[0, 2] - j.[2, 0]; j.[1, 0] - j.[0, 1]]), j.trace()
-    static member curldivergence f x = let _, c, d = DiffSharp.pcurldivergence f x in c, d
+    static member curldivergence f x = let _, c, d = DiffSharp.fcurldivergence f x in c, d
+
+
+// Functional automatic differentiation API shorthand names
+type DiffSharp with
+    static member gvp f x v = DiffSharp.gradv f x v
+    static member g f x = DiffSharp.grad f x
+    static member hvp f x v = DiffSharp.hessianv f x v
+    static member h f x = DiffSharp.hessian f x
+    static member jvp f x v = DiffSharp.jacobianv f x v
+    static member vjp f x v = DiffSharp.jacobianTv f x v
+    static member j f x = DiffSharp.jacobian f x
+    static member fgvp f x v = DiffSharp.fgradv f x v
+    static member fg f x = DiffSharp.fgrad f x
+    static member fhvp f x v = DiffSharp.fhessianv f x v
+    static member fh f x = DiffSharp.fhessian f x
+    static member fjvp f x v = DiffSharp.fjacobianv f x v
+    static member fvjp f x v = DiffSharp.fjacobianTv f x v
+    static member fj f x = DiffSharp.fjacobian f x    
 
 
 // Functional numerical differentiation API
@@ -318,75 +336,91 @@ type DiffSharp with
     static member numdiff (epsilon:float) (f:Tensor->Tensor) (x:Tensor) = 
         if x.dim <> 0 then failwithf "f must be a function of a scalar"
         ((f (x + epsilon)) - (f (x - epsilon))) / (2.*epsilon)
-    static member numpdiff epsilon f x = f x, DiffSharp.numdiff epsilon f x
-    static member numpdiff2 (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
+    static member numfdiff epsilon f x = f x, DiffSharp.numdiff epsilon f x
+    static member numfdiff2 (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
         if x.dim <> 0 then failwithf "f must be a function of a scalar"
         let fx = f x
         fx, ((f (x + epsilon)) - 2. * fx + (f (x - epsilon))) / (epsilon * epsilon)
-    static member numdiff2 epsilon f x = DiffSharp.numpdiff2 epsilon f x |> snd
+    static member numdiff2 epsilon f x = DiffSharp.numfdiff2 epsilon f x |> snd
     static member numjacobianv (epsilon:float) (f:Tensor->Tensor) (x:Tensor) (v:Tensor) =
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let veps = v * epsilon
         let fxa, fxb = f (x+veps), f (x-veps)
         if x.dim <> 1 || fxa.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fxa.shape
         (fxa - fxb) / (2.*epsilon)
-    static member numpjacobianv epsilon f x v = f x, DiffSharp.numjacobianv epsilon f x v
-    static member numpjacobian (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
+    static member numfjacobianv epsilon f x v = f x, DiffSharp.numjacobianv epsilon f x v
+    static member numfjacobian (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
         let fx = f x
         if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         let j = fx.expand([x.nelement; fx.nelement])
         let jj = DiffSharp.stack(Array.init x.nelement (fun i -> f (x + DiffSharp.onehot(x.nelement, i)*epsilon)))
         fx, (jj - j).transpose() / epsilon
-    static member numjacobian epsilon f x = DiffSharp.numpjacobian epsilon f x |> snd
+    static member numjacobian epsilon f x = DiffSharp.numfjacobian epsilon f x |> snd
     static member numgradv (epsilon:float) (f:Tensor->Tensor) (x:Tensor) (v:Tensor) =
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let veps = v * epsilon
         let fxa, fxb = f (x + veps), f (x - veps)
         if x.dim <> 1 || fxa.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fxa.shape
         (fxa - fxb) / (2.*epsilon)
-    static member numpgradv epsilon f x v = f x, DiffSharp.numgradv epsilon f x v
-    static member numpgrad (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
+    static member numfgradv epsilon f x v = f x, DiffSharp.numgradv epsilon f x v
+    static member numfgrad (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
         let fx = f x
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         let gg = DiffSharp.stack(Array.init x.nelement (fun i -> let h = DiffSharp.onehot(x.nelement, i)*epsilon in f (x + h) - f (x - h)))
         fx, gg/(2.*epsilon)
-    static member numgrad epsilon f x = DiffSharp.numpgrad epsilon f x |> snd
-    static member numpgradhessian (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
-        let fx, g = DiffSharp.numpgrad epsilon f x
+    static member numgrad epsilon f x = DiffSharp.numfgrad epsilon f x |> snd
+    static member numfgradhessian (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
+        let fx, g = DiffSharp.numfgrad epsilon f x
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         let h = g.expand([x.nelement; x.nelement])
         let hh = DiffSharp.stack(Array.init x.nelement (fun i -> DiffSharp.numgrad epsilon f (x + DiffSharp.onehot(x.nelement, i)*epsilon)))
         fx, g, (hh - h) / epsilon
-    static member numgradhessian epsilon f x = let _, g, h = DiffSharp.numpgradhessian epsilon f x in g, h
-    static member numphessian epsilon f x = let fx, _, h = DiffSharp.numpgradhessian epsilon f x in fx, h
-    static member numhessian epsilon f x = DiffSharp.numphessian epsilon f x |> snd
-    static member numphessianv (epsilon:float) (f:Tensor->Tensor) (x:Tensor) (v:Tensor) =
+    static member numgradhessian epsilon f x = let _, g, h = DiffSharp.numfgradhessian epsilon f x in g, h
+    static member numfhessian epsilon f x = let fx, _, h = DiffSharp.numfgradhessian epsilon f x in fx, h
+    static member numhessian epsilon f x = DiffSharp.numfhessian epsilon f x |> snd
+    static member numfhessianv (epsilon:float) (f:Tensor->Tensor) (x:Tensor) (v:Tensor) =
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let veps = v*epsilon
-        let fx, g = DiffSharp.numpgrad epsilon f x
+        let fx, g = DiffSharp.numfgrad epsilon f x
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         let gg = DiffSharp.numgrad epsilon f (x + veps)
         fx, (gg-g)/epsilon
-    static member numhessianv epsilon f x v = DiffSharp.numphessianv epsilon f x v |> snd
-    static member numplaplacian epsilon f x =
-        let fx, h = DiffSharp.numphessian epsilon f x
+    static member numhessianv epsilon f x v = DiffSharp.numfhessianv epsilon f x v |> snd
+    static member numflaplacian epsilon f x =
+        let fx, h = DiffSharp.numfhessian epsilon f x
         fx, h.trace()
-    static member numlaplacian epsilon f x = DiffSharp.numplaplacian epsilon f x |> snd
-    static member numpcurl epsilon f x =
-        let fx, j = DiffSharp.numpjacobian epsilon f x
+    static member numlaplacian epsilon f x = DiffSharp.numflaplacian epsilon f x |> snd
+    static member numfcurl epsilon f x =
+        let fx, j = DiffSharp.numfjacobian epsilon f x
         if j.shape <> [|3; 3|] then failwithf "f must be a function with a three-by-three Jacobian"
         fx, DiffSharp.stack([j.[2, 1] - j.[1, 2]; j.[0, 2] - j.[2, 0]; j.[1, 0] - j.[0, 1]])
-    static member numcurl epsilon f x = DiffSharp.numpcurl epsilon f x |> snd
-    static member numpdivergence epsilon f x =
-        let fx, j = DiffSharp.numpjacobian epsilon f x
+    static member numcurl epsilon f x = DiffSharp.numfcurl epsilon f x |> snd
+    static member numfdivergence epsilon f x =
+        let fx, j = DiffSharp.numfjacobian epsilon f x
         if j.shape.[0] <> j.shape.[1] then failwithf "f must have a square Jacobian"
         fx, j.trace()
-    static member numdivergence epsilon f x = DiffSharp.numpdivergence epsilon f x |> snd
-    static member numpcurldivergence epsilon f x =
-        let fx, j = DiffSharp.numpjacobian epsilon f x
+    static member numdivergence epsilon f x = DiffSharp.numfdivergence epsilon f x |> snd
+    static member numfcurldivergence epsilon f x =
+        let fx, j = DiffSharp.numfjacobian epsilon f x
         if j.shape <> [|3; 3|] then failwithf "f must be a function with a three-by-three Jacobian"
         fx, DiffSharp.stack([j.[2, 1] - j.[1, 2]; j.[0, 2] - j.[2, 0]; j.[1, 0] - j.[0, 1]]), j.trace()
-    static member numcurldivergence epsilon f x = let _, c, d = DiffSharp.numpcurldivergence epsilon f x in c, d
+    static member numcurldivergence epsilon f x = let _, c, d = DiffSharp.numfcurldivergence epsilon f x in c, d
+
+
+// Functional numerical differentiation API shorthand names
+type DiffSharp with
+    static member numgvp f x v = DiffSharp.numgradv f x v
+    static member numg f x = DiffSharp.numgrad f x
+    static member numhvp f x v = DiffSharp.numhessianv f x v
+    static member numh f x = DiffSharp.numhessian f x
+    static member numjvp f x v = DiffSharp.numjacobianv f x v
+    static member numj f x = DiffSharp.numjacobian f x
+    static member numfgvp f x v = DiffSharp.numfgradv f x v
+    static member numfg f x = DiffSharp.numfgrad f x
+    static member numfhvp f x v = DiffSharp.numfhessianv f x v
+    static member numfh f x = DiffSharp.numfhessian f x
+    static member numfjvp f x v = DiffSharp.numfjacobianv f x v
+    static member numfj f x = DiffSharp.numfjacobian f x    
 
 
 type dsharp = DiffSharp

--- a/src/DiffSharp.Tests/TestDiffSharp.fs
+++ b/src/DiffSharp.Tests/TestDiffSharp.fs
@@ -110,9 +110,9 @@ type TestDiffSharp () =
     [<Test>]
     member this.TestDiff () =
         let x = dsharp.tensor(1.5)
-        let fx, d = dsharp.pdiff fscalarvect3 x
+        let fx, d = dsharp.fdiff fscalarvect3 x
         let d2 = dsharp.diff fscalarvect3 x
-        let nfx, nd = dsharp.numpdiff 1e-5 fscalarvect3 x
+        let nfx, nd = dsharp.numfdiff 1e-5 fscalarvect3 x
         let nd2 = dsharp.numdiff 1e-5 fscalarvect3 x
         let fxCorrect = fscalarvect3 x
         let dCorrect = fscalarvect3Diff x
@@ -126,9 +126,9 @@ type TestDiffSharp () =
     [<Test>]
     member this.TestDiff2 () =
         let x = dsharp.tensor(1.5)
-        let fx, d = dsharp.pdiff2 fscalarvect3 x
+        let fx, d = dsharp.fdiff2 fscalarvect3 x
         let d2 = dsharp.diff2 fscalarvect3 x
-        let nfx, nd = dsharp.numpdiff2 1e-2 fscalarvect3 x
+        let nfx, nd = dsharp.numfdiff2 1e-2 fscalarvect3 x
         let nd2 = dsharp.numdiff2 1e-2 fscalarvect3 x
         let fxCorrect = fscalarvect3 x
         let dCorrect = fscalarvect3Diff2 x
@@ -142,7 +142,7 @@ type TestDiffSharp () =
     [<Test>]
     member this.TestDiffn () =
         let x = dsharp.tensor(1.5)
-        let fx, d = dsharp.pdiffn 3 fscalarvect3 x
+        let fx, d = dsharp.fdiffn 3 fscalarvect3 x
         let d2 = dsharp.diffn 3 fscalarvect3 x
         let fxCorrect = fscalarvect3 x
         let dCorrect = fscalarvect3Diff3 x
@@ -153,61 +153,88 @@ type TestDiffSharp () =
     [<Test>]
     member this.TestGrad () =
         let x = dsharp.tensor([1.5;2.5])
-        let fx, g = dsharp.pgrad rosenbrock x
-        let g2 = dsharp.grad rosenbrock x
-        let nfx, ng = dsharp.numpgrad 1e-6 rosenbrock x
-        let ng2 = dsharp.numgrad 1e-6 rosenbrock x
+        let fx1, g1 = dsharp.fgrad rosenbrock x
+        let fx2, g2 = dsharp.fg rosenbrock x
+        let g3 = dsharp.grad rosenbrock x
+        let g4 = dsharp.g rosenbrock x
+        let nfx1, ng1 = dsharp.numfgrad 1e-6 rosenbrock x
+        let nfx2, ng2 = dsharp.numfg 1e-6 rosenbrock x
+        let ng3 = dsharp.numgrad 1e-6 rosenbrock x
+        let ng4 = dsharp.numg 1e-6 rosenbrock x
         let fxCorrect = rosenbrock x
         let gCorrect = rosenbrockGrad x
-        printfn "%A" ng
-        printfn "%A" g
-        printfn "%A" gCorrect
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(fxCorrect, nfx)
-        Assert.AreEqual(gCorrect, g)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, nfx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(fxCorrect, nfx2)
+        Assert.AreEqual(gCorrect, g1)
         Assert.AreEqual(gCorrect, g2)
-        Assert.True(gCorrect.allclose(ng, 0.1))
+        Assert.AreEqual(gCorrect, g3)
+        Assert.AreEqual(gCorrect, g4)
+        Assert.True(gCorrect.allclose(ng1, 0.1))
         Assert.True(gCorrect.allclose(ng2, 0.1))
+        Assert.True(gCorrect.allclose(ng3, 0.1))
+        Assert.True(gCorrect.allclose(ng4, 0.1))
 
     [<Test>]
     member this.TestGradv () =
         let x = dsharp.tensor([1.5;2.5])
         let v = dsharp.tensor([2.75;-3.5])
-        let fx, gv = dsharp.pgradv rosenbrock x v
-        let gv2 = dsharp.gradv rosenbrock x v
-        let nfx, ngv = dsharp.numpgradv 1e-5 rosenbrock x v
-        let ngv2 = dsharp.numgradv 1e-5 rosenbrock x v
+        let fx1, gv1 = dsharp.fgradv rosenbrock x v
+        let fx2, gv2 = dsharp.fgvp rosenbrock x v
+        let gv3 = dsharp.gradv rosenbrock x v
+        let gv4 = dsharp.gvp rosenbrock x v
+        let nfx1, ngv1 = dsharp.numfgradv 1e-5 rosenbrock x v
+        let nfx2, ngv2 = dsharp.numfgvp 1e-5 rosenbrock x v
+        let ngv3 = dsharp.numgradv 1e-5 rosenbrock x v
+        let ngv4 = dsharp.numgvp 1e-5 rosenbrock x v
         let fxCorrect = rosenbrock x
         let gvCorrect = dsharp.dot(rosenbrockGrad x,  v)
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(fxCorrect, nfx)
-        Assert.AreEqual(gvCorrect, gv)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, nfx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(fxCorrect, nfx2)
+        Assert.AreEqual(gvCorrect, gv1)
         Assert.AreEqual(gvCorrect, gv2)
-        Assert.True(gvCorrect.allclose(ngv, 0.1))
+        Assert.AreEqual(gvCorrect, gv3)
+        Assert.AreEqual(gvCorrect, gv4)
+        Assert.True(gvCorrect.allclose(ngv1, 0.1))
         Assert.True(gvCorrect.allclose(ngv2, 0.1))
+        Assert.True(gvCorrect.allclose(ngv3, 0.1))
+        Assert.True(gvCorrect.allclose(ngv4, 0.1))
 
     [<Test>]
     member this.TestJacobianv () =
         let x = dsharp.tensor([1.5, 2.5, 3.])
         let v = dsharp.tensor([2.75, -3.5, 4.])
-        let fx, jv = dsharp.pjacobianv fvect3vect2 x v
-        let jv2 = dsharp.jacobianv fvect3vect2 x v
-        let nfx, njv = dsharp.numpjacobianv 1e-3 fvect3vect2 x v
-        let njv2 = dsharp.numjacobianv 1e-3 fvect3vect2 x v
+        let fx1, jv1 = dsharp.fjacobianv fvect3vect2 x v
+        let fx2, jv2 = dsharp.fjvp fvect3vect2 x v
+        let jv3 = dsharp.jacobianv fvect3vect2 x v
+        let jv4 = dsharp.jvp fvect3vect2 x v
+        let nfx1, njv1 = dsharp.numfjacobianv 1e-3 fvect3vect2 x v
+        let nfx2, njv2 = dsharp.numfjvp 1e-3 fvect3vect2 x v
+        let njv3 = dsharp.numjacobianv 1e-3 fvect3vect2 x v
+        let njv4 = dsharp.numjvp 1e-3 fvect3vect2 x v
         let fxCorrect = fvect3vect2 x
         let jvCorrect = dsharp.matmul(fvect3vect2Jacobian x,  v.view([-1;1])).view(-1)
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(fxCorrect, nfx)
-        Assert.AreEqual(jvCorrect, jv)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, nfx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(fxCorrect, nfx2)
+        Assert.AreEqual(jvCorrect, jv1)
         Assert.AreEqual(jvCorrect, jv2)
-        Assert.True(jvCorrect.allclose(njv, 0.1))
+        Assert.AreEqual(jvCorrect, jv3)
+        Assert.AreEqual(jvCorrect, jv4)
+        Assert.True(jvCorrect.allclose(njv1, 0.1))
         Assert.True(jvCorrect.allclose(njv2, 0.1))
+        Assert.True(jvCorrect.allclose(njv3, 0.1))
+        Assert.True(jvCorrect.allclose(njv4, 0.1))
 
     [<Test>]
     member this.TestJacobianTv () =
         let x = dsharp.tensor([1.5, 2.5, 3.])
         let v = dsharp.tensor([2.75, -3.5])
-        let fx, jTv = dsharp.pjacobianTv fvect3vect2 x v
+        let fx, jTv = dsharp.fjacobianTv fvect3vect2 x v
         let jTv2 = dsharp.jacobianTv fvect3vect2 x v
         let fxCorrect = fvect3vect2 x
         let jTvCorrect = dsharp.matmul(v.view([1;-1]), fvect3vect2Jacobian x).view(-1)
@@ -218,139 +245,217 @@ type TestDiffSharp () =
     [<Test>]
     member this.TestJacobian () =
         let x = dsharp.arange(2.)
-        let fx, j = dsharp.pjacobian fvect2vect2 x
-        let j2 = dsharp.jacobian fvect2vect2 x
-        let nfx, nj = dsharp.numpjacobian 1e-4 fvect2vect2 x
-        let nj2 = dsharp.numjacobian 1e-4 fvect2vect2 x
+        let fx1, j1 = dsharp.fjacobian fvect2vect2 x
+        let fx2, j2 = dsharp.fj fvect2vect2 x
+        let j3 = dsharp.jacobian fvect2vect2 x
+        let j4 = dsharp.j fvect2vect2 x
+        let nfx1, nj1 = dsharp.numfjacobian 1e-4 fvect2vect2 x
+        let nfx2, nj2 = dsharp.numfj 1e-4 fvect2vect2 x
+        let nj3 = dsharp.numjacobian 1e-4 fvect2vect2 x
+        let nj4 = dsharp.numj 1e-4 fvect2vect2 x
         let fxCorrect = fvect2vect2 x
         let jCorrect = fvect2vect2Jacobian x
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(fxCorrect, nfx)
-        Assert.AreEqual(jCorrect, j)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, nfx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(fxCorrect, nfx2)
+        Assert.AreEqual(jCorrect, j1)
         Assert.AreEqual(jCorrect, j2)
-        Assert.True(jCorrect.allclose(nj, 0.1, 0.1))
+        Assert.AreEqual(jCorrect, j3)
+        Assert.AreEqual(jCorrect, j4)
+        Assert.True(jCorrect.allclose(nj1, 0.1, 0.1))
         Assert.True(jCorrect.allclose(nj2, 0.1, 0.1))
+        Assert.True(jCorrect.allclose(nj3, 0.1, 0.1))
+        Assert.True(jCorrect.allclose(nj4, 0.1, 0.1))
 
         let x = dsharp.arange(3.)
-        let fx, j = dsharp.pjacobian fvect3vect2 x
-        let j2 = dsharp.jacobian fvect3vect2 x
-        let nfx, nj = dsharp.numpjacobian 1e-4 fvect3vect2 x
-        let nj2 = dsharp.numjacobian 1e-4 fvect3vect2 x
+        let fx1, j1 = dsharp.fjacobian fvect3vect2 x
+        let fx2, j2 = dsharp.fj fvect3vect2 x
+        let j3 = dsharp.jacobian fvect3vect2 x
+        let j4 = dsharp.j fvect3vect2 x
+        let nfx1, nj1 = dsharp.numfjacobian 1e-4 fvect3vect2 x
+        let nfx2, nj2 = dsharp.numfj 1e-4 fvect3vect2 x
+        let nj3 = dsharp.numjacobian 1e-4 fvect3vect2 x
+        let nj4 = dsharp.numj 1e-4 fvect3vect2 x
         let fxCorrect = fvect3vect2 x
         let jCorrect = fvect3vect2Jacobian x
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(fxCorrect, nfx)
-        Assert.AreEqual(jCorrect, j)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, nfx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(fxCorrect, nfx2)
+        Assert.AreEqual(jCorrect, j1)
         Assert.AreEqual(jCorrect, j2)
-        Assert.True(jCorrect.allclose(nj, 0.1, 0.1))
+        Assert.AreEqual(jCorrect, j3)
+        Assert.AreEqual(jCorrect, j4)
+        Assert.True(jCorrect.allclose(nj1, 0.1, 0.1))
         Assert.True(jCorrect.allclose(nj2, 0.1, 0.1))
+        Assert.True(jCorrect.allclose(nj3, 0.1, 0.1))
+        Assert.True(jCorrect.allclose(nj4, 0.1, 0.1))
 
         let x = dsharp.arange(3.)
-        let fx, j = dsharp.pjacobian fvect3vect3 x
-        let j2 = dsharp.jacobian fvect3vect3 x
-        let nfx, nj = dsharp.numpjacobian 1e-4 fvect3vect3 x
-        let nj2 = dsharp.numjacobian 1e-4 fvect3vect3 x
+        let fx1, j1 = dsharp.fjacobian fvect3vect3 x
+        let fx2, j2 = dsharp.fj fvect3vect3 x
+        let j3 = dsharp.jacobian fvect3vect3 x
+        let j4 = dsharp.j fvect3vect3 x
+        let nfx1, nj1 = dsharp.numfjacobian 1e-4 fvect3vect3 x
+        let nfx2, nj2 = dsharp.numfj 1e-4 fvect3vect3 x
+        let nj3 = dsharp.numjacobian 1e-4 fvect3vect3 x
+        let nj4 = dsharp.numj 1e-4 fvect3vect3 x
         let fxCorrect = fvect3vect3 x
         let jCorrect = fvect3vect3Jacobian x
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(fxCorrect, nfx)
-        Assert.AreEqual(jCorrect, j)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, nfx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(fxCorrect, nfx2)
+        Assert.AreEqual(jCorrect, j1)
         Assert.AreEqual(jCorrect, j2)
-        Assert.True(jCorrect.allclose(nj, 0.1, 0.1))
+        Assert.AreEqual(jCorrect, j3)
+        Assert.AreEqual(jCorrect, j4)
+        Assert.True(jCorrect.allclose(nj1, 0.1, 0.1))
         Assert.True(jCorrect.allclose(nj2, 0.1, 0.1))
+        Assert.True(jCorrect.allclose(nj3, 0.1, 0.1))
+        Assert.True(jCorrect.allclose(nj4, 0.1, 0.1))
 
         let x = dsharp.arange(3.)
-        let fx, j = dsharp.pjacobian fvect3vect4 x
-        let j2 = dsharp.jacobian fvect3vect4 x
-        let nfx, nj = dsharp.numpjacobian 1e-4 fvect3vect4 x
-        let nj2 = dsharp.numjacobian 1e-4 fvect3vect4 x
+        let fx1, j1 = dsharp.fjacobian fvect3vect4 x
+        let fx2, j2 = dsharp.fj fvect3vect4 x
+        let j3 = dsharp.jacobian fvect3vect4 x
+        let j4 = dsharp.j fvect3vect4 x
+        let nfx1, nj1 = dsharp.numfjacobian 1e-4 fvect3vect4 x
+        let nfx2, nj2 = dsharp.numfj 1e-4 fvect3vect4 x
+        let nj3 = dsharp.numjacobian 1e-4 fvect3vect4 x
+        let nj4 = dsharp.numj 1e-4 fvect3vect4 x
         let fxCorrect = fvect3vect4 x
         let jCorrect = fvect3vect4Jacobian x
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(fxCorrect, nfx)
-        Assert.AreEqual(jCorrect, j)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, nfx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(fxCorrect, nfx2)
+        Assert.AreEqual(jCorrect, j1)
         Assert.AreEqual(jCorrect, j2)
-        Assert.True(jCorrect.allclose(nj, 0.1, 0.1))
+        Assert.AreEqual(jCorrect, j3)
+        Assert.AreEqual(jCorrect, j4)
+        Assert.True(jCorrect.allclose(nj1, 0.1, 0.1))
         Assert.True(jCorrect.allclose(nj2, 0.1, 0.1))
+        Assert.True(jCorrect.allclose(nj3, 0.1, 0.1))
+        Assert.True(jCorrect.allclose(nj4, 0.1, 0.1))
 
     [<Test>]
     member this.TestGradhessianv () =
         let x = dsharp.tensor([1.5, 2.5])
         let v = dsharp.tensor([0.5, -2.])
-        let fx, gv, hv = dsharp.pgradhessianv rosenbrock x v
-        let gv2, hv2 = dsharp.gradhessianv rosenbrock x v
+        let fx1, gv1, hv1 = dsharp.fgradhessianv rosenbrock x v
+        let fx2, gv2, hv2 = dsharp.fghvp rosenbrock x v
+        let gv3, hv3 = dsharp.gradhessianv rosenbrock x v
+        let gv4, hv4 = dsharp.ghvp rosenbrock x v
         let fxCorrect = rosenbrock x
         let gvCorrect = dsharp.dot(rosenbrockGrad x,  v)        
         let hvCorrect = dsharp.matmul(rosenbrockHessian x,  v.view([-1;1])).view(-1)
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(gvCorrect, gv)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(gvCorrect, gv1)
         Assert.AreEqual(gvCorrect, gv2)
-        Assert.AreEqual(hvCorrect, hv)
+        Assert.AreEqual(gvCorrect, gv3)
+        Assert.AreEqual(gvCorrect, gv4)
+        Assert.AreEqual(hvCorrect, hv1)
         Assert.AreEqual(hvCorrect, hv2)
+        Assert.AreEqual(hvCorrect, hv3)
+        Assert.AreEqual(hvCorrect, hv4)
 
     [<Test>]
     member this.TestGradhessian () =
         let x = dsharp.tensor([1.5, 2.5])
-        let fx, g, h = dsharp.pgradhessian rosenbrock x
-        let g2, h2 = dsharp.gradhessian rosenbrock x
-        let nfx, ng, nh = dsharp.numpgradhessian 1e-3 rosenbrock x
-        let ng2, nh2 = dsharp.numgradhessian 1e-3 rosenbrock x
+        let fx1, g1, h1 = dsharp.fgradhessian rosenbrock x
+        let fx2, g2, h2 = dsharp.fgh rosenbrock x
+        let g3, h3 = dsharp.gradhessian rosenbrock x
+        let g4, h4 = dsharp.gh rosenbrock x
+        let nfx1, ng1, nh1 = dsharp.numfgradhessian 1e-3 rosenbrock x
+        let nfx2, ng2, nh2 = dsharp.numfgh 1e-3 rosenbrock x
+        let ng3, nh3 = dsharp.numgradhessian 1e-3 rosenbrock x
+        let ng4, nh4 = dsharp.numgh 1e-3 rosenbrock x
         let fxCorrect = rosenbrock x
         let gCorrect = rosenbrockGrad x
         let hCorrect = rosenbrockHessian x
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(fxCorrect, nfx)
-        Assert.AreEqual(gCorrect, g)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, nfx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(fxCorrect, nfx2)
+        Assert.AreEqual(gCorrect, g1)
         Assert.AreEqual(gCorrect, g2)
-        Assert.AreEqual(hCorrect, h)
+        Assert.AreEqual(gCorrect, g3)
+        Assert.AreEqual(gCorrect, g4)
+        Assert.AreEqual(hCorrect, h1)
         Assert.AreEqual(hCorrect, h2)
-        Assert.True(gCorrect.allclose(ng, 0.1))
+        Assert.AreEqual(hCorrect, h3)
+        Assert.AreEqual(hCorrect, h4)
+        Assert.True(gCorrect.allclose(ng1, 0.1))
         Assert.True(gCorrect.allclose(ng2, 0.1))
-        Assert.True(hCorrect.allclose(nh, 0.1))
+        Assert.True(gCorrect.allclose(ng3, 0.1))
+        Assert.True(gCorrect.allclose(ng4, 0.1))
+        Assert.True(hCorrect.allclose(nh1, 0.1))
         Assert.True(hCorrect.allclose(nh2, 0.1))
+        Assert.True(hCorrect.allclose(nh3, 0.1))
+        Assert.True(hCorrect.allclose(nh4, 0.1))
 
     [<Test>]
     member this.TestHessianv () =
         let x = dsharp.tensor([1.5, 2.5])
         let v = dsharp.tensor([0.5, -2.])
-        let fx, hv = dsharp.phessianv rosenbrock x v
-        let hv2 = dsharp.hessianv rosenbrock x v
-        let nfx, nhv = dsharp.numphessianv 1e-3 rosenbrock x v
-        let nhv2 = dsharp.numhessianv 1e-3 rosenbrock x v
+        let fx1, hv1 = dsharp.fhessianv rosenbrock x v
+        let fx2, hv2 = dsharp.fhvp rosenbrock x v
+        let hv3 = dsharp.hessianv rosenbrock x v
+        let hv4 = dsharp.hvp rosenbrock x v
+        let nfx1, nhv1 = dsharp.numfhessianv 1e-3 rosenbrock x v
+        let nfx2, nhv2 = dsharp.numfhvp 1e-3 rosenbrock x v
+        let nhv3 = dsharp.numhessianv 1e-3 rosenbrock x v
+        let nhv4 = dsharp.numhvp 1e-3 rosenbrock x v
         let fxCorrect = rosenbrock x
         let hvCorrect = dsharp.matmul(rosenbrockHessian x,  v.view([-1;1])).view(-1)
-        printfn "%A" hv
-        printfn "%A" nhv
-        printfn "%A" nhv2
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(fxCorrect, nfx)
-        Assert.AreEqual(hvCorrect, hv)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, nfx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(fxCorrect, nfx2)
+        Assert.AreEqual(hvCorrect, hv1)
         Assert.AreEqual(hvCorrect, hv2)
-        Assert.True(hvCorrect.allclose(nhv, 0.1))
+        Assert.AreEqual(hvCorrect, hv3)
+        Assert.AreEqual(hvCorrect, hv4)
+        Assert.True(hvCorrect.allclose(nhv1, 0.1))
         Assert.True(hvCorrect.allclose(nhv2, 0.1))
+        Assert.True(hvCorrect.allclose(nhv3, 0.1))
+        Assert.True(hvCorrect.allclose(nhv4, 0.1))
 
     [<Test>]
     member this.TestHessian () =
         let x = dsharp.tensor([1.5, 2.5])
-        let fx, h = dsharp.phessian rosenbrock x
-        let h2 = dsharp.hessian rosenbrock x
-        let nfx, nh = dsharp.numphessian 1e-3 rosenbrock x
-        let nh2 = dsharp.numhessian 1e-3 rosenbrock x
+        let fx1, h1 = dsharp.fhessian rosenbrock x
+        let fx2, h2 = dsharp.fh rosenbrock x
+        let h3 = dsharp.hessian rosenbrock x
+        let h4 = dsharp.h rosenbrock x
+        let nfx1, nh1 = dsharp.numfhessian 1e-3 rosenbrock x
+        let nfx2, nh2 = dsharp.numfh 1e-3 rosenbrock x
+        let nh3 = dsharp.numhessian 1e-3 rosenbrock x
+        let nh4 = dsharp.numh 1e-3 rosenbrock x
         let fxCorrect = rosenbrock x
         let hCorrect = rosenbrockHessian x
-        Assert.AreEqual(fxCorrect, fx)
-        Assert.AreEqual(fxCorrect, nfx)
-        Assert.AreEqual(hCorrect, h)
+        Assert.AreEqual(fxCorrect, fx1)
+        Assert.AreEqual(fxCorrect, nfx1)
+        Assert.AreEqual(fxCorrect, fx2)
+        Assert.AreEqual(fxCorrect, nfx2)
+        Assert.AreEqual(hCorrect, h1)
         Assert.AreEqual(hCorrect, h2)
-        Assert.True(hCorrect.allclose(nh, 0.1))
+        Assert.AreEqual(hCorrect, h3)
+        Assert.AreEqual(hCorrect, h4)
+        Assert.True(hCorrect.allclose(nh1, 0.1))
         Assert.True(hCorrect.allclose(nh2, 0.1))
+        Assert.True(hCorrect.allclose(nh3, 0.1))
+        Assert.True(hCorrect.allclose(nh4, 0.1))
 
     [<Test>]
     member this.TestLaplacian () =
         let x = dsharp.tensor([1.5, 2.5])
-        let fx, l = dsharp.plaplacian rosenbrock x
+        let fx, l = dsharp.flaplacian rosenbrock x
         let l2 = dsharp.laplacian rosenbrock x
-        let nfx, nl = dsharp.numplaplacian 1e-3 rosenbrock x
+        let nfx, nl = dsharp.numflaplacian 1e-3 rosenbrock x
         let nl2 = dsharp.numlaplacian 1e-3 rosenbrock x
         let fxCorrect = rosenbrock x
         let lCorrect = (rosenbrockHessian x).trace()
@@ -364,9 +469,9 @@ type TestDiffSharp () =
     [<Test>]
     member this.TestCurl () =
         let x = dsharp.tensor([1.5, 2.5, 0.2])
-        let fx, c = dsharp.pcurl fvect3vect3 x
+        let fx, c = dsharp.fcurl fvect3vect3 x
         let c2 = dsharp.curl fvect3vect3 x
-        let nfx, nc = dsharp.numpcurl 1e-3 fvect3vect3 x
+        let nfx, nc = dsharp.numfcurl 1e-3 fvect3vect3 x
         let nc2 = dsharp.numcurl 1e-3 fvect3vect3 x
         let fxCorrect = fvect3vect3 x
         let cCorrect = dsharp.tensor([-0.879814, -2.157828, 0.297245])
@@ -380,9 +485,9 @@ type TestDiffSharp () =
     [<Test>]
     member this.TestDivergence () =
         let x = dsharp.tensor([1.5, 2.5, 0.2])
-        let fx, d = dsharp.pdivergence fvect3vect3 x
+        let fx, d = dsharp.fdivergence fvect3vect3 x
         let d2 = dsharp.divergence fvect3vect3 x
-        let nfx, nd = dsharp.numpdivergence 1e-3 fvect3vect3 x
+        let nfx, nd = dsharp.numfdivergence 1e-3 fvect3vect3 x
         let nd2 = dsharp.numdivergence 1e-3 fvect3vect3 x
         let fxCorrect = fvect3vect3 x
         let dCorrect = dsharp.tensor(-0.695911)
@@ -396,9 +501,9 @@ type TestDiffSharp () =
     [<Test>]
     member this.TestCurlDivergence () =
         let x = dsharp.tensor([1.5, 2.5, 0.2])
-        let fx, c, d = dsharp.pcurldivergence fvect3vect3 x
+        let fx, c, d = dsharp.fcurldivergence fvect3vect3 x
         let c2, d2 = dsharp.curldivergence fvect3vect3 x
-        let nfx, nc, nd = dsharp.numpcurldivergence 1e-3 fvect3vect3 x
+        let nfx, nc, nd = dsharp.numfcurldivergence 1e-3 fvect3vect3 x
         let nc2, nd2 = dsharp.numcurldivergence 1e-3 fvect3vect3 x
         let fxCorrect = fvect3vect3 x
         let cCorrect = dsharp.tensor([-0.879814, -2.157828, 0.297245])

--- a/src/Test/Program.fs
+++ b/src/Test/Program.fs
@@ -100,7 +100,7 @@ let main _argv =
     let loss = net.forwardLoss dsharp.crossEntropyLoss
     let mutable p = net.getParameters()
     for i, data, target in dataloader.epoch() do
-        let loss, g = dsharp.pgrad (loss data target) p
+        let loss, g = dsharp.fgrad (loss data target) p
         p <- p - 0.1 * g
         printfn "%A %A" i loss
 


### PR DESCRIPTION
This is for updating the naming scheme of differentiation ops while maintaining some backward compatibility with previous DiffSharp versions and publications. 

We replaced the `'`-suffixed versions of ops (referring to ops that return a function's original value in a tuple along with the derivative, e.g., `jacobianv'`) previously before this PR. This PR introduces the prefix `f` for this purpose (e.g., `jacobianv'` becomes `fjacobianv` and `fjacobianv f x v` returns `f x, jacobianv f x v`, the advantage being the value of `f x` is already computed when one computes `jacobianv`).

We also introduce alternative short names with which people in machine learning have gained familiarity recently (e.g., the `jvp`, `vjp` in [jax](https://github.com/google/jax)). For example, `jacobianv` can be used as `jvp` (stands for "Jacobian-vector product") and `fjacobianv` can be used as `fjvp`.

The same API is implemented in Python in [difftorch](https://github.com/gbaydin/difftorch) using PyTorch reverse mode. This greatly simplifies comparisons of derivative values in DiffSharp and PyTorch.