### PR TITLE
Additional tests for addition and multiplication

### DIFF
--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -628,7 +628,7 @@ type Tensor =
             let dfTensorFwdTC(cp:Tensor,ap:Tensor,ad:Tensor) = ad * b
             let dfTensorFwdCT(cp:Tensor,bp:Tensor,bd:Tensor) = a * bd
             let dfTensorRevTT(a,b) = MulTT0(b,a)
-            let dfTensorRevTC(a,b) = MulTConstT0(a,b)
+            let dfTensorRevTC(a,b) = MulTConstT0(b,a)
             let dfTensorRevCT(a,b) = MulTT0Const(b,a)
             Tensor.OpBinary(a, b, fRaw, fTensor, dfTensorFwdTT, dfTensorFwdTC, dfTensorFwdCT, dfTensorRevTT, dfTensorRevTC, dfTensorRevCT)
         elif b.dim = 0 then
@@ -639,7 +639,7 @@ type Tensor =
             let dfTensorFwdCT(cp:Tensor,bp:Tensor,bd:Tensor) = a * bd
             let dfTensorRevTT(a,b) = MulTT0(a,b)
             let dfTensorRevTC(a,b) = MulTT0Const(a,b)
-            let dfTensorRevCT(a,b) = MulTConstT0(b,a)
+            let dfTensorRevCT(a,b) = MulTConstT0(a,b)
             Tensor.OpBinary(a, b, fRaw, fTensor, dfTensorFwdTT, dfTensorFwdTC, dfTensorFwdCT, dfTensorRevTT, dfTensorRevTC, dfTensorRevCT)
         else
             let newShape = Shape.broadcast2 a.shape b.shape

--- a/tests/DiffSharp.Tests/TestDerivatives.fs
+++ b/tests/DiffSharp.Tests/TestDerivatives.fs
@@ -39,37 +39,177 @@ type TestDerivatives () =
             Assert.AreEqual(revydCorrect, revyd)
 
     [<Test>]
-    member _.TestDerivativeAddT2T1 () =
+    member _.TestDerivativeAddTTConst () =
         for combo in Combos.AllDevicesAndBackends do
-            let fwdx = combo.tensor([[1.; 2.]; [3.; 4.]]).forwardDiff(combo.tensor([[2.; 3.]; [4.; 5.]]))
-            let fwdy = combo.tensor([5.; 6.]).forwardDiff(combo.tensor([2.; 3.]))
+            let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+            let fwdy = combo.tensor([5.; 6.; 7.])
             let fwdz = fwdx + fwdy
-            let fwdzCorrect = combo.tensor([[6.; 8.]; [8.; 10.]])
+            let fwdzCorrect = combo.tensor([6.; 8.; 10.])
             let fwdzd = fwdz.derivative
-            let fwdzdCorrect = combo.tensor([[4.; 6.]; [6.; 8.]])
+            let fwdzdCorrect = combo.tensor([2.; 3.; 4.])
 
-            let revx = combo.tensor([[1.; 2.]; [3.; 4.]]).reverseDiff()
-            let revy = combo.tensor([5.; 6.]).reverseDiff()
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.])
             let revz = revx + revy
-            let revzCorrect = combo.tensor([[6.; 8.]; [8.; 10.]])
-            revz.reverse(combo.tensor([[2.; 3.]; [4.; 5.]]))
+            let revzCorrect = combo.tensor([6.; 8.; 10.])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
             let revxd = revx.derivative
-            let revxdCorrect = combo.tensor([[2.; 3.]; [4.; 5.]])
-            let revyd = revy.derivative
-            let revydCorrect = combo.tensor([6.; 8.])
+            let revxdCorrect = combo.tensor([5.; 5.; 5.])
 
             Assert.AreEqual(fwdzCorrect, fwdz)
             Assert.AreEqual(fwdzdCorrect, fwdzd)
             Assert.AreEqual(revzCorrect, revz)
             Assert.AreEqual(revxdCorrect, revxd)
-            Assert.AreEqual(revydCorrect, revyd)
 
