### PR TITLE
Debug/memory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
 
      <LibTorchNugetVersion>1.5.6</LibTorchNugetVersion>
-     <TorchSharpVersion>0.3.52235</TorchSharpVersion>
+     <TorchSharpVersion>0.3.52249</TorchSharpVersion>
       <!-- Standard nuget.org location -->
     <RestoreSources>https://api.nuget.org/v3/index.json</RestoreSources>
 

--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -50,6 +50,7 @@ module internal Utils =
 /// This is the base class for all RawTensorXyz tuypes.
 /// All type-independent operations are implemented directly on this class. 
 type TorchRawTensor(tt: TorchTensor, shape: int[], dtype, device) =
+
     inherit RawTensor(shape, dtype, device, Backend.Torch)
 
     do 
@@ -58,12 +59,6 @@ type TorchRawTensor(tt: TorchTensor, shape: int[], dtype, device) =
 
        if toTorchShape shape <> tt.Shape then 
            failwithf "mismatched Torch tensor shape, expected %A, got %A" (toTorchShape shape) tt.Shape
-
-    override _.Finalize() =
-        try
-            tt.Dispose()
-        finally
-            base.Finalize()
 
     member t.MakeLike(tt, ?shape, ?dtype, ?device) : RawTensor =
         upcast TorchRawTensor(tt, defaultArg shape t.Shape, defaultArg dtype t.Dtype, defaultArg device t.Device)
@@ -79,7 +74,7 @@ type TorchRawTensor(tt: TorchTensor, shape: int[], dtype, device) =
             let stop = fullBounds.[i,1] + 1
 
             let len = stop - start
-            let idxs = LongTensor.Arange(int64 start, int64 stop, 1L, device=toTorchDevice t.Device)
+            use idxs = LongTensor.Arange(int64 start, int64 stop, 1L, device=toTorchDevice t.Device)
             res <- res.IndexSelect(int64 dim, idxs)  // yield len // if len=1 then squeeze this dimension
             if fullBounds.[i, 2] = 1 && len = 1 then 
                 res <- res.Squeeze(int64 dim)  // yield len // if len=1 then squeeze this dimension

--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -59,6 +59,12 @@ type TorchRawTensor(tt: TorchTensor, shape: int[], dtype, device) =
        if toTorchShape shape <> tt.Shape then 
            failwithf "mismatched Torch tensor shape, expected %A, got %A" (toTorchShape shape) tt.Shape
 
+    override _.Finalize() =
+        try
+            tt.Dispose()
+        finally
+            base.Finalize()
+
     member t.MakeLike(tt, ?shape, ?dtype, ?device) : RawTensor =
         upcast TorchRawTensor(tt, defaultArg shape t.Shape, defaultArg dtype t.Dtype, defaultArg device t.Device)
 

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -289,6 +289,13 @@ type TestTensor () =
             Assert.AreEqual(t1.dtype, combo.dtype)
 
     [<Test>]
+    member _.TestTensorZerosDisposal () =
+        for i in 0..1024 do
+            let _ = dsharp.zeros([1024; 1024])
+            printfn "%A" i
+            //System.GC.Collect()
+
+    [<Test>]
     member _.TestTensorZeros () =
         for combo in Combos.All do 
             let t0 = combo.zeros([])

--- a/tests/MemoryTest/MemoryTest.fsproj
+++ b/tests/MemoryTest/MemoryTest.fsproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\..\src\DiffSharp.Core\DiffSharp.Core.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Reference\DiffSharp.Backends.Reference.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Torch\DiffSharp.Backends.Torch.fsproj" />
+    <PackageReference Include="TorchSharp" Version="0.3.52235" />
     <PackageReference Include="libtorch-cpu" Version="1.5.6" />
   </ItemGroup>
 

--- a/tests/MemoryTest/MemoryTest.fsproj
+++ b/tests/MemoryTest/MemoryTest.fsproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DiffSharp.Core\DiffSharp.Core.fsproj" />
+    <ProjectReference Include="..\..\src\DiffSharp.Backends.Reference\DiffSharp.Backends.Reference.fsproj" />
+    <ProjectReference Include="..\..\src\DiffSharp.Backends.Torch\DiffSharp.Backends.Torch.fsproj" />
+    <PackageReference Include="libtorch-cpu" Version="1.5.6" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MemoryTest/MemoryTest.sln
+++ b/tests/MemoryTest/MemoryTest.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30128.74
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "MemoryTest", "MemoryTest.fsproj", "{9386535A-1A54-40FA-81DF-7EEBCED679CB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9386535A-1A54-40FA-81DF-7EEBCED679CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9386535A-1A54-40FA-81DF-7EEBCED679CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9386535A-1A54-40FA-81DF-7EEBCED679CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9386535A-1A54-40FA-81DF-7EEBCED679CB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AC27EB2B-C103-4F91-8658-3A46D853D5A4}
+	EndGlobalSection
+EndGlobal

