### PR TITLE
When serializing a tensor save the right device

### DIFF
--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -750,9 +750,9 @@ type TorchRawTensor(tt: TorchTensor, shape: int[], dtype, device) =
             // Torch Tensors must be CPU before they can be saved
             let tCpu = t.MoveTo(Device.CPU) :?> TorchRawTensor
 
-            info.AddValue("device", tCpu.Device)
-            info.AddValue("dtype", tCpu.Dtype)
-            info.AddValue("shape", tCpu.Shape)
+            info.AddValue("device", device)
+            info.AddValue("dtype", dtype)
+            info.AddValue("shape", shape)
             info.AddValue("data", tCpu.ToRawData())
 
 /// The concrete implementation of BackendStatics for Float32 data.


### PR DESCRIPTION
When serializing a tensor we save the device it is associated with, and resurrect it back to that device.

One of the last bugs detected by this test pass for libtorch on GPU https://github.com/xamarin/TorchSharp/issues/143