-    // TODO: add test for AddTTConst
-    // TODO: add test for AddTT0
-    // TODO: add test for AddTT0Const
-    // TODO: add test for AddTConstT0
-    // TODO: add test for AddT2T1Const
-    // TODO: add test for AddT2ConstT1
+    [<Test>]
+    member _.TestDerivativeAddT2T1 () =
+        for swap in [true; false] do
+            for combo in Combos.AllDevicesAndBackends do
+                let fwdx = combo.tensor([[1.; 2.]; [3.; 4.]]).forwardDiff(combo.tensor([[2.; 3.]; [4.; 5.]]))
+                let fwdy = combo.tensor([5.; 6.]).forwardDiff(combo.tensor([2.; 3.]))
+                let fwdz = if swap then fwdy + fwdx else fwdx + fwdy
+                let fwdzCorrect = combo.tensor([[6.; 8.]; [8.; 10.]])
+                let fwdzd = fwdz.derivative
+                let fwdzdCorrect = combo.tensor([[4.; 6.]; [6.; 8.]])
+
+                let revx = combo.tensor([[1.; 2.]; [3.; 4.]]).reverseDiff()
+                let revy = combo.tensor([5.; 6.]).reverseDiff()
+                let revz = if swap then revy + revx else revx + revy
+                let revzCorrect = combo.tensor([[6.; 8.]; [8.; 10.]])
+                revz.reverse(combo.tensor([[2.; 3.]; [4.; 5.]]))
+                let revxd = revx.derivative
+                let revxdCorrect = combo.tensor([[2.; 3.]; [4.; 5.]])
+                let revyd = revy.derivative
+                let revydCorrect = combo.tensor([6.; 8.])
+
+                Assert.AreEqual(fwdzCorrect, fwdz)
+                Assert.AreEqual(fwdzdCorrect, fwdzd)
+                Assert.AreEqual(revzCorrect, revz)
+                Assert.AreEqual(revxdCorrect, revxd)
+                Assert.AreEqual(revydCorrect, revyd)
+
+    [<Test>]
+    member _.TestDerivativeAddT2T1Const () =
+        for swap in [true; false] do
+            for combo in Combos.AllDevicesAndBackends do
+                let fwdx = combo.tensor([[1.; 2.]; [3.; 4.]]).forwardDiff(combo.tensor([[2.; 3.]; [4.; 5.]]))
+                let fwdy = combo.tensor([5.; 6.])
+                let fwdz = if swap then fwdy + fwdx else fwdx + fwdy
+                let fwdzCorrect = combo.tensor([[6.; 8.]; [8.; 10.]])
+                let fwdzd = fwdz.derivative
+                let fwdzdCorrect = combo.tensor([[2.; 3.]; [4.; 5.]])
+
+                let revx = combo.tensor([[1.; 2.]; [3.; 4.]]).reverseDiff()
+                let revy = combo.tensor([5.; 6.])
+                let revz = if swap then revy + revx else revx + revy
+                let revzCorrect = combo.tensor([[6.; 8.]; [8.; 10.]])
+                revz.reverse(combo.tensor([[2.; 3.]; [4.; 5.]]))
+                let revxd = revx.derivative
+                let revxdCorrect = combo.tensor([[2.; 3.]; [4.; 5.]])
+
+                Assert.AreEqual(fwdzCorrect, fwdz)
+                Assert.AreEqual(fwdzdCorrect, fwdzd)
+                Assert.AreEqual(revzCorrect, revz)
+                Assert.AreEqual(revxdCorrect, revxd)
+
+    [<Test>]
+    member _.TestDerivativeAddT2ConstT1 () =
+        for swap in [true; false] do
+            for combo in Combos.AllDevicesAndBackends do
+                let fwdx = combo.tensor([[1.; 2.]; [3.; 4.]])
+                let fwdy = combo.tensor([5.; 6.]).forwardDiff(combo.tensor([2.; 3.]))
+                let fwdz = if swap then fwdy + fwdx else fwdx + fwdy
+                let fwdzCorrect = combo.tensor([[6.; 8.]; [8.; 10.]])
+                let fwdzd = fwdz.derivative
+                let fwdzdCorrect = combo.tensor([[2.; 3.]; [2.; 3.]])
+
+                let revx = combo.tensor([[1.; 2.]; [3.; 4.]])
+                let revy = combo.tensor([5.; 6.]).reverseDiff()
+                let revz = if swap then revy + revx else revx + revy
+                let revzCorrect = combo.tensor([[6.; 8.]; [8.; 10.]])
+                revz.reverse(combo.tensor([[2.; 3.]; [4.; 5.]]))
+                let revyd = revy.derivative
+                let revydCorrect = combo.tensor([6.; 8.])
+
+                Assert.AreEqual(fwdzCorrect, fwdz)
+                Assert.AreEqual(fwdzdCorrect, fwdzd)
+                Assert.AreEqual(revzCorrect, revz)
+                Assert.AreEqual(revydCorrect, revyd)
+
+    [<Test>]
+    member _.TestDerivativeAddTT0Const () =
+        for swap in [true; false] do
+            for combo in Combos.AllDevicesAndBackends do
+                let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+                let fwdy = 5.
+                let fwdz = if swap then fwdy + fwdx else fwdx + fwdy
+                let fwdzCorrect = combo.tensor([6.; 7.; 8.])
+                let fwdzd = fwdz.derivative
+                let fwdzdCorrect = combo.tensor([2.; 3.; 4.])
+
+                let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+                let revy = 5.
+                let revz = if swap then revy + revx else revx + revy
+                let revzCorrect = combo.tensor([6.; 7.; 8.])
+                revz.reverse(combo.tensor([5.; 6.; 7.]))
+                let revxd = revx.derivative
+                let revxdCorrect = combo.tensor([5.; 6.; 7.])
+
+                Assert.AreEqual(fwdzCorrect, fwdz)
+                Assert.AreEqual(fwdzdCorrect, fwdzd)
+                Assert.AreEqual(revzCorrect, revz)
+                Assert.AreEqual(revxdCorrect, revxd)
+
+    [<Test>]
+    member _.TestDerivativeAddTT0 () =
+        for swap in [true; false] do
+            for combo in Combos.AllDevicesAndBackends do
+                let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+                let fwdy = combo.tensor(5.).forwardDiff(combo.tensor(3.))
+                let fwdz = if swap then fwdy + fwdx else fwdx + fwdy
+                let fwdzCorrect = combo.tensor([6.; 7.; 8.])
+                let fwdzd = fwdz.derivative
+                let fwdzdCorrect = combo.tensor([5.; 6.; 7.])
+
+                let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+                let revy = combo.tensor(5.).reverseDiff()
+                let revz = if swap then revy + revx else revx + revy
+                let revzCorrect = combo.tensor([6.; 7.; 8.])
+                revz.reverse(combo.tensor([5.; 6.; 7.]))
+                let revxd = revx.derivative
+                let revxdCorrect = combo.tensor([5.; 6.; 7.])
+                let revyd = revy.derivative
+                let revydCorrect = combo.tensor(18.)
+
+                Assert.AreEqual(fwdzCorrect, fwdz)
+                Assert.AreEqual(fwdzdCorrect, fwdzd)
+                Assert.AreEqual(revzCorrect, revz)
+                Assert.AreEqual(revxdCorrect, revxd)
+                Assert.AreEqual(revydCorrect, revyd)
+
+    [<Test>]
+    member _.TestDerivativeAddTConstT0 () =
+        for swap in [true; false] do
+            for combo in Combos.AllDevicesAndBackends do
+                let fwdx = combo.tensor([1.; 2.; 3.])
+                let fwdy = combo.tensor(5.).forwardDiff(combo.tensor(3.))
+                let fwdz = if swap then fwdy + fwdx else fwdx + fwdy
+                let fwdzCorrect = combo.tensor([6.; 7.; 8.])
+                let fwdzd = fwdz.derivative
+                let fwdzdCorrect = combo.tensor([3.; 3.; 3.])
+
+                let revx = combo.tensor([1.; 2.; 3.])
+                let revy = combo.tensor(5.).reverseDiff()
+                let revz = if swap then revy + revx else revx + revy
+                let revzCorrect = combo.tensor([6.; 7.; 8.])
+                revz.reverse(combo.tensor([5.; 6.; 7.]))
+                let revyd = revy.derivative
+                let revydCorrect = combo.tensor(18.)
+
+                Assert.AreEqual(fwdzCorrect, fwdz)
+                Assert.AreEqual(fwdzdCorrect, fwdzd)
+                Assert.AreEqual(revzCorrect, revz)
+                Assert.AreEqual(revydCorrect, revyd)
 
     [<Test>]
     member _.TestDerivativeExpand () =