--- a/tests/MemoryTest/Program.fs
+++ b/tests/MemoryTest/Program.fs
@@ -1,0 +1,59 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+open DiffSharp
+open DiffSharp.Model
+open DiffSharp.Optim
+open DiffSharp.Data
+
+[<EntryPoint>]
+let main _ =
+    printfn "Hello World from F#!"
+
+    // let din, dout = 1024, 512
+    // let batchSize = 512
+    // let net = Linear(din, dout)
+    // let optimizer = SGD(net, lr=dsharp.tensor(0.01))
+
+    // let steps = 10
+    // for i in 0..steps do
+    //     let inputs, targets = dsharp.randn([batchSize; din]), dsharp.randn([batchSize; dout])
+    //     net.reverseDiff()
+    //     let y = net.forward(inputs)
+    //     let loss = dsharp.mseLoss y targets
+    //     loss.reverse()
+    //     optimizer.step()
+    //     printfn "%A %A" i (float loss)
+    
+    dsharp.config(backend=Backend.Torch)
+    dsharp.seed(12)
+
+    let dataset = MNIST("./data", train=true)
+    let dataloader = dataset.loader(64, shuffle=true)
+
+    // let net =
+    //     let convs = Conv2d(1, 32, 3)
+    //                 --> dsharp.relu
+    //                 --> Conv2d(32, 64, 3)
+    //                 --> dsharp.relu
+    //                 --> dsharp.maxpool2d 2
+    //     let k = dsharp.randn([1;1;28;28]) --> convs --> dsharp.nelement
+    //     convs
+    //     --> dsharp.flatten 1
+    //     --> Linear(k, 128)
+    //     --> dsharp.relu
+    //     --> Linear(128, 10)
+
+    let net =
+        dsharp.flatten 1
+        --> Linear(28*28, 128)
+        --> Linear(128, 10)
+
+    printfn "net params: %A" net.nparameters
+
+    printfn "%A" net.parameters.backend
+    Optimizer.adam(net, dataloader, dsharp.crossEntropyLoss, iters=200, threshold=0.1)
+    let i, t = dataset.item(0)
+    let o = i --> dsharp.move() --> dsharp.unsqueeze(0) --> net
+    printfn "%A %A %A" o o.backend t    
+    0 // return an integer exit code

--- a/tests/MemoryTest/Program.fs
+++ b/tests/MemoryTest/Program.fs
@@ -1,79 +1,21 @@
-﻿// Learn more about F# at http://fsharp.org
-
-open System
+﻿open System
 open DiffSharp
-open DiffSharp.Model
-open DiffSharp.Optim
-open DiffSharp.Data
 
 [<EntryPoint>]
 let main _ =
-    printfn "Hello World from F#!"
+    //dsharp.config(backend=Backend.Reference)
+    dsharp.config(backend=Backend.Torch)
+    dsharp.seed(1)
 
-    // let din, dout = 1024, 512
-    // let batchSize = 512
-    // let net = Linear(din, dout)
-    // let optimizer = SGD(net, lr=dsharp.tensor(0.01))
-
-    // let steps = 10
-    // for i in 0..steps do
-    //     let inputs, targets = dsharp.randn([batchSize; din]), dsharp.randn([batchSize; dout])
-    //     net.reverseDiff()
-    //     let y = net.forward(inputs)
-    //     let loss = dsharp.mseLoss y targets
-    //     loss.reverse()
-    //     optimizer.step()
-    //     printfn "%A %A" i (float loss)
-    printfn "Press any key to continue... 1"
+    printfn "Press any key to continue..."
     Console.ReadKey() |> ignore
 
-    dsharp.config(backend=Backend.Reference)
-    dsharp.seed(12)
+    for i in 0..1024 do
+        let _ = dsharp.randn([1024; 1024])
+        printfn "%A" i
+        System.GC.Collect()
 
-    let dataset = MNIST("./data", train=true)
-    let dataloader = dataset.loader(64, shuffle=true)
-
-    printfn "Press any key to continue... 2"
-    Console.ReadKey() |> ignore
-
-    // let net =
-    //     let convs = Conv2d(1, 32, 3)
-    //                 --> dsharp.relu
-    //                 --> Conv2d(32, 64, 3)
-    //                 --> dsharp.relu
-    //                 --> dsharp.maxpool2d 2
-    //     let k = dsharp.randn([1;1;28;28]) --> convs --> dsharp.nelement
-    //     convs
-    //     --> dsharp.flatten 1
-    //     --> Linear(k, 128)
-    //     --> dsharp.relu
-    //     --> Linear(128, 10)
-
-    let net =
-        dsharp.flatten 1
-        --> Linear(28*28, 128)
-        --> Linear(128, 10)
-
-    printfn "net params: %A" net.nparameters
-
-    printfn "Press any key to continue... 3"
-    Console.ReadKey() |> ignore
-
-    printfn "%A" net.parameters.backend
-    Optimizer.adam(net, dataloader, dsharp.crossEntropyLoss, iters=200)
-
-    //let i, t = dataset.item(0)
-    //let o = i --> dsharp.move() --> dsharp.unsqueeze(0) --> net
-    //printfn "%A %A %A" o o.backend t    
-
-    printfn "Press any key to continue... 4"
-    Console.ReadKey() |> ignore
-
-    printfn "%A" net.parameters.backend
-    Optimizer.adam(net, dataloader, dsharp.crossEntropyLoss, iters=200)
-
-
-    printfn "Press any key to continue... 5"
+    printfn "Press any key to continue..."
     Console.ReadKey() |> ignore
 
     0 // return an integer exit code