@@ -193,14 +333,195 @@ type TestDerivatives () =
             Assert.AreEqual(revxdCorrect, revxd)
             Assert.AreEqual(revydCorrect, revyd)
 
-    // TODO: add test for SubTTConst
-    // TODO: add test for SubTConstT
-    // TODO: add test for SubT0T
-    // TODO: add test for SubT0TConst
-    // TODO: add test for SubT0ConstT
-    // TODO: add test for SubTT0
-    // TODO: add test for SubTT0Const
-    // TODO: add test for SubTConstT0
+    [<Test>]
+    member _.TestDerivativeSubTTConst () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+            let fwdy = combo.tensor([5.; 6.; 7.])
+            let fwdz = fwdx - fwdy
+            let fwdzCorrect = combo.tensor([-4.; -4.; -4.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([2.; 3.; 4.])
+
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.])
+            let revz = revx - revy
+            let revzCorrect = combo.tensor([-4.; -4.; -4.])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([5.; 5.; 5.])
+
+            Assert.AreEqual(fwdzCorrect, fwdz)
+            Assert.AreEqual(fwdzdCorrect, fwdzd)
+            Assert.AreEqual(revzCorrect, revz)
+            Assert.AreEqual(revxdCorrect, revxd)
+
+    [<Test>]
+    member _.TestDerivativeSubTConstT () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.])
+            let fwdy = combo.tensor([5.; 6.; 7.]).forwardDiff(combo.tensor([2.; 2.; 3.]))
+            let fwdz = fwdx - fwdy
+            let fwdzCorrect = combo.tensor([-4.; -4.; -4.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([-2.; -2.; -3.])
+
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.]).reverseDiff()
+            let revz = revx - revy
+            let revzCorrect = combo.tensor([-4.; -4.; -4.])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor([-5.; -5.; -5.])
+
+            Assert.AreEqual(fwdzCorrect, fwdz)
+            Assert.AreEqual(fwdzdCorrect, fwdzd)
+            Assert.AreEqual(revzCorrect, revz)
+            Assert.AreEqual(revydCorrect, revyd)
+
+    [<Test>]
+    member _.TestDerivativeSubT0T () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor(9.).forwardDiff(combo.tensor(7.))
+            let fwdy = combo.tensor([5.; 6.; 7.]).forwardDiff(combo.tensor([2.; 2.; 3.]))
+            let fwdz = fwdx - fwdy
+            let fwdzCorrect = combo.tensor([4.; 3.; 2.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([5.; 5.; 4.])
+
+            let revx = combo.tensor(9.).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.]).reverseDiff()
+            let revz = revx - revy
+            let revzCorrect = combo.tensor([4.; 3.; 2.])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor(15.)
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor([-5.; -5.; -5.])
+
+            Assert.AreEqual(fwdzCorrect, fwdz)
+            Assert.AreEqual(fwdzdCorrect, fwdzd)
+            Assert.AreEqual(revzCorrect, revz)
+            Assert.AreEqual(revxdCorrect, revxd)
+            Assert.AreEqual(revydCorrect, revyd)
+
+    [<Test>]
+    member _.TestDerivativeSubTT0 () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+            let fwdy = combo.tensor(5.).forwardDiff(combo.tensor(7.))
+            let fwdz = fwdx - fwdy
+            let fwdzCorrect = combo.tensor([-4.; -3.; -2.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([-5.; -4.; -3.])
+
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor(5.).reverseDiff()
+            let revz = revx - revy
+            let revzCorrect = combo.tensor([-4.; -3.; -2.])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([5.; 5.; 5.])
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor(-15.)
+
+            Assert.AreEqual(fwdzCorrect, fwdz)
+            Assert.AreEqual(fwdzdCorrect, fwdzd)
+            Assert.AreEqual(revzCorrect, revz)
+            Assert.AreEqual(revxdCorrect, revxd)
+            Assert.AreEqual(revydCorrect, revyd)
+
+    [<Test>]
+    member _.TestDerivativeSubT0TConst () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor(9.).forwardDiff(combo.tensor(7.))
+            let fwdy = combo.tensor([5.; 6.; 7.])
+            let fwdz = fwdx - fwdy
+            let fwdzCorrect = combo.tensor([4.; 3.; 2.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([7.; 7.; 7.])
+
+            let revx = combo.tensor(9.).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.])
+            let revz = revx - revy
+            let revzCorrect = combo.tensor([4.; 3.; 2.])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor(15.)
+
+            Assert.AreEqual(fwdzCorrect, fwdz)
+            Assert.AreEqual(fwdzdCorrect, fwdzd)
+            Assert.AreEqual(revzCorrect, revz)
+            Assert.AreEqual(revxdCorrect, revxd)
+
+    [<Test>]
+    member _.TestDerivativeSubTConstT0 () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.])
+            let fwdy = combo.tensor(5.).forwardDiff(combo.tensor(7.))
+            let fwdz = fwdx - fwdy
+            let fwdzCorrect = combo.tensor([-4.; -3.; -2.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([-7.; -7.; -7.])
+
+            let revx = combo.tensor([1.; 2.; 3.])
+            let revy = combo.tensor(5.).reverseDiff()
+            let revz = revx - revy
+            let revzCorrect = combo.tensor([-4.; -3.; -2.])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor(-15.)
+
+            Assert.AreEqual(fwdzCorrect, fwdz)
+            Assert.AreEqual(fwdzdCorrect, fwdzd)
+            Assert.AreEqual(revzCorrect, revz)
+            Assert.AreEqual(revydCorrect, revyd)
+
+    [<Test>]
+    member _.TestDerivativeSubT0ConstT () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor(9.)
+            let fwdy = combo.tensor([5.; 6.; 7.]).forwardDiff(combo.tensor([2.; 2.; 3.]))
+            let fwdz = fwdx - fwdy
+            let fwdzCorrect = combo.tensor([4.; 3.; 2.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([-2.; -2.; -3.])
+
+            let revx = combo.tensor(9.)
+            let revy = combo.tensor([5.; 6.; 7.]).reverseDiff()
+            let revz = revx - revy
+            let revzCorrect = combo.tensor([4.; 3.; 2.])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor([-5.; -5.; -5.])
+
+            Assert.AreEqual(fwdzCorrect, fwdz)
+            Assert.AreEqual(fwdzdCorrect, fwdzd)
+            Assert.AreEqual(revzCorrect, revz)
+            Assert.AreEqual(revydCorrect, revyd)
+
+    [<Test>]
+    member _.TestDerivativeSubTT0Const () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+            let fwdy = combo.tensor(5.)
+            let fwdz = fwdx - fwdy
+            let fwdzCorrect = combo.tensor([-4.; -3.; -2.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([2.; 3.; 4.])
+
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor(5.)
+            let revz = revx - revy
+            let revzCorrect = combo.tensor([-4.; -3.; -2.])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([5.; 5.; 5.])
+
+            Assert.AreEqual(fwdzCorrect, fwdz)
+            Assert.AreEqual(fwdzdCorrect, fwdzd)
+            Assert.AreEqual(revzCorrect, revz)
+            Assert.AreEqual(revxdCorrect, revxd)
 
     [<Test>]
     member _.TestDerivativeMulTT () =
@@ -228,10 +549,104 @@ type TestDerivatives () =
             Assert.AreEqual(revxdCorrect, revxd)
             Assert.AreEqual(revydCorrect, revyd)
 
-    // TODO: add test for MulTTConst
-    // TODO: add test for MulTT0
-    // TODO: add test for MulTConstT0
-    // TODO: add test for MulTT0Const
+    [<Test>]
+    member _.TestDerivativeMulTTConst () =
+        for swap in [true; false] do
+            for combo in Combos.AllDevicesAndBackends do
+                let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+                let fwdy = combo.tensor([5.; 6.; 7.])
+                let fwdz = if swap then fwdy * fwdx else fwdx * fwdy
+                let fwdzCorrect = combo.tensor([5.; 12.; 21.])
+                let fwdzd = fwdz.derivative
+                let fwdzdCorrect = combo.tensor([10.; 18.; 28.])
+
+                let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+                let revy = combo.tensor([5.; 6.; 7.])
+                let revz = if swap then revy * revx else revx * revy
+                let revzCorrect = combo.tensor([5.; 12.; 21.])
+                revz.reverse(combo.tensor([5.; 5.; 5.]))
+                let revxd = revx.derivative
+                let revxdCorrect = combo.tensor([25.; 30.; 35.])
+
+                Assert.AreEqual(fwdzCorrect, fwdz)
+                Assert.AreEqual(fwdzdCorrect, fwdzd)
+                Assert.AreEqual(revzCorrect, revz)
+                Assert.AreEqual(revxdCorrect, revxd)
+
+    [<Test>]
+    member _.TestDerivativeMulTT0 () =
+        for swap in [true; false] do
+            for combo in Combos.AllDevicesAndBackends do
+                let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+                let fwdy = combo.tensor(5.).forwardDiff(combo.tensor(2.))
+                let fwdz = if swap then fwdy * fwdx else fwdx * fwdy
+                let fwdzCorrect = combo.tensor([5.; 10.; 15.])
+                let fwdzd = fwdz.derivative
+                let fwdzdCorrect = combo.tensor([12.; 19.; 26.])
+
+                let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+                let revy = combo.tensor(5.).reverseDiff()
+                let revz = if swap then revy * revx else revx * revy
+                let revzCorrect = combo.tensor([5.; 10.; 15.])
+                revz.reverse(combo.tensor([5.; 6.; 7.]))
+                let revxd = revx.derivative
+                let revxdCorrect = combo.tensor([25.; 30.; 35.])
+                let revyd = revy.derivative
+                let revydCorrect = combo.tensor(38.)
+
+                Assert.AreEqual(fwdzCorrect, fwdz)
+                Assert.AreEqual(fwdzdCorrect, fwdzd)
+                Assert.AreEqual(revzCorrect, revz)
+                Assert.AreEqual(revxdCorrect, revxd)
+                Assert.AreEqual(revydCorrect, revyd)
+
+    [<Test>]
+    member _.TestDerivativeMulTConstT0 () =
+        for swap in [true; false] do
+            for combo in Combos.AllDevicesAndBackends do
+                let fwdx = combo.tensor([1.; 2.; 3.])
+                let fwdy = combo.tensor(5.).forwardDiff(combo.tensor(2.))
+                let fwdz = if swap then fwdy * fwdx else fwdx * fwdy
+                let fwdzCorrect = combo.tensor([5.; 10.; 15.])
+                let fwdzd = fwdz.derivative
+                let fwdzdCorrect = combo.tensor([2.; 4.; 6.])
+
+                let revx = combo.tensor([1.; 2.; 3.])
+                let revy = combo.tensor(5.).reverseDiff()
+                let revz = if swap then revy * revx else revx * revy
+                let revzCorrect = combo.tensor([5.; 10.; 15.])
+                revz.reverse(combo.tensor([5.; 6.; 7.]))
+                let revyd = revy.derivative
+                let revydCorrect = combo.tensor(38.)
+
+                Assert.AreEqual(fwdzCorrect, fwdz)
+                Assert.AreEqual(fwdzdCorrect, fwdzd)
+                Assert.AreEqual(revzCorrect, revz)
+                Assert.AreEqual(revydCorrect, revyd)
+
+    [<Test>]
+    member _.TestDerivativeMulTT0Const () =
+        for swap in [true; false] do
+            for combo in Combos.AllDevicesAndBackends do
+                let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+                let fwdy = combo.tensor(5.)
+                let fwdz = if swap then fwdy * fwdx else fwdx * fwdy
+                let fwdzCorrect = combo.tensor([5.; 10.; 15.])
+                let fwdzd = fwdz.derivative
+                let fwdzdCorrect = combo.tensor([10.; 15.; 20.])
+
+                let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+                let revy = combo.tensor(5.)
+                let revz = if swap then revy * revx else revx * revy
+                let revzCorrect = combo.tensor([5.; 10.; 15.])
+                revz.reverse(combo.tensor([5.; 6.; 7.]))
+                let revxd = revx.derivative
+                let revxdCorrect = combo.tensor([25.; 30.; 35.])
+
+                Assert.AreEqual(fwdzCorrect, fwdz)
+                Assert.AreEqual(fwdzdCorrect, fwdzd)
+                Assert.AreEqual(revzCorrect, revz)
+                Assert.AreEqual(revxdCorrect, revxd)
 
     [<Test>]
     member _.TestDerivativeDivTT () =
@@ -258,15 +673,196 @@ type TestDerivatives () =
             Assert.True(revz.allclose(revzCorrect, 0.01))
             Assert.True(revxd.allclose(revxdCorrect, 0.01))
             Assert.True(revyd.allclose(revydCorrect, 0.01))
+
+    [<Test>]
+    member _.TestDerivativeDivTTConst () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+            let fwdy = combo.tensor([5.; 6.; 7.])
+            let fwdz = fwdx / fwdy
+            let fwdzCorrect = combo.tensor([0.2; 0.333333; 0.428571])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([0.4; 0.5; 0.571428571428571])
+
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.])
+            let revz = revx / revy
+            let revzCorrect = combo.tensor([0.2; 0.333333; 0.428571])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([1.; 0.833333; 0.714286])
+
+            Assert.True(fwdz.allclose(fwdzCorrect, 0.01))
+            Assert.True(fwdzd.allclose(fwdzdCorrect, 0.01))
+            Assert.True(revz.allclose(revzCorrect, 0.01))
+            Assert.True(revxd.allclose(revxdCorrect, 0.01))
     
-    // TODO: add test for DivTTConst
-    // TODO: add test for DivTConstT
-    // TODO: add test for DivT0T
-    // TODO: add test for DivT0TConst
-    // TODO: add test for DivT0ConstT
-    // TODO: add test for DivTT0
-    // TODO: add test for DivTT0Const
-    // TODO: add test for DivTConstT0
+    [<Test>]
+    member _.TestDerivativeDivTConstT () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.])
+            let fwdy = combo.tensor([5.; 6.; 7.]).forwardDiff(combo.tensor([2.; 2.; 3.]))
+            let fwdz = fwdx / fwdy
+            let fwdzCorrect = combo.tensor([0.2; 0.333333; 0.428571])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([-0.08; -0.111111111111111; -0.183673469387755])
+
+            let revx = combo.tensor([1.; 2.; 3.])
+            let revy = combo.tensor([5.; 6.; 7.]).reverseDiff()
+            let revz = revx / revy
+            let revzCorrect = combo.tensor([0.2; 0.333333; 0.428571])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor([-0.2; -0.277778; -0.306122])
+
+            Assert.True(fwdz.allclose(fwdzCorrect, 0.01))
+            Assert.True(fwdzd.allclose(fwdzdCorrect, 0.01))
+            Assert.True(revz.allclose(revzCorrect, 0.01))
+            Assert.True(revyd.allclose(revydCorrect, 0.01))
+
+    [<Test>]
+    member _.TestDerivativeDivTT0 () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+            let fwdy = combo.tensor(5.).forwardDiff(combo.tensor(2.))
+            let fwdz = fwdx / fwdy
+            let fwdzCorrect = combo.tensor([0.2; 0.4; 0.6])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([0.32; 0.44; 0.56])
+
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor(5.).reverseDiff()
+            let revz = revx / revy
+            let revzCorrect = combo.tensor([0.2; 0.4; 0.6])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([1.; 1.; 1.])
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor(-1.2)
+
+            Assert.True(fwdz.allclose(fwdzCorrect, 0.01))
+            Assert.True(fwdzd.allclose(fwdzdCorrect, 0.01))
+            Assert.True(revz.allclose(revzCorrect, 0.01))
+            Assert.True(revxd.allclose(revxdCorrect, 0.01))
+            Assert.True(revyd.allclose(revydCorrect, 0.01))
+
+    [<Test>]
+    member _.TestDerivativeDivT0T () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor(3.).forwardDiff(combo.tensor(2.))
+            let fwdy = combo.tensor([5.; 6.; 7.]).forwardDiff(combo.tensor([2.; 2.; 3.]))
+            let fwdz = fwdx / fwdy
+            let fwdzCorrect = combo.tensor([0.6; 0.5; 0.428571428571429])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([0.16; 0.166666666666667; 0.102040816326531])
+
+            let revx = combo.tensor(3.).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.]).reverseDiff()
+            let revz = revx / revy
+            let revzCorrect = combo.tensor([0.6; 0.5; 0.428571428571429])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor(2.54761871428571)
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor([-0.6; -0.416666666666667; -0.306122448979592])
+
+            Assert.True(fwdz.allclose(fwdzCorrect, 0.01))
+            Assert.True(fwdzd.allclose(fwdzdCorrect, 0.01))
+            Assert.True(revz.allclose(revzCorrect, 0.01))
+            Assert.True(revxd.allclose(revxdCorrect, 0.01))
+            Assert.True(revyd.allclose(revydCorrect, 0.01))
+
+    [<Test>]
+    member _.TestDerivativeDivTConstT0 () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.])
+            let fwdy = combo.tensor(5.).forwardDiff(combo.tensor(2.))
+            let fwdz = fwdx / fwdy
+            let fwdzCorrect = combo.tensor([0.2; 0.4; 0.6])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([-0.08; -0.16; -0.24])
+
+            let revx = combo.tensor([1.; 2.; 3.])
+            let revy = combo.tensor(5.).reverseDiff()
+            let revz = revx / revy
+            let revzCorrect = combo.tensor([0.2; 0.4; 0.6])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor(-1.2)
+
+            Assert.True(fwdz.allclose(fwdzCorrect, 0.01))
+            Assert.True(fwdzd.allclose(fwdzdCorrect, 0.01))
+            Assert.True(revz.allclose(revzCorrect, 0.01))
+            Assert.True(revyd.allclose(revydCorrect, 0.01))
+
+    [<Test>]
+    member _.TestDerivativeDivT0TConst () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor(3.).forwardDiff(combo.tensor(2.))
+            let fwdy = combo.tensor([5.; 6.; 7.])
+            let fwdz = fwdx / fwdy
+            let fwdzCorrect = combo.tensor([0.6; 0.5; 0.428571428571429])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([0.4; 0.333333333333333; 0.285714285714286])
+
+            let revx = combo.tensor(3.).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.])
+            let revz = revx / revy
+            let revzCorrect = combo.tensor([0.6; 0.5; 0.428571428571429])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor(2.54761871428571)
+
+            Assert.True(fwdz.allclose(fwdzCorrect, 0.01))
+            Assert.True(fwdzd.allclose(fwdzdCorrect, 0.01))
+            Assert.True(revz.allclose(revzCorrect, 0.01))
+            Assert.True(revxd.allclose(revxdCorrect, 0.01))
+
+    [<Test>]
+    member _.TestDerivativeDivTT0Const () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+            let fwdy = combo.tensor(5.)
+            let fwdz = fwdx / fwdy
+            let fwdzCorrect = combo.tensor([0.2; 0.4; 0.6])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([0.4; 0.6; 0.8])
+
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor(5.)
+            let revz = revx / revy
+            let revzCorrect = combo.tensor([0.2; 0.4; 0.6])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([1.; 1.; 1.])
+
+            Assert.True(fwdz.allclose(fwdzCorrect, 0.01))
+            Assert.True(fwdzd.allclose(fwdzdCorrect, 0.01))
+            Assert.True(revz.allclose(revzCorrect, 0.01))
+            Assert.True(revxd.allclose(revxdCorrect, 0.01))
+
+    [<Test>]
+    member _.TestDerivativeDivT0ConstT () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor(3.)
+            let fwdy = combo.tensor([5.; 6.; 7.]).forwardDiff(combo.tensor([2.; 2.; 3.]))
+            let fwdz = fwdx / fwdy
+            let fwdzCorrect = combo.tensor([0.6; 0.5; 0.428571428571429])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([-0.24; -0.166666666666667; -0.183673469387755])
+
+            let revx = combo.tensor(3.)
+            let revy = combo.tensor([5.; 6.; 7.]).reverseDiff()
+            let revz = revx / revy
+            let revzCorrect = combo.tensor([0.6; 0.5; 0.428571428571429])
+            revz.reverse(combo.tensor([5.; 5.; 5.]))
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor([-0.6; -0.416666666666667; -0.306122448979592])
+
+            Assert.True(fwdz.allclose(fwdzCorrect, 0.01))
+            Assert.True(fwdzd.allclose(fwdzdCorrect, 0.01))
+            Assert.True(revz.allclose(revzCorrect, 0.01))
+            Assert.True(revyd.allclose(revydCorrect, 0.01))
 
     [<Test>]
     member _.TestDerivativePowTT () =