--- a/tests/MemoryTest/Program.fs
+++ b/tests/MemoryTest/Program.fs
@@ -1,17 +1,19 @@
 ﻿open System
 open DiffSharp
+//open TorchSharp
 
 [<EntryPoint>]
 let main _ =
-    //dsharp.config(backend=Backend.Reference)
-    dsharp.config(backend=Backend.Torch)
-    dsharp.seed(1)
+    //dsharp.config(backend=Backend.Reference) // Uses around 23 MB
+    dsharp.config(backend=Backend.Torch) // Uses around 4GB
 
     printfn "Press any key to continue..."
     Console.ReadKey() |> ignore
 
     for i in 0..1024 do
-        let _ = dsharp.randn([1024; 1024])
+        let x = dsharp.zeros([1024; 1024])
+        //let x = TorchSharp.Tensor.FloatTensor.Zeros([|1024L;1024L|])
+        //x.Dispose()
         printfn "%A" i
         System.GC.Collect()
 

--- a/tests/MemoryTest/Program.fs
+++ b/tests/MemoryTest/Program.fs
@@ -24,12 +24,17 @@ let main _ =
     //     loss.reverse()
     //     optimizer.step()
     //     printfn "%A %A" i (float loss)
-    
-    dsharp.config(backend=Backend.Torch)
+    printfn "Press any key to continue... 1"
+    Console.ReadKey() |> ignore
+
+    dsharp.config(backend=Backend.Reference)
     dsharp.seed(12)
 
     let dataset = MNIST("./data", train=true)
     let dataloader = dataset.loader(64, shuffle=true)
+
+    printfn "Press any key to continue... 2"
+    Console.ReadKey() |> ignore
 
     // let net =
     //     let convs = Conv2d(1, 32, 3)
@@ -51,9 +56,24 @@ let main _ =
 
     printfn "net params: %A" net.nparameters
 
+    printfn "Press any key to continue... 3"
+    Console.ReadKey() |> ignore
+
     printfn "%A" net.parameters.backend
-    Optimizer.adam(net, dataloader, dsharp.crossEntropyLoss, iters=200, threshold=0.1)
-    let i, t = dataset.item(0)
-    let o = i --> dsharp.move() --> dsharp.unsqueeze(0) --> net
-    printfn "%A %A %A" o o.backend t    
+    Optimizer.adam(net, dataloader, dsharp.crossEntropyLoss, iters=200)
+
+    //let i, t = dataset.item(0)
+    //let o = i --> dsharp.move() --> dsharp.unsqueeze(0) --> net
+    //printfn "%A %A %A" o o.backend t    
+
+    printfn "Press any key to continue... 4"
+    Console.ReadKey() |> ignore
+
+    printfn "%A" net.parameters.backend
+    Optimizer.adam(net, dataloader, dsharp.crossEntropyLoss, iters=200)
+
+
+    printfn "Press any key to continue... 5"
+    Console.ReadKey() |> ignore
+
     0 // return an integer exit code


### PR DESCRIPTION
@dsyme I think I identified the source of the excessive memory usage we witnessed in some code after merging the libtorch backend to dev.

The problem seems to be related with not disposing `TorchTensor` objects and freeing the associated unmanaged memory. The `MemoryTest` project in this PR provides an isolated minimal example. The problem is only with the libtorch backend and is not present in the Reference backend.

The core of the problem is
```fsharp
    dsharp.config(backend=Backend.Reference) // Uses around 23 MB
    //dsharp.config(backend=Backend.Torch) // Uses around 4GB

    for i in 0..1024 do
        let _ = dsharp.zeros([1024; 1024])
        printfn "%A" i
```

When run with the libtorch backend, the memory usage of this example is monotonically rising and reaches around 4GB:
<img src="https://user-images.githubusercontent.com/5365982/83968982-e0fdb080-a8c4-11ea-8836-5017b6a94313.PNG" width="400px">

When run with the Reference backend, it is around 20 MB (and the managed heap seems to hold around 4MB which is consistent with what one would expect from holding a single instance of a 1024x1024 single precision tensor). I can see the memory use fluctuate around this value as Tensors get created and discarded.
<img src="https://user-images.githubusercontent.com/5365982/83969028-3c2fa300-a8c5-11ea-90cd-4286a0641aa5.PNG" width="400px">

This behavior is the same on Windows and Linux (I tested both).

The problem remains if I remove DiffSharp from the code and just use TorchSharp. The following uses around 4GB memory.
```fsharp
    for i in 0..1024 do
        let x = TorchSharp.Tensor.FloatTensor.Zeros([|1024L;1024L|])
        //x.Dispose()
        printfn "%A" i
        System.GC.Collect()
```
The problem disappears when I manually do `x.Dispose()`.