--- a/tests/DiffSharp.Tests/TestDerivatives.fs
+++ b/tests/DiffSharp.Tests/TestDerivatives.fs
@@ -890,14 +890,195 @@ type TestDerivatives () =
             Assert.True(revxd.allclose(revxdCorrect,0.1))
             Assert.True(revyd.allclose(revydCorrect,0.1))
     
-    // TODO: add test for PowTTConst
-    // TODO: add test for PowTConstT
-    // TODO: add test for PowT0T
-    // TODO: add test for PowT0TConst
-    // TODO: add test for PowT0ConstT
-    // TODO: add test for PowTT0
-    // TODO: add test for PowTT0Const
-    // TODO: add test for PowTConstT0
+    [<Test>]
+    member _.TestDerivativePowTTConst () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+            let fwdy = combo.tensor([5.; 6.; 7.])
+            let fwdz = fwdx ** fwdy
+            let fwdzCorrect = combo.tensor([1.; 64.; 2187.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([10.; 576.; 20412.])
+
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.])
+            let revz = revx ** revy
+            let revzCorrect = combo.tensor([1.; 64.; 2187.])
+            revz.reverse(combo.tensor([5.; 15.; 25.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([25.; 2880.; 127575.])
+
+            Assert.True(fwdz.allclose(fwdzCorrect,0.1))
+            Assert.True(fwdzd.allclose(fwdzdCorrect,0.1))
+            Assert.True(revz.allclose(revzCorrect,0.1))
+            Assert.True(revxd.allclose(revxdCorrect,0.1))
+    
+    [<Test>]
+    member _.TestDerivativePowTConstT () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.])
+            let fwdy = combo.tensor([5.; 6.; 7.]).forwardDiff(combo.tensor([2.; 2.; 3.]))
+            let fwdz = fwdx ** fwdy
+            let fwdzCorrect = combo.tensor([1.; 64.; 2187.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([0.; 88.722839111673; 7207.99522595147])
+
+            let revx = combo.tensor([1.; 2.; 3.])
+            let revy = combo.tensor([5.; 6.; 7.]).reverseDiff()
+            let revz = revx ** revy
+            let revzCorrect = combo.tensor([1.; 64.; 2187.])
+            revz.reverse(combo.tensor([5.; 15.; 25.]))
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor([0.; 665.421; 60066.6])
+
+            Assert.True(fwdz.allclose(fwdzCorrect,0.1))
+            Assert.True(fwdzd.allclose(fwdzdCorrect,0.1))
+            Assert.True(revz.allclose(revzCorrect,0.1))
+            Assert.True(revyd.allclose(revydCorrect,0.1))
+    
+    [<Test>]
+    member _.TestDerivativePowTT0 () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+            let fwdy = combo.tensor(5.).forwardDiff(combo.tensor(2.))
+            let fwdz = fwdx ** fwdy
+            let fwdzCorrect = combo.tensor([1.; 32.; 243.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([10.; 284.361419555837; 2153.9255722927])
+
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor(5.).reverseDiff()
+            let revz = revx ** revy
+            let revzCorrect = combo.tensor([1.; 32.; 243.])
+            revz.reverse(combo.tensor([5.; 15.; 25.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([25.; 1200.; 10125.])
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor(7006.78030032754)
+
+            Assert.True(fwdz.allclose(fwdzCorrect,0.1))
+            Assert.True(fwdzd.allclose(fwdzdCorrect,0.1))
+            Assert.True(revz.allclose(revzCorrect,0.1))
+            Assert.True(revxd.allclose(revxdCorrect,0.1))
+            Assert.True(revyd.allclose(revydCorrect,0.1))
+    
+    [<Test>]
+    member _.TestDerivativePowT0T () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor(2.).forwardDiff(combo.tensor(3.))
+            let fwdy = combo.tensor([5.; 6.; 7.]).forwardDiff(combo.tensor([2.; 2.; 3.]))
+            let fwdz = fwdx ** fwdy
+            let fwdzCorrect = combo.tensor([32.; 64.; 128.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([284.361419555837; 664.722839111673; 1610.16851733502])
+
+            let revx = combo.tensor(2.).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.]).reverseDiff()
+            let revz = revx ** revy
+            let revzCorrect = combo.tensor([32.; 64.; 128.])
+            revz.reverse(combo.tensor([5.; 15.; 25.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor(14480)
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor([110.903548889591; 665.421293337547; 2218.07097779183])
+
+            Assert.True(fwdz.allclose(fwdzCorrect,0.1))
+            Assert.True(fwdzd.allclose(fwdzdCorrect,0.1))
+            Assert.True(revz.allclose(revzCorrect,0.1))
+            Assert.True(revxd.allclose(revxdCorrect,0.1))
+            Assert.True(revyd.allclose(revydCorrect,0.1))
+    
+    [<Test>]
+    member _.TestDerivativePowTT0Const () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.]).forwardDiff(combo.tensor([2.; 3.; 4.]))
+            let fwdy = combo.tensor(5.)
+            let fwdz = fwdx ** fwdy
+            let fwdzCorrect = combo.tensor([1.; 32.; 243.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([10.; 240.; 1620.])
+
+            let revx = combo.tensor([1.; 2.; 3.]).reverseDiff()
+            let revy = combo.tensor(5.).reverseDiff()
+            let revz = revx ** revy
+            let revzCorrect = combo.tensor([1.; 32.; 243.])
+            revz.reverse(combo.tensor([5.; 15.; 25.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([25.; 1200.; 10125.])
+
+            Assert.True(fwdz.allclose(fwdzCorrect,0.1))
+            Assert.True(fwdzd.allclose(fwdzdCorrect,0.1))
+            Assert.True(revz.allclose(revzCorrect,0.1))
+            Assert.True(revxd.allclose(revxdCorrect,0.1))
+    
+    [<Test>]
+    member _.TestDerivativePowTConstT0 () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor([1.; 2.; 3.])
+            let fwdy = combo.tensor(5.).forwardDiff(combo.tensor(2.))
+            let fwdz = fwdx ** fwdy
+            let fwdzCorrect = combo.tensor([1.; 32.; 243.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([0.; 44.3614195558365; 533.925572292701])
+
+            let revx = combo.tensor([1.; 2.; 3.])
+            let revy = combo.tensor(5.).reverseDiff()
+            let revz = revx ** revy
+            let revzCorrect = combo.tensor([1.; 32.; 243.])
+            revz.reverse(combo.tensor([5.; 15.; 25.]))
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor(7006.78030032754)
+
+            Assert.True(fwdz.allclose(fwdzCorrect,0.1))
+            Assert.True(fwdzd.allclose(fwdzdCorrect,0.1))
+            Assert.True(revz.allclose(revzCorrect,0.1))
+            Assert.True(revyd.allclose(revydCorrect,0.1))
+    
+    [<Test>]
+    member _.TestDerivativePowT0TConst () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor(2.).forwardDiff(combo.tensor(3.))
+            let fwdy = combo.tensor([5.; 6.; 7.])
+            let fwdz = fwdx ** fwdy
+            let fwdzCorrect = combo.tensor([32.; 64.; 128.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([240.; 576.; 1344.])
+
+            let revx = combo.tensor(2.).reverseDiff()
+            let revy = combo.tensor([5.; 6.; 7.])
+            let revz = revx ** revy
+            let revzCorrect = combo.tensor([32.; 64.; 128.])
+            revz.reverse(combo.tensor([5.; 15.; 25.]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor(14480)
+
+            Assert.True(fwdz.allclose(fwdzCorrect,0.1))
+            Assert.True(fwdzd.allclose(fwdzdCorrect,0.1))
+            Assert.True(revz.allclose(revzCorrect,0.1))
+            Assert.True(revxd.allclose(revxdCorrect,0.1))
+    
+    [<Test>]
+    member _.TestDerivativePowT0ConstT () =
+        for combo in Combos.AllDevicesAndBackends do
+            let fwdx = combo.tensor(2.)
+            let fwdy = combo.tensor([5.; 6.; 7.]).forwardDiff(combo.tensor([2.; 2.; 3.]))
+            let fwdz = fwdx ** fwdy
+            let fwdzCorrect = combo.tensor([32.; 64.; 128.])
+            let fwdzd = fwdz.derivative
+            let fwdzdCorrect = combo.tensor([44.3614195558365; 88.722839111673; 266.168517335019])
+
+            let revx = combo.tensor(2.)
+            let revy = combo.tensor([5.; 6.; 7.]).reverseDiff()
+            let revz = revx ** revy
+            let revzCorrect = combo.tensor([32.; 64.; 128.])
+            revz.reverse(combo.tensor([5.; 15.; 25.]))
+            let revyd = revy.derivative
+            let revydCorrect = combo.tensor([110.903548889591; 665.421293337547; 2218.07097779183])
+
+            Assert.True(fwdz.allclose(fwdzCorrect,0.1))
+            Assert.True(fwdzd.allclose(fwdzdCorrect,0.1))
+            Assert.True(revz.allclose(revzCorrect,0.1))
+            Assert.True(revyd.allclose(revydCorrect,0.1))
 
     [<Test>]
     member _.TestDerivativeMaxPool1D () =


### PR DESCRIPTION
Adds additional tests for addition, multiplication, subtraction, division, and exponentiation. 

Fixes 2 issues, where reverse mode differentiation between scalars and constants resulted in incorrect derivatives (see #131)

I couldn't find any contributor guidelines: shout if you want this broken up into separate PRs etc.