### PR TITLE
Add docs to DiffSharp.Util

### DIFF
--- a/DiffSharp.sln
+++ b/DiffSharp.sln
@@ -32,7 +32,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{841AB16F-5
 		docs\_template.html = docs\_template.html
 		docs\api-overview.fsx = docs\api-overview.fsx
 		docs\examples-topic1.fsx = docs\examples-topic1.fsx
-		docs\gettingstarted-topic1.fsx = docs\gettingstarted-topic1.fsx
+		docs\getting-started-topic1.fsx = docs\getting-started-topic1.fsx
+		docs\getting-started-torch.fsx = docs\getting-started-torch.fsx
 		docs\index.fsx = docs\index.fsx
 	EndProjectSection
 EndProject

--- a/docs/_template.html
+++ b/docs/_template.html
@@ -14,8 +14,8 @@
     <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
     
-    <link type="text/css" rel="stylesheet" href="{{root}}/content/fsdocs-default.css" />
-    <script src="{{root}}/content/fsdocs-tips.js" type="text/javascript"></script>
+    <link type="text/css" rel="stylesheet" href="{{root}}content/fsdocs-default.css" />
+    <script src="{{root}}content/fsdocs-tips.js" type="text/javascript"></script>
 
     <!-- BEGIN SEARCH BOX: this adds support for the search box -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.4/auto-complete.css" />
@@ -36,7 +36,7 @@
           {{fsdocs-tooltips}}         
         </div>
         <div class="span3">
-          <a href="index.html"><img src="{{root}}/img/diffsharp-logo.png" style="width:140px;height:140px;margin:10px 0px 0px 20px;border-style:none;"/></a>
+          <a href="index.html"><img src="{{root}}img/diffsharp-logo.png" style="width:140px;height:140px;margin:10px 0px 0px 20px;border-style:none;"/></a>
 
                 <!-- BEGIN SEARCH BOX: this adds support for the search box -->
                 <div id="header">
@@ -55,21 +55,21 @@
         <ul class="nav nav-list" id="menu">
             <li class="nav-header">DiffSharp</li>
             <li class="divider"></li>
-            <li><a href="{{root}}/index.html">Home Page</a></li>
+            <li><a href="{{root}}index.html">Home Page</a></li>
             <li><a href="https://github.com/DiffSharp/DiffSharp/">GitHub Page</a></li>
 
             <li class="nav-header">Getting Started</li>
             <li class="divider"></li>
-            <li><a href="{{root}}/api-overview.html">API Overview</a></li>
-            <li><a href="{{root}}/getting-started-torch.html">Using DiffSharp with LibTorch</a></li>
-            <li><a href="{{root}}/getting-started-topic1.html">Getting Started Topic 1</a></li>
-            <li><a href="{{root}}/reference/index.html">API Reference</a></li>
+            <li><a href="{{root}}api-overview.html">API Overview</a></li>
+            <li><a href="{{root}}getting-started-torch.html">Using DiffSharp with LibTorch</a></li>
+            <li><a href="{{root}}getting-started-topic1.html">Getting Started Topic 1</a></li>
+            <li><a href="{{root}}reference/index.html">API Reference</a></li>
 
             <li class="nav-header">Examples</li>
             <li class="divider"></li>
 
             <li class="nav-header">Machine Learning</li>
-            <li><a href="{{root}}/examples-topic1.html">Topic 1</a></li>
+            <li><a href="{{root}}examples-topic1.html">Topic 1</a></li>
 
             <li class="nav-header">Authors</li>
             <li class="divider"></li>
@@ -85,7 +85,7 @@
     <script type="text/javascript">var fsdocs_search_baseurl = '{{root}}'</script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.8/lunr.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.4/auto-complete.min.js"></script>
-    <script type="text/javascript" src="{{root}}/content/fsdocs-search.js"></script>
+    <script type="text/javascript" src="{{root}}content/fsdocs-search.js"></script>
     <!-- END SEARCH BOX: this adds support for the search box -->
   </body>
 </html>

--- a/docs/api-overview.fsx
+++ b/docs/api-overview.fsx
@@ -11,6 +11,9 @@
 #if IPYNB
 #i "nuget: https://ci.appveyor.com/nuget/diffsharp"
 #r "nuget: DiffSharp-lite,{{fsdocs-package-version}}"
+
+Formatter.SetPreferredMimeTypeFor(typeof<obj>, "text/plain")
+Formatter.Register(fun (x:obj) (writer: TextWriter) -> fprintfn writer "%120A" x )
 #endif // IPYNB
 
 (**

--- a/docs/api-overview.fsx
+++ b/docs/api-overview.fsx
@@ -1,6 +1,7 @@
 ﻿(*** condition: prepare ***)
-#r "../src/DiffSharp.Core/bin/Debug/netstandard2.1/DiffSharp.Core.dll"
-#r "../src/DiffSharp.Backends.Reference/bin/Debug/netstandard2.1/DiffSharp.Backends.Reference.dll"
+#I "../tests/DiffSharp.Tests/bin/Debug/netcoreapp3.0"
+#r "DiffSharp.Core.dll"
+#r "DiffSharp.Backends.Reference.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget:RestoreSources=https://ci.appveyor.com/nuget/diffsharp"

--- a/docs/examples-topic1.fsx
+++ b/docs/examples-topic1.fsx
@@ -1,6 +1,7 @@
 ﻿(*** condition: prepare ***)
-#r "../src/DiffSharp.Core/bin/Debug/netstandard2.1/DiffSharp.Core.dll"
-#r "../src/DiffSharp.Backends.Reference/bin/Debug/netstandard2.1/DiffSharp.Backends.Reference.dll"
+#I "../tests/DiffSharp.Tests/bin/Debug/netcoreapp3.0"
+#r "DiffSharp.Core.dll"
+#r "DiffSharp.Backends.Reference.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget:RestoreSources=https://ci.appveyor.com/nuget/diffsharp"

--- a/docs/examples-topic1.fsx
+++ b/docs/examples-topic1.fsx
@@ -11,6 +11,9 @@
 #if IPYNB
 #i "nuget: https://ci.appveyor.com/nuget/diffsharp"
 #r "nuget: DiffSharp-lite,{{fsdocs-package-version}}"
+
+Formatter.SetPreferredMimeTypeFor(typeof<obj>, "text/plain")
+Formatter.Register(fun (x:obj) (writer: TextWriter) -> fprintfn writer "%120A" x )
 #endif // IPYNB
 
 

--- a/docs/getting-started-topic1.fsx
+++ b/docs/getting-started-topic1.fsx
@@ -11,6 +11,9 @@
 #if IPYNB
 #i "nuget: https://ci.appveyor.com/nuget/diffsharp"
 #r "nuget: DiffSharp-lite,{{fsdocs-package-version}}"
+
+Formatter.SetPreferredMimeTypeFor(typeof<obj>, "text/plain")
+Formatter.Register(fun (x:obj) (writer: TextWriter) -> fprintfn writer "%120A" x )
 #endif // IPYNB
 
 (**

--- a/docs/getting-started-topic1.fsx
+++ b/docs/getting-started-topic1.fsx
@@ -1,6 +1,7 @@
 ﻿(*** condition: prepare ***)
-#r "../src/DiffSharp.Core/bin/Debug/netstandard2.1/DiffSharp.Core.dll"
-#r "../src/DiffSharp.Backends.Reference/bin/Debug/netstandard2.1/DiffSharp.Backends.Reference.dll"
+#I "../tests/DiffSharp.Tests/bin/Debug/netcoreapp3.0"
+#r "DiffSharp.Core.dll"
+#r "DiffSharp.Backends.Reference.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget:RestoreSources=https://ci.appveyor.com/nuget/diffsharp"

--- a/docs/getting-started-torch.fsx
+++ b/docs/getting-started-torch.fsx
@@ -4,12 +4,10 @@
 #r "DiffSharp.Backends.Torch.dll"
 (*** condition: fsx ***)
 #if FSX
-#r "nuget:RestoreSources=https://ci.appveyor.com/nuget/diffsharp"
 #r "nuget: DiffSharp-cpu,{{fsdocs-package-version}}"
 #endif // FSX
 (*** condition: ipynb ***)
 #if IPYNB
-#i "nuget: https://ci.appveyor.com/nuget/diffsharp"
 #r "nuget: DiffSharp-cpu,{{fsdocs-package-version}}"
 
 Formatter.SetPreferredMimeTypeFor(typeof<obj>, "text/plain")

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -1,14 +1,13 @@
 ﻿(*** condition: prepare ***)
-#r "../src/DiffSharp.Core/bin/Debug/netstandard2.1/DiffSharp.Core.dll"
-#r "../src/DiffSharp.Backends.Reference/bin/Debug/netstandard2.1/DiffSharp.Backends.Reference.dll"
+#I "../tests/DiffSharp.Tests/bin/Debug/netcoreapp3.0"
+#r "DiffSharp.Core.dll"
+#r "DiffSharp.Backends.Reference.dll"
 (*** condition: fsx ***)
 #if FSX
-#r "nuget:RestoreSources=https://ci.appveyor.com/nuget/diffsharp"
 #r "nuget: DiffSharp-lite,{{fsdocs-package-version}}"
 #endif // FSX
 (*** condition: ipynb ***)
 #if IPYNB
-#i "nuget: https://ci.appveyor.com/nuget/diffsharp"
 #r "nuget: DiffSharp-lite,{{fsdocs-package-version}}"
 
 Formatter.SetPreferredMimeTypeFor(typeof<obj>, "text/plain")

--- a/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
+++ b/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
@@ -403,10 +403,10 @@ module internal RawTensorCPU =
         (result, t1.Shape)
 
     let inline MaxIndexT(t: RawTensorCPU< ^T >) =
-        t.FlatIndexToIndex(maxIndex t.Values)
+        t.FlatIndexToIndex(Seq.maxIndex t.Values)
 
     let inline MinIndexT(t: RawTensorCPU< ^T >) =
-        t.FlatIndexToIndex(minIndex t.Values)
+        t.FlatIndexToIndex(Seq.minIndex t.Values)
 
     let inline AddTT(t1: RawTensorCPU< ^T >, t2: RawTensor) : (^T[] * int[]) =
         let t1value = t1.Values

--- a/src/DiffSharp.Core/Data.fs
+++ b/src/DiffSharp.Core/Data.fs
@@ -13,7 +13,6 @@ type Dataset() =
     abstract member item: int -> Tensor * Tensor
     member d.loader(batchSize:int, ?shuffle:bool, ?numBatches:int, ?dtype:Dtype, ?device:Device, ?backend:Backend, ?targetDtype:Dtype, ?targetDevice:Device, ?targetBackend:Backend) = DataLoader(d, batchSize=batchSize, ?shuffle=shuffle, ?numBatches=numBatches, ?dtype=dtype, ?device=device, ?backend=backend, ?targetDtype=targetDtype, ?targetDevice=targetDevice, ?targetBackend=targetBackend)
 
-
 type DataLoader(dataset:Dataset, batchSize:int, ?shuffle:bool, ?numBatches:int, ?dtype:Dtype, ?device:Device, ?backend:Backend, ?targetDtype:Dtype, ?targetDevice:Device, ?targetBackend:Backend) =
     let shuffle = defaultArg shuffle false
     let batchSize = min batchSize dataset.length
@@ -25,19 +24,17 @@ type DataLoader(dataset:Dataset, batchSize:int, ?shuffle:bool, ?numBatches:int, 
     let targetBackend = defaultArg targetBackend backend
     member d.length = defaultArg numBatches (dataset.length/batchSize)
     member d.epoch() =
-        let indexer = if shuffle then shuffledIndices (dataset.length) else id
+        let indexer = if shuffle then Random.shuffledIndices (dataset.length) else id
         let indices = Seq.init dataset.length id |> Seq.map indexer
         let batchIndices = indices |> Seq.chunkBySize batchSize
         let batches = batchIndices |> Seq.map (Array.map dataset.item >> Array.unzip)
         batches |> Seq.mapi (fun i (data, target) -> i, data |> dsharp.stack |> dsharp.move(dtype, device, backend), target |> dsharp.stack |> dsharp.move(targetDtype, targetDevice, targetBackend))
-
 
 type TensorDataset(data:Tensor, target:Tensor) =
     inherit Dataset()
     do if data.shape.[0] <> target.shape.[0] then failwith "Expecting data and target to have the same size in the first dimension"
     override d.length = data.shape.[0]
     override d.item(i) = data.[i], target.[i]
-
 
 type MNIST(path:string, ?urls:seq<string>, ?train:bool, ?transform:Tensor->Tensor, ?targetTransform:Tensor->Tensor) =
     inherit Dataset()

--- a/src/DiffSharp.Core/DiffSharp.Core.fsproj
+++ b/src/DiffSharp.Core/DiffSharp.Core.fsproj
@@ -4,7 +4,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Extensions.fs" />
     <Compile Include="Dtype.fs" />
+    <Compile Include="Shape.fs" />
     <Compile Include="Util.fs" />
     <Compile Include="RawTensor.fs" />
     <Compile Include="Tensor.fs" />

--- a/src/DiffSharp.Core/Distributions.fs
+++ b/src/DiffSharp.Core/Distributions.fs
@@ -149,13 +149,13 @@ type Empirical<'T when 'T:equality>(values:seq<'T>, ?weights:Tensor, ?logWeights
                             let lw2 = uniques.[v]
                             uniques.[v] <- dsharp.stack([lw; lw2]).logsumexp(dim=0)
                         else uniques.[v] <- lw
-                    copyKeys uniques, dsharp.stack(copyValues uniques).view(-1)
+                    Dictionary.copyKeys uniques, dsharp.stack(Dictionary.copyValues uniques).view(-1)
                 else
                     let vals, counts = getUniqueCounts _values false
                     vals, dsharp.tensor(counts)
             _values <- newValues
             _categorical <- Categorical(logits=newLogWeights)
-        _weighted <- not (allEqual (_categorical.probs.unstack()))
+        _weighted <- not (Seq.allEqual (_categorical.probs.unstack()))
     member d.values = _values
     member d.valuesTensor = _valuesTensor.Force()
     member d.length = d.values.Length

--- a/src/DiffSharp.Core/Distributions.fs
+++ b/src/DiffSharp.Core/Distributions.fs
@@ -151,7 +151,7 @@ type Empirical<'T when 'T:equality>(values:seq<'T>, ?weights:Tensor, ?logWeights
                         else uniques.[v] <- lw
                     Dictionary.copyKeys uniques, dsharp.stack(Dictionary.copyValues uniques).view(-1)
                 else
-                    let vals, counts = getUniqueCounts _values false
+                    let vals, counts = _values |> Array.getUniqueCounts false
                     vals, dsharp.tensor(counts)
             _values <- newValues
             _categorical <- Categorical(logits=newLogWeights)
@@ -208,7 +208,7 @@ type Empirical<'T when 'T:equality>(values:seq<'T>, ?weights:Tensor, ?logWeights
             let dCombined = d.combineDuplicates()
             let i = dCombined.logWeights.argmax() in dCombined.values.[i.[0]]
         else
-            let vals, _ = getUniqueCounts d.values true
+            let vals, _ = d.values |> Array.getUniqueCounts true
             vals.[0]
     member d.min = d.valuesTensor.min()
     member d.max = d.valuesTensor.max()

--- a/src/DiffSharp.Core/Dtype.fs
+++ b/src/DiffSharp.Core/Dtype.fs
@@ -1,6 +1,16 @@
 ﻿namespace DiffSharp
 
-// Note, same indexes as PyTorch
+/// <summary>
+///   Represents the type of a device. 
+/// </summary>
+///
+/// <remarks>
+///   The numeric values used are as for LibTorch.
+/// </remarks>
+///
+/// <namespacedoc>
+///   <summary>Contains fundamental types for the DiffSharp tensor programming model, including Tensor and Shape, and the <c>dsharp</c> API.</summary>
+/// </namespacedoc>
 type DeviceType =
     | CPU = 0
     | CUDA = 1 // CUDA.
@@ -14,6 +24,7 @@ type DeviceType =
     | XLA = 9 // XLA / TPU
 
 
+/// Represents a device specification.
 [<Struct>]
 type Device =
     | Device of DeviceType * int
@@ -38,14 +49,22 @@ type Device =
         | DeviceType.XLA -> "xla"
         | _ -> failwith "unknown device type") + string x.DeviceIndex
 
+/// Contains functions and settings related to device specifications.
 module Device = 
+
+    /// Get or set the default device used when creating tensors.  Note, use <c>dsharp.config(...)</c> instead.
     let mutable Default : Device = Device(DeviceType.CPU, 0)
 
+/// Represents a backend for DiffSharp tensors
 [<RequireQualifiedAccess>]
 type Backend =
+    /// The reference backend 
     | Reference
+    /// The LibTorch backend 
     | Torch
+    /// Reserved for future use
     | OpenBLAS
+    /// Reserved for future use
     | Other of name: string * code: int
 
     member internal x.Code = 
@@ -55,6 +74,7 @@ type Backend =
         | Torch -> 0x0200
         | Other (_name, code) -> (code + 3) <<< 8
 
+    /// Get the name of the backend
     member x.Name = 
         match x with 
         | Reference -> "Reference"
@@ -62,22 +82,37 @@ type Backend =
         | Torch -> "Torch"
         | Other (name, _) -> name
 
+/// Contains functions and settings related to backend specifications.
 module Backend = 
     let internal count = ref 0
     let internal codes = System.Collections.Concurrent.ConcurrentDictionary<string,Backend>()
+
+    /// Register a new backend
     let Register name = codes.GetOrAdd(name, (fun _ -> incr count; Backend.Other(name, count.Value)))
+
+    /// Get or set the default backend used when creating tensors.  Note, use <c>dsharp.config(...)</c> instead.
     let mutable Default = Backend.Reference
 
+/// Represents a storage type for elements of a tensor
 type Dtype =
     //| Float16
+    /// Store elements as 32-bit floating point numbers
     | Float32
+    /// Store elements as 64-bit floating point numbers
     | Float64
+    /// Store elements as 8-bit integers
     | Int8
+    /// Store elements as 8-bit unsigned integers
     | Byte
+    /// Store elements as 16-bit signed integers
     | Int16
+    /// Store elements as 32-bit signed integers
     | Int32
+    /// Store elements as 64-bit signed integers
     | Int64
+    /// Store elements as booleans
     | Bool
+    /// Reserved for future use
     | Other of name:string * code:int * inOutType: System.Type
 
     member internal x.Code =
@@ -106,6 +141,7 @@ type Dtype =
         | Bool -> "Bool"
         | Other (name, _, _) -> name
 
+    /// Get the .NET type that corresponds to this type when data is transferred to .NET
     member x.AsType () =
         match x with
         //| Float16 -> typeof<single>
@@ -125,17 +161,21 @@ type Dtype =
         | Bool | Byte | Int8 | Int16 | Int32 | Int64 -> Dtype.Int64
         | dt -> dt
 
+/// Contains functions and settings related to tensor element types
 module Dtype =
+    /// Matches all floating point tensor element types
     let (|FloatingPoint|_|) x =
         match x with
         | Float32 | Float64 -> Some()
         | _ -> None
 
+    /// Matches all integral tensor element types
     let (|Integral|_|) x =
         match x with
         | Byte | Int8 | Int16 | Int32 | Int64 -> Some()
         | _ -> None
 
+    /// Matches all integral or boolean tensor element types
     let (|IntegralOrBool|_|) x =
         match x with
         | Integral | Bool -> Some()
@@ -174,18 +214,25 @@ module Dtype =
     let internal count = ref 0
     let internal codes = System.Collections.Concurrent.ConcurrentDictionary<string,Dtype>()
 
+    /// Register a user-defined type (reserved for future use)
     let Register name inOutType = codes.GetOrAdd(name, (fun _ -> incr count; Dtype.Other(name, count.Value, inOutType)))
 
+    /// Get or set the default element type used when creating tensors.  Note, use <c>dsharp.config(...)</c> instead.
     let mutable Default = Dtype.Float32
 
+/// Contains global functions and settings related to tensor element types, used when writing backends.
 [<AutoOpen>]
 module DtypeGlobalOps =
+
+    /// Raise an exception indicating the given operation is not supported for the given tensor element type.
     let opNotSupported msg (dtype: Dtype) =
         invalidOp (sprintf "operation '%s' not permitted on tensors of type %A" msg dtype)
 
+    /// Raise an exception indicating the given operation is not supported for the given tensor device type.
     let opNotSupportedOnDeviceType msg (dtype: Dtype) (deviceType: DeviceType) =
         invalidOp (sprintf "operation '%s' not permitted on tensors of type %A on device type %A" msg dtype deviceType)
 
+    /// Raise an exception indicating the given binary operation is not supported for the two given tensor element types.
     let opNotSupported2 msg (dtype1: Dtype) (dtype2: Dtype) =
         invalidOp (sprintf "operation '%s' not permitted on tensors of type (%A, %A)" msg dtype1 dtype2)
 

--- a/src/DiffSharp.Core/Extensions.fs
+++ b/src/DiffSharp.Core/Extensions.fs
@@ -1,0 +1,72 @@
+﻿namespace DiffSharp.Util
+
+open System.Collections.Generic
+open System.Diagnostics.CodeAnalysis
+
+/// <summary>
+///   Contains extensions to the F# Array module. 
+/// </summary>
+///
+/// <namespacedoc>
+///   <summary>Contains utilities and library extensions related to the DiffSharp programming model.</summary>
+/// </namespacedoc>
+module Array =
+    [<ExcludeFromCodeCoverage>]
+    let inline allClose (relativeTolerance:'T) (absoluteTolerance:'T) (array1:'T[]) (array2:'T[]) =
+        let dim1 = array1.Length
+        let dim2 = array2.Length
+        if dim1 <> dim2 then false
+        else (array1,array2) ||> Array.forall2 (fun a b -> abs(a-b) <= absoluteTolerance + relativeTolerance*abs(b)) 
+
+    [<ExcludeFromCodeCoverage>]
+    let inline cumulativeSum (a:_[]) = (Array.scan (+) LanguagePrimitives.GenericZero a).[1..]
+
+/// Contains extensions to the F# Seq module. 
+module Seq =
+    let maxIndex seq =  seq |> Seq.mapi (fun i x -> i, x) |> Seq.maxBy snd |> fst
+
+    let minIndex seq =  seq |> Seq.mapi (fun i x -> i, x) |> Seq.minBy snd |> fst
+
+    let allEqual (items:seq<'a>) =
+        let item0 = items |> Seq.head
+        items |> Seq.forall ((=) item0)
+
+    let duplicates l =
+       l |> List.ofSeq
+       |> List.groupBy id
+       |> List.choose ( function
+              | _, x::_::_ -> Some x
+              | _ -> None )
+
+    let hasDuplicates l =
+        duplicates l |> List.isEmpty |> not
+
+/// Contains extensions related to .NET dictionaries. 
+module Dictionary =
+    let copyKeys (dictionary:Dictionary<'a, 'b>) =
+        let keys = Array.zeroCreate dictionary.Count
+        dictionary.Keys.CopyTo(keys, 0)
+        keys
+
+    let copyValues (dictionary:Dictionary<'a, 'b>) =
+        let values = Array.zeroCreate dictionary.Count
+        dictionary.Values.CopyTo(values, 0)
+        values
+
+
+/// Contains auto-opened extensions to the F# programming model
+[<AutoOpen>]
+module ExtensionAutoOpens =
+    [<ExcludeFromCodeCoverage>]
+    let inline notNull value = not (obj.ReferenceEquals(value, null))
+
+    let memoize fn =
+        let cache = new Dictionary<_,_>()
+        fun x ->
+            match cache.TryGetValue x with
+            | true, v -> v
+            | false, _ ->
+                let v = fn x
+                cache.Add(x,v)
+                v
+

--- a/src/DiffSharp.Core/Extensions.fs
+++ b/src/DiffSharp.Core/Extensions.fs
@@ -2,6 +2,11 @@
 
 open System.Collections.Generic
 open System.Diagnostics.CodeAnalysis
+open System.IO
+open System.IO.Compression
+open System.Net
+open System.Runtime.Serialization
+open System.Runtime.Serialization.Formatters.Binary
 
 /// <summary>
 ///   Contains extensions to the F# Array module. 
@@ -11,6 +16,8 @@ open System.Diagnostics.CodeAnalysis
 ///   <summary>Contains utilities and library extensions related to the DiffSharp programming model.</summary>
 /// </namespacedoc>
 module Array =
+
+    /// Determine if all values of the first array lie within the given tolerances of the second array
     [<ExcludeFromCodeCoverage>]
     let inline allClose (relativeTolerance:'T) (absoluteTolerance:'T) (array1:'T[]) (array2:'T[]) =
         let dim1 = array1.Length
@@ -18,19 +25,35 @@ module Array =
         if dim1 <> dim2 then false
         else (array1,array2) ||> Array.forall2 (fun a b -> abs(a-b) <= absoluteTolerance + relativeTolerance*abs(b)) 
 
+    /// Get the cumulative sum of the input array
     [<ExcludeFromCodeCoverage>]
     let inline cumulativeSum (a:_[]) = (Array.scan (+) LanguagePrimitives.GenericZero a).[1..]
 
+    /// Get the unique counts of the input array
+    let getUniqueCounts (sorted:bool) (values:'T[]) =
+        let counts = Dictionary<'T, int>()
+        for v in values do
+            if counts.ContainsKey(v) then counts.[v] <- counts.[v] + 1 else counts.[v] <- 1
+        if sorted then
+            counts |> Array.ofSeq |> Array.sortByDescending (fun (KeyValue(_, v)) -> v) |> Array.map (fun (KeyValue(k, v)) -> k, v) |> Array.unzip
+        else
+            counts |> Array.ofSeq |> Array.map (fun (KeyValue(k, v)) -> k, v) |> Array.unzip
+
 /// Contains extensions to the F# Seq module. 
 module Seq =
+
+    /// Get the index of the maximum element of the sequence
     let maxIndex seq =  seq |> Seq.mapi (fun i x -> i, x) |> Seq.maxBy snd |> fst
 
+    /// Get the index of the minimum element of the sequence
     let minIndex seq =  seq |> Seq.mapi (fun i x -> i, x) |> Seq.minBy snd |> fst
 
-    let allEqual (items:seq<'a>) =
+    /// Indicates if all elements of the sequence are equal
+    let allEqual (items:seq<'T>) =
         let item0 = items |> Seq.head
         items |> Seq.forall ((=) item0)
 
+    /// Get the duplicate elements in the sequence
     let duplicates l =
        l |> List.ofSeq
        |> List.groupBy id
@@ -38,28 +61,34 @@ module Seq =
               | _, x::_::_ -> Some x
               | _ -> None )
 
+    /// Indicates if a sequence has duplicate elements
     let hasDuplicates l =
         duplicates l |> List.isEmpty |> not
 
 /// Contains extensions related to .NET dictionaries. 
 module Dictionary =
-    let copyKeys (dictionary:Dictionary<'a, 'b>) =
+
+    /// Get a fresh array containing the keys of the dictionary
+    let copyKeys (dictionary:Dictionary<'Key, 'Value>) =
         let keys = Array.zeroCreate dictionary.Count
         dictionary.Keys.CopyTo(keys, 0)
         keys
 
-    let copyValues (dictionary:Dictionary<'a, 'b>) =
+    /// Get a fresh array containing the values of the dictionary
+    let copyValues (dictionary:Dictionary<'Key, 'Value>) =
         let values = Array.zeroCreate dictionary.Count
         dictionary.Values.CopyTo(values, 0)
         values
 
-
 /// Contains auto-opened extensions to the F# programming model
 [<AutoOpen>]
 module ExtensionAutoOpens =
+
+    /// Indicates if a value is not null
     [<ExcludeFromCodeCoverage>]
     let inline notNull value = not (obj.ReferenceEquals(value, null))
 
+    /// Return a function that memoizes the given function using a lookaside table
     let memoize fn =
         let cache = new Dictionary<_,_>()
         fun x ->
@@ -69,4 +98,37 @@ module ExtensionAutoOpens =
                 let v = fn x
                 cache.Add(x,v)
                 v
+
+    /// Synchronously download the given URL to the given local file
+    let download (url:string) (localFileName:string) =
+        let wc = new WebClient()
+        printfn "Downloading %A to %A" url localFileName
+        wc.DownloadFile(url, localFileName)
+        wc.Dispose()
+
+    /// Save the given value to the given local file using binary serialization
+    let saveBinary (object: 'T) (fileName:string) =
+        let formatter = BinaryFormatter()
+        let fs = new FileStream(fileName, FileMode.Create)
+        let cs = new GZipStream(fs, CompressionMode.Compress)
+        try
+            formatter.Serialize(cs, object)
+            cs.Flush()
+            cs.Close()
+            fs.Close()
+        with
+        | :? SerializationException as e -> failwithf "Cannot save to file. %A" e.Message
+
+    /// Load the given value from the given local file using binary serialization
+    let loadBinary (fileName:string):'T =
+        let formatter = BinaryFormatter()
+        let fs = new FileStream(fileName, FileMode.Open)
+        let cs = new GZipStream(fs, CompressionMode.Decompress)
+        try
+            let object = formatter.Deserialize(cs) :?> 'T
+            cs.Close()
+            fs.Close()
+            object
+        with
+        | :? SerializationException as e -> failwithf "Cannot load from file. %A" e.Message
 

--- a/src/DiffSharp.Core/Model.fs
+++ b/src/DiffSharp.Core/Model.fs
@@ -52,7 +52,7 @@ type ParameterDict() =
         let sizes = [|for s in shapes do shapeLength s|]
         let ts = Array.map2 (fun (t:Tensor) (s:int[]) -> t.view(s)) (tensors.split(sizes)) shapes
         let mutable i = 0
-        let keys = copyKeys d.values
+        let keys = Dictionary.copyKeys d.values
         for n in keys do
             d.[n] <- ts.[i]
             i <- i+1

--- a/src/DiffSharp.Core/RawTensor.fs
+++ b/src/DiffSharp.Core/RawTensor.fs
@@ -1,11 +1,11 @@
-namespace DiffSharp.Backends
+namespace rec DiffSharp.Backends
 
 open System
 open DiffSharp
 open DiffSharp.Util
 
-type [<AbstractClass>]
-     BackendStatics() = 
+[<AbstractClass>]
+type BackendStatics() = 
     // cache for most recently accessed backend
     static let mutable last = None
     static let backends = System.Collections.Concurrent.ConcurrentDictionary<int, BackendStatics>()
@@ -62,8 +62,8 @@ type [<AbstractClass>]
             last <- Some (code, res)
             res
 
-and [<AbstractClass>]
-    RawTensor(shape:int[], dtype:Dtype, device:Device, backend:Backend) =
+[<AbstractClass>]
+type RawTensor(shape:int[], dtype:Dtype, device:Device, backend:Backend) =
 
     member t.Shape = shape
     member t.Dim = shape.Length
@@ -119,38 +119,38 @@ and [<AbstractClass>]
         let data, shape, dtype =
             match dtype with 
             | Some Dtype.Int64 ->
-                let a,s = dataOfValuesForInt64 values
+                let a,s = DataConverter.dataOfValuesForInt64 values
                 (a :> Array), s, Dtype.Int64
             | Some Dtype.Int32 ->
-                let a,s = dataOfValuesForInt32 values
+                let a,s = DataConverter.dataOfValuesForInt32 values
                 (a :> Array), s, Dtype.Int32
             | Some Dtype.Int16 ->
-                let a,s = dataOfValuesForInt16 values
+                let a,s = DataConverter.dataOfValuesForInt16 values
                 (a :> Array), s, Dtype.Int16
             | Some Dtype.Int8 ->
-                let a,s = dataOfValuesForInt8 values
+                let a,s = DataConverter.dataOfValuesForInt8 values
                 (a :> Array), s, Dtype.Int8
             | Some Dtype.Byte ->
-                let a,s = dataOfValuesForByte values
+                let a,s = DataConverter.dataOfValuesForByte values
                 (a :> Array), s, Dtype.Byte
             | Some Dtype.Bool ->
-                let a,s = dataOfValuesForBool values
+                let a,s = DataConverter.dataOfValuesForBool values
                 (a :> Array), s, Dtype.Bool
             | Some Dtype.Float64 ->
-                let a,s = dataOfValuesForFloat64 values
+                let a,s = DataConverter.dataOfValuesForFloat64 values
                 (a :> Array), s, Dtype.Float64
             | Some Dtype.Float32 ->
-                let a,s = dataOfValuesForFloat32 values
+                let a,s = DataConverter.dataOfValuesForFloat32 values
                 (a :> Array), s, Dtype.Float32
             | Some (Dtype.Other (name, _, _)) ->
                 failwithf "can't directly create tensors of user-defined type %s" name
             | None ->
                 // Prefer Bool tensor if all bool
-                match values |> tryFlatArrayAndShape<bool> with
+                match values |> DataConverter.tryFlatArrayAndShape<bool> with
                 | Some (values, shape) -> ((values :> Array), shape, Dtype.Bool)
                 | _ ->
                 // Otherwise prefer float32
-                let a,s = dataOfValuesForFloat32 values 
+                let a,s = DataConverter.dataOfValuesForFloat32 values 
                 (a :> Array), s, Dtype.Float32
 
         let statics = BackendStatics.Get(dtype=dtype, ?backend=backend)

--- a/src/DiffSharp.Core/Shape.fs
+++ b/src/DiffSharp.Core/Shape.fs
@@ -1,0 +1,532 @@
+﻿namespace DiffSharp
+
+open DiffSharp.Util
+
+/// Represents the shape of a tensor.
+type Shape = int[]
+
+/// Contains functions and values related to tensor shapes.
+module Shape =
+        
+    /// Get the number of dimensions in the shape.
+    let length (shape: Shape) =
+        if shape.Length = 0 then 1
+        else Array.reduce (*) shape
+
+    /// The shape for a scalar value.
+    let scalar : Shape = [| |]
+
+    /// Indicates if one shape contains another.
+    let contains (bigShape:Shape) (smallShape: Shape) =
+        if bigShape.Length <> smallShape.Length then failwithf "Expecting bigShape (%A) and smallShape (%A) to have the same number of dimensions" bigShape.Length smallShape.Length
+        Array.map2 (<=) smallShape bigShape |> Array.forall id
+
+    /// Check if the given shapes are appropriate for a stack operation and return information related to the resulting shape.
+    let checkCanStack (shapes:Shape[]) (dim: int) =
+        if not (Seq.allEqual shapes) then failwith "Cannot stack Tensors with different shapes"
+        let n = shapes.Length
+        if n = 0 then failwithf "Expecting a non-empty sequence of Tensors"
+        let shape = shapes.[0]
+        if dim < 0 || dim > shape.Length then invalidArg "dim" "invalid dimension"
+        if dim < 0 || dim > n then invalidArg "dim" "invalid dimension"
+        let shape1 = shape.[0..dim-1]
+        let shape2 = shape.[dim..]
+        let outputShape = [| yield! shape1; yield n; yield! shape2 |]
+        n, shape1, shape2, outputShape
+
+    /// Check if the given shapes are appropriate for a GetSlice operation and return information related to the resulting shape.
+    let checkCanGetSlice (shape: Shape) (fullBounds: int[,]) =
+        if Array2D.length1 fullBounds <> shape.Length then failwithf "Expecting %i-by-3 fullBounds" shape.Length
+        let outputShape = 
+            [|for i=0 to (fullBounds.GetLength(0) - 1) do
+                let len = fullBounds.[i,1] - fullBounds.[i,0] + 1
+                if fullBounds.[i, 2] = 1 then
+                    if len > 1 then yield len // if len=1 then squeeze this dimension
+                else
+                    yield len|]
+        outputShape
+
+    /// Check if the given shapes are appropriate for a concatenation operation and return information related to the resulting shape.
+    let checkCanCat (shapes: Shape[]) (dim: int) =
+        let n = shapes.Length
+        if n = 0 then invalidArg "tensors" "Expecting at least one tensor"
+        let shape = shapes.[0]
+        if dim < 0 || dim >= shape.Length then invalidArg "dim" "invalid dimension"
+        let shape1 = shape.[0..dim-1]
+        let shape3 = shape.[dim+1..]
+        if shapes |> Array.exists (fun shapeOther -> shapeOther.[0..dim-1] <> shape1 || shapeOther.[dim+1..] <> shape3) then
+            invalidArg "tensors" "Expecting Tensors with similar shapes"
+        let m2 = shapes |> Array.sumBy (fun shape -> shape.[dim])
+        let outputShape = [| yield! shape1; yield m2; yield! shape3 |]
+        n, shape1, m2, shape3, outputShape
+
+    /// Check if the given shapes are appropriate for a split operation and return information related to the resulting shape.
+    let checkCanSplit (shape: Shape) (sizes: int[]) (dim: int) =
+        if dim < 0 || dim >= shape.Length then invalidArg "dim" "invalid dimension"
+        if Array.sum sizes <> shape.[dim] then invalidArg "sizes" "the sum of sizes must equal the relevant dimension"
+        let shape1 = shape.[0..dim-1]
+        let shape2 = shape.[dim+1..]
+        let outputShapes = sizes |> Array.map (fun sz -> [| yield! shape1; yield sz; yield! shape2 |])
+        outputShapes
+
+    /// Check if the given shapes are appropriate for an unstack operation and return information related to the resulting shape.
+    let checkCanUnstack (shape: Shape) (dim: int) =
+        if shape.Length < 1 then failwith "Cannot unstack scalar Tensor (dim < 1)"
+        if dim < 0 || dim >= shape.Length then invalidArg "dim" "invalid dimension"
+        let shape1 = shape.[0..dim-1]
+        let shape2 = shape.[dim+1..]
+        let outputShape = Array.append shape1 shape2
+        shape1, shape2, outputShape
+
+    /// Check if the given shapes are appropriate for a transpose operation and return information related to the resulting shape.
+    let computeTranspose2d (shape: Shape) =
+        let nrows = shape.[0]
+        let ncols = shape.[1]
+        let outputShape = [| ncols; nrows |]
+        outputShape
+
+    /// Check the two device types are equal
+    let checkDeviceTypes (deviceType1: DeviceType) (deviceType2: DeviceType) =
+        if deviceType1 <> deviceType2 then failwithf "Expecting input device types %A and %A to be the same" deviceType1 deviceType2
+
+    /// Check the two tensor element types are equal
+    let checkDtypes (dtype1: Dtype) (dtype2: Dtype) =
+        if dtype1 <> dtype2 then failwithf "Expecting input tensor types %A and %A to be the same" dtype1 dtype2
+
+    /// Check the tensor element type is appropriate for a convolution operation
+    let private checkConvDType op (dtype: Dtype) =
+        match dtype with 
+        | Dtype.Bool -> opNotSupported op dtype
+        | _ -> ()
+
+    /// Check if the given shapes are appropriate for a convolution operation and return information related to the resulting shape.
+    let checkCanConv1d (deviceType1: DeviceType) (deviceType2: DeviceType) (dtype1: Dtype) (dtype2: Dtype) (shape1:Shape) (shape2:Shape) (stride: int) (padding: int) (dilation: int) =
+        checkDeviceTypes deviceType1 deviceType2
+        checkDtypes dtype1 dtype2
+        checkConvDType "conv1d" dtype1
+        if shape1.Length <> 3 || shape2.Length <> 3 then failwithf "Expecting two 3d tensors t1, t2 where t1 is input (NxCxI: batchSize x inputChannels x inputLength) and t2 is filters (KxCxF: outputChannels x inputChannels x kernelLength), received Tensors with shapes %A, %A" shape1 shape2
+        if padding < 0 then failwithf "Expecting padding (%A) >= 0" padding
+        if stride < 1 then failwithf "Expecting stride (%A) >= 1" stride
+        if dilation < 1 then failwithf "Expecting dilation (%A) >=1" dilation
+        let batchSize = shape1.[0]
+        let inputChannels = shape1.[1]
+        let inputLength = shape1.[2]
+        let outputChannels = shape2.[0]
+        let filtersChannels = shape2.[1]
+        let kernelLength = shape2.[2]
+        let inputLengthAfterPadding = inputLength + 2*padding
+        if shape2.[1] <> inputChannels then failwithf "Input and filters have different number of channels: %A, %A" inputChannels filtersChannels
+        if kernelLength > inputLengthAfterPadding then failwithf "Expecting kernelLength (%A) <= inputLengthAfterPadding (%A)" kernelLength inputLengthAfterPadding
+        let outputSize = int (floor (float (inputLengthAfterPadding - kernelLength)/(float stride))) + 1
+        let outputShape = [|batchSize; outputChannels; outputSize|]
+        batchSize, inputChannels, kernelLength, outputChannels, outputSize, outputShape
+
+    /// Check if the given shapes are appropriate for a convolution operation and return information related to the resulting shape.
+    let checkCanConv2d (deviceType1: DeviceType) (deviceType2: DeviceType) (dtype1: Dtype) (dtype2: Dtype) (shape1: Shape) (shape2: Shape) (stride: int[]) (padding: int[]) (dilation: int[]) =
+        checkDeviceTypes deviceType1 deviceType2
+        checkDtypes dtype1 dtype2
+        checkConvDType "conv2d" dtype1
+        if shape1.Length <> 4 || shape2.Length <> 4 then failwithf "Expecting two 4d tensors t1, t2 where t1 is input, NxCxHxW (batchSize x inputChannels x inputHeight x inputWidth) and t2 is filters, KxCxFxG (outputChannels x inputChannels x kernelHeight x kernelWidth), received Tensors with shapes %A, %A" shape1 shape2
+        if stride.Length <> 2 then failwithf "Expecting stride (%A) to be a two-dimensional array" stride
+        if padding.Length <> 2 then failwithf "Expecting padding (%A) to be a two-dimensional array" padding
+        if dilation.Length <> 2 then failwithf "Expecting dilation (%A) to be a two-dimensional array" dilation
+        if padding.[0] < 0 || padding.[1] < 0 then failwithf "Expecting all paddings (%A) >= 0" padding
+        if stride.[0] < 1 || stride.[1] < 1 then failwithf "Expecting all strides (%A) >= 1" stride
+        if dilation.[0] < 1 || dilation.[1] < 1 then failwithf "Expecting all dilations (%A) >= 1" dilation
+        let batchSize = shape1.[0]
+        let inputChannels = shape1.[1]
+        let inputHeight = shape1.[2]
+        let inputWidth = shape1.[3]
+        let outputChannels = shape2.[0]
+        let filtersChannels = shape2.[1]
+        let kernelHeight = shape2.[2]
+        let kernelWidth = shape2.[3]
+        let inputHeightAfterPadding = inputHeight + 2*padding.[0]
+        let inputWidthAfterPadding = inputWidth + 2*padding.[1]
+        if filtersChannels <> inputChannels then failwithf "Input and filters have different number of channels: %A, %A" inputChannels filtersChannels
+        if kernelHeight > inputHeightAfterPadding then failwithf "Expecting kernelHeight (%A) <= inputHeightAfterPadding (%A)" kernelHeight inputHeightAfterPadding
+        if kernelWidth > inputWidthAfterPadding then failwithf "Expecting kernelWidth (%A) <= inputWidthAfterPadding (%A)" kernelWidth inputWidthAfterPadding
+        let outputHeight = int (floor (float (inputHeightAfterPadding - kernelHeight)/(float stride.[0]))) + 1
+        let outputWidth = int (floor (float (inputWidthAfterPadding - kernelWidth)/(float stride.[1]))) + 1
+        let outputShape = [|batchSize; outputChannels; outputHeight; outputWidth|]
+        batchSize, inputChannels, (kernelHeight, kernelWidth), (outputChannels, outputHeight, outputWidth), outputShape
+
+    /// Check if the given shapes are appropriate for a convolution operation and return information related to the resulting shape.
+    let checkCanConv3d (deviceType1: DeviceType) (deviceType2: DeviceType) (dtype1: Dtype) (dtype2: Dtype) (shape1: Shape) (shape2: Shape) (stride: int[]) (padding: int[]) (dilation: int[]) =
+        checkDeviceTypes deviceType1 deviceType2
+        checkDtypes dtype1 dtype2
+        checkConvDType "conv3d" dtype1
+        if shape1.Length <> 5 || shape2.Length <> 5 then failwithf "Expecting two 4d Tensors t1, t2 where t1 is input, NxCxDxHxW (batchSize x inputChannels x inputDepth x inputHeight x inputWidth) and t2 is filters, KxCxExFxG (outputChannels x inputChannels x kernelDepth x kernelHeight x kernelWidth), received Tensors with shapes %A, %A" shape1 shape2
+        if stride.Length <> 3 then failwithf "Expecting stride (%A) to be a length-three array" stride
+        if padding.Length <> 3 then failwithf "Expecting padding (%A) to be a length-three array" padding
+        if dilation.Length <> 3 then failwithf "Expecting dilation (%A) to be a length-three array" dilation
+        if padding.[0] < 0 || padding.[1] < 0 || padding.[2] < 0 then failwithf "Expecting all paddings (%A) >= 0" padding
+        if stride.[0] < 1 || stride.[1] < 1 || stride.[2] < 1 then failwithf "Expecting all strides (%A) >= 1" stride
+        if dilation.[0] < 1 || dilation.[1] < 1 || dilation.[2] < 1 then failwithf "Expecting all dilations (%A) >= 1" dilation
+        let batchSize = shape1.[0]
+        let inputChannels = shape1.[1]
+        let inputDepth = shape1.[2]
+        let inputHeight = shape1.[3]
+        let inputWidth = shape1.[4]
+        let outputChannels = shape2.[0]
+        let filtersChannels = shape2.[1]
+        let kernelDepth = shape2.[2]
+        let kernelHeight = shape2.[3]
+        let kernelWidth = shape2.[4]
+        let inputDepthAfterPadding = inputDepth + 2*padding.[0]
+        let inputHeightAfterPadding = inputHeight + 2*padding.[1]
+        let inputWidthAfterPadding = inputWidth + 2*padding.[2]
+        if filtersChannels <> inputChannels then failwithf "Input and filters have different number of channels: %A, %A" inputChannels filtersChannels
+        if kernelDepth > inputDepthAfterPadding then failwithf "Expecting kernelDepth (%A) <= inputDepthAfterPadding (%A)" kernelDepth inputDepthAfterPadding
+        if kernelHeight > inputHeightAfterPadding then failwithf "Expecting kernelHeight (%A) <= inputHeightAfterPadding (%A)" kernelHeight inputHeightAfterPadding
+        if kernelWidth > inputWidthAfterPadding then failwithf "Expecting kernelWidth (%A) <= inputWidthAfterPadding (%A)" kernelWidth inputWidthAfterPadding
+        let outputDepth = int (floor (float (inputDepthAfterPadding - kernelDepth)/(float stride.[0]))) + 1
+        let outputHeight = int (floor (float (inputHeightAfterPadding - kernelHeight)/(float stride.[1]))) + 1
+        let outputWidth = int (floor (float (inputWidthAfterPadding - kernelWidth)/(float stride.[2]))) + 1
+        let outputShape = [|batchSize; outputChannels; outputDepth; outputHeight; outputWidth|]
+        batchSize, inputChannels, (kernelDepth, kernelHeight, kernelWidth), (outputChannels, outputDepth, outputHeight, outputWidth), outputShape
+
+    /// Check if the given shapes are appropriate for a maxpool operation and return information related to the resulting shape.
+    let checkCanMaxpool1d (dtype: Dtype) (shape: Shape) (kernelSize: int) (stride: int) (padding: int) =
+        match dtype with 
+        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxpool1d" dtype
+        | _ ->
+        if shape.Length <> 3 then failwithf "Expecting a 3d tensor (NxCxL: batchSize x inputChannels x inputLength), received tensor with shape %A" shape
+        if kernelSize < 1 then failwithf "Expecting kernelSize (%A) >= 1" kernelSize
+        if padding < 0 then failwithf "Expecting padding (%A) >= 0" padding
+        if padding > kernelSize/2 then failwithf "Expecting padding (%A) < kernelSize (%A) / 2" padding kernelSize
+        if stride < 1 then failwithf "Expecting stride (%A) >= 1" stride
+        let batchSize = shape.[0]
+        let channels = shape.[1]
+        let inputSize = shape.[2]
+        let inputLengthAfterPadding = inputSize + 2*padding
+        if kernelSize > inputLengthAfterPadding then failwithf "Expecting kernelSize (%A) <= inputLengthAfterPadding (%A)" kernelSize inputLengthAfterPadding
+        let outputSize = int (floor (float (inputSize + 2*padding - kernelSize)/(float stride))) + 1
+        let outputShape = [|batchSize; channels; outputSize|]
+        batchSize, channels, inputSize, outputSize, outputShape
+
+    /// Check if the given shapes are appropriate for a maxpool operation and return information related to the resulting shape.
+    let checkCanMaxpool2d (dtype: Dtype) (shape: Shape) (kernelSize: int[]) (stride: int[]) (padding: int[]) =
+        match dtype with 
+        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxpool2d" dtype
+        | _ ->
+        if shape.Length <> 4 then failwithf "Expecting a 4d tensor (NxCxHxW: batchSize x inputChannels x inputHeight x inputWidth), received tensor with shape %A" shape
+        if kernelSize.[0] < 1 || kernelSize.[1] < 1 then failwithf "Expecting all kernelSizes (%A) >= 1" kernelSize
+        if padding.[0] < 0 || padding.[1] < 0 then failwithf "Expecting all paddings (%A) >= 0" padding
+        if padding.[0] > kernelSize.[0]/2 || padding.[1] > kernelSize.[1]/2 then failwithf "Expecting all paddings (%A) < kernelSizes (%A) / 2" padding kernelSize
+        if stride.[0] < 1 || stride.[1] < 1 then failwithf "Expecting all strides (%A) >= 1" stride
+        let batchSize = shape.[0]
+        let channels = shape.[1]
+        let inputHeight = shape.[2]
+        let inputWidth = shape.[3]
+        let kernelHeight = kernelSize.[0]
+        let kernelWidth = kernelSize.[1]
+        let inputHeightAfterPadding = inputHeight + 2*padding.[0]
+        let inputWidthAfterPadding = inputWidth + 2*padding.[1]
+        if kernelSize.[0] > inputHeightAfterPadding then failwithf "Expecting kernelSize.[0] (%A) <= inputHeightAfterPadding (%A)" kernelSize.[0] inputHeightAfterPadding
+        if kernelSize.[1] > inputWidthAfterPadding then failwithf "Expecting kernelSize.[1] (%A) <= inputWidthAfterPadding (%A)" kernelSize.[1] inputWidthAfterPadding
+        let outputHeight = int (floor (float (inputHeight + 2*padding.[0] - kernelHeight)/(float stride.[0]))) + 1
+        let outputWidth = int (floor (float (inputWidth + 2*padding.[1] - kernelWidth)/(float stride.[1]))) + 1
+        let outputShape = [|batchSize; channels; outputHeight; outputWidth|]
+        (batchSize, channels, (inputHeight, inputWidth), (kernelHeight, kernelWidth), (outputHeight, outputWidth), outputShape)
+
+    /// Check if the given shapes are appropriate for a maxpool operation and return information related to the resulting shape.
+    let checkCanMaxpool3d (dtype: Dtype) (shape: Shape) (kernelSize: int[]) (stride: int[]) (padding: int[]) =
+        match dtype with 
+        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxpool3d" dtype
+        | _ ->
+        if shape.Length <> 5 then failwithf "Expecting a 5d tensor (NxCxDxHxW: batchSize x inputChannels x inputDepth x inputHeight x inputWidth), received tensor with shape %A" shape
+        if kernelSize.[0] < 1 || kernelSize.[1] < 1 || kernelSize.[2] < 1 then failwithf "Expecting all kernelSizes (%A) >= 1" kernelSize
+        if padding.[0] < 0 || padding.[1] < 0 || padding.[2] < 0 then failwithf "Expecting all paddings (%A) >= 0" padding
+        if padding.[0] > kernelSize.[0]/2 || padding.[1] > kernelSize.[1]/2 || padding.[2] > kernelSize.[2]/2 then failwithf "Expecting all paddings (%A) < kernelSizes (%A) / 2" padding kernelSize
+        if stride.[0] < 1 || stride.[1] < 1 || stride.[2] < 1 then failwithf "Expecting all strides (%A) >= 1" stride
+        let batchSize = shape.[0]
+        let channels = shape.[1]
+        let inputDepth = shape.[2]
+        let inputHeight = shape.[3]
+        let inputWidth = shape.[4]
+        let kernelDepth = kernelSize.[0]
+        let kernelHeight = kernelSize.[1]
+        let kernelWidth = kernelSize.[2]
+        let inputDepthAfterPadding = inputDepth + 2*padding.[0]
+        let inputHeightAfterPadding = inputHeight + 2*padding.[1]
+        let inputWidthAfterPadding = inputWidth + 2*padding.[2]
+        if kernelSize.[0] > inputDepthAfterPadding then failwithf "Expecting kernelSize.[0] (%A) <= inputDepthAfterPadding (%A)" kernelSize.[0] inputDepthAfterPadding
+        if kernelSize.[1] > inputHeightAfterPadding then failwithf "Expecting kernelSize.[1] (%A) <= inputHeightAfterPadding (%A)" kernelSize.[1] inputHeightAfterPadding
+        if kernelSize.[2] > inputWidthAfterPadding then failwithf "Expecting kernelSize.[1] (%A) <= inputWidthAfterPadding (%A)" kernelSize.[1] inputWidthAfterPadding
+        let outputDepth = int (floor (float (inputDepth + 2*padding.[0] - kernelDepth)/(float stride.[0]))) + 1
+        let outputHeight = int (floor (float (inputHeight + 2*padding.[1] - kernelHeight)/(float stride.[1]))) + 1
+        let outputWidth = int (floor (float (inputWidth + 2*padding.[2] - kernelWidth)/(float stride.[2]))) + 1
+        let outputShape = [|batchSize; channels; outputDepth; outputHeight; outputWidth|]
+        (batchSize, channels, (inputDepth, inputHeight, inputWidth), (kernelDepth, kernelHeight, kernelWidth), (outputDepth, outputHeight, outputWidth), outputShape)
+
+    /// Check if the given shapes are appropriate for a maxunpool operation and return information related to the resulting shape.
+    let checkCanMaxunpool1d (dtype: Dtype) (shape: Shape) (indicesDtype: Dtype) (indicesShape: Shape) (outputSize: int[]) =
+        match dtype with 
+        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxunpool2d" dtype
+        | _ ->
+        if indicesDtype <> Dtype.Int32 then failwithf "Expecting indices to have type %A" Dtype.Int32
+        if outputSize.Length <> 3 then failwithf "Expecting outputSize (%A) to be 3-dimensional" outputSize
+        let batchSize = shape.[0]
+        let channels = shape.[1]
+        let inputSize = shape.[2]
+        if outputSize.[0] <> indicesShape.[0] || outputSize.[1] <> indicesShape.[1] then failwithf "Expecting the first two elements of outputSize (%A) and indicesShape (%A) to be the same" outputSize indicesShape
+        let outputShape = [|batchSize; channels; outputSize.[2]|]
+        batchSize, channels, inputSize, outputShape
+
+    /// Check if the given shapes are appropriate for a maxunpool operation and return information related to the resulting shape.
+    let checkCanMaxunpool2d (dtype: Dtype) (shape: Shape) (indicesDtype: Dtype) (indicesShape: Shape) (outputSize: int[]) =
+        match dtype with 
+        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxunpool2d" dtype
+        | _ ->
+        if indicesDtype <> Dtype.Int32 then failwithf "Expecting indices to have type %A" Dtype.Int32
+        if outputSize.Length <> 4 then failwithf "Expecting outputSize (%A) to be 4-dimensional" outputSize
+        let batchSize = shape.[0]
+        let channels = shape.[1]
+        let inputHeight = shape.[2]
+        let inputWidth = shape.[3]
+        if outputSize.[0] <> indicesShape.[0] || outputSize.[1] <> indicesShape.[1] then failwithf "Expecting the first two elements of outputSize (%A) and indicesShape (%A) to be the same" outputSize indicesShape
+        let outputShape = [|batchSize; channels; outputSize.[2]; outputSize.[3]|]
+        batchSize, channels, (inputHeight, inputWidth), outputShape
+
+    /// Check if the given shapes are appropriate for a maxunpool operation and return information related to the resulting shape.
+    let checkCanMaxunpool3d (dtype: Dtype) (shape: Shape) (indicesDtype: Dtype) (indicesShape: Shape) (outputSize: int[]) =
+        match dtype with 
+        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxunpool2d" dtype
+        | _ ->
+        if indicesDtype <> Dtype.Int32 then failwithf "Expecting indices to have type %A" Dtype.Int32
+        if outputSize.Length <> 5 then failwithf "Expecting outputSize (%A) to be 5-dimensional" outputSize
+        let batchSize = shape.[0]
+        let channels = shape.[1]
+        let inputDepth = shape.[2]
+        let inputHeight = shape.[3]
+        let inputWidth = shape.[4]
+        if outputSize.[0] <> indicesShape.[0] || outputSize.[1] <> indicesShape.[1] then failwithf "Expecting the first two elements of outputSize (%A) and indicesShape (%A) to be the same" outputSize indicesShape
+        let outputShape = [|batchSize; channels; outputSize.[2]; outputSize.[3]; outputSize.[4]|]
+        batchSize, channels, (inputDepth, inputHeight, inputWidth), outputShape
+
+    /// Indicates if one shape can expand into another through the addition of single or broadcast dimensions
+    let canExpand (oldShape: Shape) (newShape: Shape) =
+        newShape.Length >= oldShape.Length &&
+        let trim = newShape.Length - oldShape.Length
+        (oldShape,newShape.[trim..]) ||> Array.forall2 (fun n m -> n = 1 || n = m)
+
+    /// Check if one shape can expand into another through the addition of single or broadcast dimensions
+    let checkCanExpand (oldShape: Shape) (newShape: Shape) =
+        let isOK = canExpand oldShape newShape
+        if not isOK then failwithf "can't expand from shape %A to %A - each dimension must either be equal or expand from 1" oldShape newShape
+
+    /// Check if the given shape is appropriate for a transpose operation and return information related to the resulting shape.
+    let checkCanTranspose (shape: Shape) (dim0: int) (dim1: int) =
+        if dim0 < 0 || dim0 >= shape.Length then failwithf "Expecting 0 <= dim0 (%A) < shape.Length (%A)" dim0 shape.Length
+        if dim1 < 0 || dim1 >= shape.Length then failwithf "Expecting 0 <= dim1 (%A) < shape.Length (%A)" dim1 shape.Length
+
+    /// Check if the given shape is appropriate for a transpose operation.
+    let checkCanTranspose2d (dim: int) =
+        if dim <> 2 then failwith "Expecting dim=2 when no specific dimensions are given to transpose. Consider using general transpose(dim0, dim1)."
+
+    /// Check if the given shape is appropriate for a flip operation.
+    let checkCanFlip (dim: int) (dims: int[]) =
+        if dims.Length > dim then failwithf "Expecting dims (list of dimension indices to flip) of length less than Tensor's dimensions, received %A, %A" dims.Length dim
+        if Seq.hasDuplicates dims then failwithf "Expecting dims (list of dimension indices to flip) without repetition, received %A" dims
+        if (Array.max dims) >= dim then failwithf "Expecting dims (list of dimension indices to flip) where all indices are less than the tensor dimension, received %A, %A" dims dim
+
+    /// Check if the given shape is appropriate for a repeat operation.
+    let checkCanRepeat (shape: Shape) (dim: int) =
+        if shape.[dim] <> 1 then failwithf "Expecting Tensor's shape (%A) at dim (%A) to be 1" shape dim
+
+    /// Check if the given shape is appropriate for a dilate operation.
+    let checkCanDilate (dim: int) (dilations: int[]) =
+        if dilations.Length <> dim then failwithf "Expecting dilations (dilation to use in each dimension) of same length with Tensor's dimensions, received %A, %A" dilations.Length dim
+        if (Array.min dilations) < 1 then failwithf "Expecting dilations (dilation to use in each dimension) >= 1 where 1 represents no dilation, received %A" dilations
+
+    /// Check if the given shape is appropriate for a gather operation.
+    let checkCanGather (shape: Shape) (dim: int) (indicesShape: Shape) (indicesDtype:Dtype) =
+        if shape.Length <> indicesShape.Length then failwithf "Expecting tensorShape (%A) and indicesShape (%A) to have the same number of dimensions" shape indicesShape
+        if dim < 0 || dim > shape.Length-1 then failwithf "Expecting 0<= dim (%A) < tensorShape.Length (%A)" dim shape.Length
+        if indicesShape.[dim] < 1 then failwithf "Expecting indicesShape.[dim] (%A) >= 1" indicesShape.[dim]
+        if indicesDtype <> Dtype.Int32 then failwithf "Expecting indices to have type %A" Dtype.Int32
+
+    /// Check if the given shape is appropriate for a gather operation.
+    let checkCanView (shape1: Shape) (shape2: Shape) =
+        if length shape1 <> length shape2 then failwithf "Cannot view Tensor of shape %A as shape %A" shape1 shape2
+
+    /// Check if the given shape is appropriate for a flatten operation.
+    let checkCanFlatten (shape: Shape) (startDim: int) (endDim: int) =
+        if startDim < 0 || startDim >= shape.Length then failwithf "Expecting 0 <= startDim (%A) < %A" startDim shape.Length
+        if endDim < 0 || endDim >= shape.Length then failwithf "Expecting 0 <= endDim (%A) < %A" endDim shape.Length
+        if endDim <= startDim then failwithf "Expecting startDim (%A) < endDim (%A)" startDim endDim
+
+    /// Check if the given shape is appropriate for an addSlice operation.
+    let checkCanAddSlice (shape1: Shape) (location: int[]) (shape2: Shape) =
+        if not (contains shape1 shape2) then failwithf "Expecting shape1 to contain shape2, received %A, %A" shape1 shape2
+        if location.Length <> shape1.Length then failwithf "Expecting location of the same length as shape1, received %A, %A" (location.Length) shape1
+
+    /// Check if the given shape is appropriate for a matmul operation.
+    let checkCanMatmul (shape1: Shape) (shape2: Shape) =
+        if shape1.Length <> 2 || shape2.Length <> 2 then failwithf "Expecting two 2d Tensors, received Tensors with shapes %A, %A" shape1 shape2
+        if shape1.[1] <> shape2.[0] then failwithf "Cannot multiply Tensors with shapes %A, %A" shape1 shape2
+
+    /// Check if the given shape is appropriate for a dot product operation.
+    let checkCanDot (shape1: Shape) (shape2: Shape) =
+        if shape1.Length <> 1 || shape2.Length <> 1 then failwithf "Expecting two vectors (1d Tensors), received Tensors with shapes %A, %A" shape1 shape2
+        if shape1.[0] <> shape2.[0] then failwithf "Cannot multiply vectors with different lengths %A, %A" shape1.[0] shape2.[0]
+
+    /// Check if the given shape is appropriate for a pad operation.
+    let checkCanPad (shape: Shape) (paddings: int[]) =
+        if shape.Length <> paddings.Length then failwithf "Expecting shape (%A) and paddings (%A) to have the same length" shape paddings
+        if not (paddings |> Array.forall (fun p -> p >= 0)) then failwithf "Expecting all paddings (%A) >= 0" paddings
+
+    /// Check if the given shape is appropriate for a dropout operation.
+    let checkCanDropout (p:double) =
+        if p < 0. || p > 1. then failwithf "Expecting 0 <= p <= 1, but received %A" p
+
+    /// Check if the given shape is appropriate for a dropout2d operation.
+    let checkCanDropout2d (shape: Shape) (p:double) =
+        checkCanDropout p
+        if shape.Length <> 4 then failwithf "Expecting shape (%A) to be 4-dimensional (NxCxHxW: batchSize, inputChannels, inputHeight, inputWidth)" shape
+
+    /// Check if the given shape is appropriate for a dropout3d operation.
+    let checkCanDropout3d (shape: Shape) (p:double) =
+        checkCanDropout p
+        if shape.Length <> 5 then failwithf "Expecting shape (%A) to be 5-dimensional (NxCxDxHxW: batchSize, inputChannels, inputDepth, inputHeight, inputWidth)" shape
+
+    /// Compute the shape that results from a squeeze operation.
+    let squeeze (dim: int) (shape: Shape) =
+        if dim = -1 then
+            [|for s in shape do if s <> 1 then yield s|]
+        elif shape.[dim] = 1 then
+            [|for i=0 to shape.Length - 1 do 
+                if i < dim then yield shape.[i]
+                elif i > dim then yield shape.[i]|]
+        else
+            shape
+
+    /// Compute the shape that results from an unsqueeze operation.
+    let checkCanUnsqueeze (dim: int) (shape: Shape) =
+        if dim < 0 || dim > shape.Length then failwithf "Expecting dim in range [0, %A] but received %A" shape.Length dim
+        [|for i=0 to shape.Length - 1 + 1 do 
+            if i < dim then yield shape.[i]
+            elif i = dim then yield 1
+            else yield shape.[i-1]|]
+
+    /// Compute the shape that results from an unsqueezeAs operation.
+    let unsqueezeAs (shape1: Shape) (shape2: Shape) =
+        if shape1.Length > shape2.Length then failwithf "Expecting shape1.Length (%A) <= shape2.Length (%A)" shape1.Length shape2.Length
+        let ones = Array.create (shape2.Length - shape1.Length) 1
+        Array.append ones shape1
+
+    /// Convert the given location to a three-element bounds array in the context of the given shape.
+    let locationToBounds (shape: Shape) (location: int[]) =
+        Array2D.init location.Length 3 (fun i j -> if j=0 then location.[i] elif j=1 then location.[i] + shape.[i] - 1 else 1)
+
+    /// Compute the shape that results from a flatten operation.
+    let flatten (startDim: int) (endDim: int) (shape: Shape) =
+        let shape = [|for i in 0..shape.Length-1 do if (i < startDim) || (i > endDim) then shape.[i] else -1|]
+        let mutable emitted = false
+        [|for s in shape do if s <> -1 then s elif not emitted then emitted <- true; -1|]
+
+    /// Find the shape into which shape1 and shape2 can be expanded
+    let broadcast2 (shape1: Shape) (shape2: Shape) =
+        if canExpand shape1 shape2 || canExpand shape2 shape1 then 
+            let n1 = shape1.Length
+            let n2 = shape2.Length
+            let mx = max n1 n2
+            let mn = mx - min n1 n2
+            Array.init mx (fun i -> 
+                if i < mn then (if n1 > n2 then shape1.[i] else shape2.[i])
+                elif n1 > n2 then max shape1.[i] shape2.[i-mn]
+                else max shape1.[i-mn] shape2.[i])
+        else failwithf "shapes %A and %A are not related by broadcasting - each dimension must either be extra, equal, expand from 1" shape1 shape2
+
+    /// Find the shape into which all the shapes can be expanded
+    let broadcastShapes (shapes: Shape[]) = Array.reduce broadcast2 shapes
+
+    /// Compute the shape that results from a dilation operation.
+    let dilated (shape: Shape) (dilations: int[]) =
+        Array.map2 (fun n d -> n + (n - 1) * (d - 1)) shape dilations
+
+    /// Compute the shape that results from a pairwise dilation operation.
+    let dilated2 (shape: Shape) (dilations: int[]) =
+        Array.map2 (*) shape dilations
+
+    /// Compute the shape that results from an undilation operation.
+    let undilatedShape (shape: Shape) (dilations: int[]) =
+        Array.map2 (fun n d -> (n + d - 1) / d) shape dilations
+
+    /// Complete the given shape with respect to a tensor with the given number of elements.
+    let complete (nelement: int) (shape: Shape) =
+        if (shape |> Array.filter (fun x -> x < -1) |> Array.length) > 0 then failwithf "Invalid shape %A" shape
+        let numUnspecified = shape |> Array.filter ((=) -1) |> Array.length
+        if numUnspecified > 1 then
+            failwithf "Cannot complete shape %A, expecting at most one unspecified dimension (-1)" shape
+        elif numUnspecified = 0 then 
+            shape
+        else
+            let divisor = shape |> Array.filter ((<>) -1) |> length
+            if nelement % divisor <> 0 then failwithf "Cannot complete shape %A to have %A elements" shape nelement
+            let missing = nelement / divisor
+            [|for d in shape do if d = -1 then yield missing else yield d|]
+
+    /// Complete the given shape dimension with respect to a concrete dimension
+    let completeDim (dims:int) (dim:int) =
+      if dim < -dims || dim >= dims then failwithf "Invalid choice (%A) for dim (%A)" dim dims
+      if dim < 0 then dims+dim
+      else dim    
+
+
+[<AutoOpen>]
+module ShapeAutoOpens =
+
+    /// Get the number of dimensions in a shape.
+    let shapeLength (shape: Shape) = Shape.length shape
+
+    /// Convert the array of three-position bounds specifications to a location.
+    let boundsToLocation (bounds: int[,]) =
+        [|for i=0 to bounds.GetLength(0) - 1 do yield bounds.[i, 0]|]
+
+    /// Convert the array of three-position bounds specifications to a shape.
+    let boundsToShape (bounds: int[,]) =
+        [|for i=0 to bounds.GetLength(0) - 1 do yield bounds.[i, 1] - bounds.[i, 0] + 1|] 
+
+    /// Mirror the coordinates in the given dimensions in the context of the given shape.
+    let mirrorCoordinates (coordinates: int[]) (shape: Shape) (mirrorDims: int[]) =
+        if coordinates.Length <> shape.Length then failwithf "Expecting coordinates and shape of the same dimension, received %A, %A" coordinates.Length shape.Length
+        let result = Array.copy coordinates
+        for d=0 to coordinates.Length-1 do
+            if mirrorDims |> Array.contains d then
+                result.[d] <- abs (coordinates.[d] - shape.[d] + 1)
+        result
+
+    /// Dilate the coordinates 
+    let dilatedCoordinates (coordinates: int[]) (dilations: int[]) =
+        Array.map2 (*) coordinates dilations
+
+    /// Check if the given index is valid in the context of the given shape.
+    let checkValidIndex (shape: Shape) (index: int[]) =
+        if shape.Length <> index.Length then failwithf "Expecting shape (%A) and index (%A) to have the same length" shape index
+        let valid = Array.forall2 (fun s i -> i < s) shape index
+        if not valid then failwithf "index (%A) is not valid for shape (%A)" index shape
+
+    /// Convert the given index to a flat index in the context of the given shape.
+    let indexToFlatIndex (shape: Shape) (index: int[]) =
+        checkValidIndex shape index
+        let mutable flatIndex = 0
+        for i=0 to index.Length - 1 do
+            let v = if i = index.Length - 1 then 1 else (Array.reduce (*) shape.[i+1..])
+            flatIndex <- flatIndex + index.[i] * v
+        flatIndex
+
+    /// Convert the given flat index to an index in the context of the given shape.
+    let flatIndexToIndex (shape: Shape) (flatIndex: int) =
+        let dim = shape.Length
+        let nelement = shapeLength shape
+        let index = Array.create dim 0
+        let mutable mul = nelement
+        let mutable fi = flatIndex
+        for i=dim downto 1 do
+            mul <- mul / shape.[dim-i]
+            index.[i-1] <- fi / mul
+            fi <- fi - index.[i-1] * mul
+        index |> Array.rev
+    

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -396,7 +396,7 @@ type Tensor =
             t.GetSlice(bounds)
 
     static member create(value:obj, ?dtype:Dtype, ?device:Device, ?backend:Backend) =
-        let res = value |> tryFlatArrayAndShape<Tensor> // support creation of new Tensor from a structure holding scalar Tensors
+        let res = value |> DataConverter.tryFlatArrayAndShape<Tensor> // support creation of new Tensor from a structure holding scalar Tensors
         match res with
         | Some (array, shape) -> 
             let array = array |> Array.map float32

--- a/src/DiffSharp.Core/Util.fs
+++ b/src/DiffSharp.Core/Util.fs
@@ -1,4 +1,5 @@
-module DiffSharp.Util
+/// Contains utilities related to the DiffSharp programming model.
+namespace DiffSharp.Util
 
 open System
 open System.Net
@@ -9,25 +10,24 @@ open System.IO
 open System.IO.Compression
 open System.Runtime.Serialization
 open System.Runtime.Serialization.Formatters.Binary
+
+open DiffSharp
+
 open FSharp.Reflection
 
-let logSqrt2Pi = log(sqrt(2. * Math.PI))
-let log10Val = log 10.
-
+/// Represents a nesting level with a differentiation operation.
 type NestingLevel =
     val mutable Current:uint32
     new() = {Current = 0u}
     member t.Next() = t.Current <- t.Current + 1u; t.Current
 
+/// Operations to get, set or reset the global nesting level for differentiation operations.
 type GlobalNestingLevel() =
     static let tagger = NestingLevel()
     static member Current = tagger.Current
     static member Next() = tagger.Next()
     static member Reset() = tagger.Current <- 0u
     static member Set(level) = tagger.Current <- level
-
-[<ExcludeFromCodeCoverage>]
-let inline cumulativeSum (a:_[]) = (Array.scan (+) LanguagePrimitives.GenericZero a).[1..]
 
 type Random() =
     static let mutable rnd = System.Random()
@@ -44,7 +44,7 @@ type Random() =
     static member Integer(low, high) = rnd.Next(low, high)
     static member ChoiceIndex(probs:float[]) =
         let probsSum = probs |> Array.sum
-        let cumulativeProbs = probs |> Array.map (fun v -> v / probsSum) |> cumulativeSum
+        let cumulativeProbs = probs |> Array.map (fun v -> v / probsSum) |> Array.cumulativeSum
         let p = rnd.NextDouble()
         cumulativeProbs |> Array.findIndex (fun v -> v >= p)
     static member Choice(array:_[]) = array.[rnd.Next(array.Length)]
@@ -69,822 +69,315 @@ type Random() =
             a.[n] <- temp
         a
 
-[<ExcludeFromCodeCoverage>]
-let inline notNull value = not (obj.ReferenceEquals(value, null))
-
-let duplicates l =
-   l |> List.ofSeq
-   |> List.groupBy id
-   |> List.choose ( function
-          | _, x::_::_ -> Some x
-          | _ -> None )
-
-let hasDuplicates l =
-    (duplicates l) |> List.isEmpty |> not
-        
-let allEqual (items:seq<'a>) =
-    let item0 = items |> Seq.head
-    items |> Seq.forall ((=) item0)
-
-type Shape = int[]
-
-let shapeLength (shape: Shape) =
-    if shape.Length = 0 then 1
-    else Array.reduce (*) shape
-
-module Shape =
-    let scalar : Shape = [| |]
-
-    let contains (bigShape:Shape) (smallShape: Shape) =
-        if bigShape.Length <> smallShape.Length then failwithf "Expecting bigShape (%A) and smallShape (%A) to have the same number of dimensions" bigShape.Length smallShape.Length
-        Array.map2 (<=) smallShape bigShape |> Array.forall id
-
-    let checkCanStack (shapes:Shape[]) (dim: int) =
-        if not (allEqual shapes) then failwith "Cannot stack Tensors with different shapes"
-        let n = shapes.Length
-        if n = 0 then failwithf "Expecting a non-empty sequence of Tensors"
-        let shape = shapes.[0]
-        if dim < 0 || dim > shape.Length then invalidArg "dim" "invalid dimension"
-        if dim < 0 || dim > n then invalidArg "dim" "invalid dimension"
-        let shape1 = shape.[0..dim-1]
-        let shape2 = shape.[dim..]
-        let outputShape = [| yield! shape1; yield n; yield! shape2 |]
-        n, shape1, shape2, outputShape
-
-    let checkCanGetSlice (shape: Shape) (fullBounds: int[,]) =
-        if Array2D.length1 fullBounds <> shape.Length then failwithf "Expecting %i-by-3 fullBounds" shape.Length
-        let outputShape = 
-            [|for i=0 to (fullBounds.GetLength(0) - 1) do
-                let len = fullBounds.[i,1] - fullBounds.[i,0] + 1
-                if fullBounds.[i, 2] = 1 then
-                    if len > 1 then yield len // if len=1 then squeeze this dimension
-                else
-                    yield len|]
-        outputShape
-
-    let checkCanCat (shapes: Shape[]) (dim: int) =
-        let n = shapes.Length
-        if n = 0 then invalidArg "tensors" "Expecting at least one tensor"
-        let shape = shapes.[0]
-        if dim < 0 || dim >= shape.Length then invalidArg "dim" "invalid dimension"
-        let shape1 = shape.[0..dim-1]
-        let shape3 = shape.[dim+1..]
-        if shapes |> Array.exists (fun shapeOther -> shapeOther.[0..dim-1] <> shape1 || shapeOther.[dim+1..] <> shape3) then
-            invalidArg "tensors" "Expecting Tensors with similar shapes"
-        let m2 = shapes |> Array.sumBy (fun shape -> shape.[dim])
-        let outputShape = [| yield! shape1; yield m2; yield! shape3 |]
-        n, shape1, m2, shape3, outputShape
-
-    let checkCanSplit (shape: Shape) (sizes: int[]) (dim: int) =
-        if dim < 0 || dim >= shape.Length then invalidArg "dim" "invalid dimension"
-        if Array.sum sizes <> shape.[dim] then invalidArg "sizes" "the sum of sizes must equal the relevant dimension"
-        let shape1 = shape.[0..dim-1]
-        let shape2 = shape.[dim+1..]
-        let outputShapes = sizes |> Array.map (fun sz -> [| yield! shape1; yield sz; yield! shape2 |])
-        outputShapes
-
-    let checkCanUnstack (shape: Shape) (dim: int) =
-        if shape.Length < 1 then failwith "Cannot unstack scalar Tensor (dim < 1)"
-        if dim < 0 || dim >= shape.Length then invalidArg "dim" "invalid dimension"
-        let shape1 = shape.[0..dim-1]
-        let shape2 = shape.[dim+1..]
-        let outputShape = Array.append shape1 shape2
-        shape1, shape2, outputShape
-
-    let computeTranspose2d (shape: Shape) =
-        let nrows = shape.[0]
-        let ncols = shape.[1]
-        let outputShape = [| ncols; nrows |]
-        outputShape
-
-    let checkDeviceTypes (deviceType1: DeviceType) (deviceType2: DeviceType) =
-        if deviceType1 <> deviceType2 then failwithf "Expecting input device types %A and %A to be the same" deviceType1 deviceType2
-
-    let checkDtypes (dtype1: Dtype) (dtype2: Dtype) =
-        if dtype1 <> dtype2 then failwithf "Expecting input tensor types %A and %A to be the same" dtype1 dtype2
-
-    let private checkConvDType op (dtype: Dtype) =
-        match dtype with 
-        | Dtype.Bool -> opNotSupported op dtype
-        | _ -> ()
-
-    let checkCanConv1d (deviceType1: DeviceType) (deviceType2: DeviceType) (dtype1: Dtype) (dtype2: Dtype) (shape1:Shape) (shape2:Shape) (stride: int) (padding: int) (dilation: int) =
-        checkDeviceTypes deviceType1 deviceType2
-        checkDtypes dtype1 dtype2
-        checkConvDType "conv1d" dtype1
-        if shape1.Length <> 3 || shape2.Length <> 3 then failwithf "Expecting two 3d tensors t1, t2 where t1 is input (NxCxI: batchSize x inputChannels x inputLength) and t2 is filters (KxCxF: outputChannels x inputChannels x kernelLength), received Tensors with shapes %A, %A" shape1 shape2
-        if padding < 0 then failwithf "Expecting padding (%A) >= 0" padding
-        if stride < 1 then failwithf "Expecting stride (%A) >= 1" stride
-        if dilation < 1 then failwithf "Expecting dilation (%A) >=1" dilation
-        let batchSize = shape1.[0]
-        let inputChannels = shape1.[1]
-        let inputLength = shape1.[2]
-        let outputChannels = shape2.[0]
-        let filtersChannels = shape2.[1]
-        let kernelLength = shape2.[2]
-        let inputLengthAfterPadding = inputLength + 2*padding
-        if shape2.[1] <> inputChannels then failwithf "Input and filters have different number of channels: %A, %A" inputChannels filtersChannels
-        if kernelLength > inputLengthAfterPadding then failwithf "Expecting kernelLength (%A) <= inputLengthAfterPadding (%A)" kernelLength inputLengthAfterPadding
-        let outputSize = int (floor (float (inputLengthAfterPadding - kernelLength)/(float stride))) + 1
-        let outputShape = [|batchSize; outputChannels; outputSize|]
-        batchSize, inputChannels, kernelLength, outputChannels, outputSize, outputShape
-
-    let checkCanConv2d (deviceType1: DeviceType) (deviceType2: DeviceType) (dtype1: Dtype) (dtype2: Dtype) (shape1: Shape) (shape2: Shape) (stride: int[]) (padding: int[]) (dilation: int[]) =
-        checkDeviceTypes deviceType1 deviceType2
-        checkDtypes dtype1 dtype2
-        checkConvDType "conv2d" dtype1
-        if shape1.Length <> 4 || shape2.Length <> 4 then failwithf "Expecting two 4d tensors t1, t2 where t1 is input, NxCxHxW (batchSize x inputChannels x inputHeight x inputWidth) and t2 is filters, KxCxFxG (outputChannels x inputChannels x kernelHeight x kernelWidth), received Tensors with shapes %A, %A" shape1 shape2
-        if stride.Length <> 2 then failwithf "Expecting stride (%A) to be a two-dimensional array" stride
-        if padding.Length <> 2 then failwithf "Expecting padding (%A) to be a two-dimensional array" padding
-        if dilation.Length <> 2 then failwithf "Expecting dilation (%A) to be a two-dimensional array" dilation
-        if padding.[0] < 0 || padding.[1] < 0 then failwithf "Expecting all paddings (%A) >= 0" padding
-        if stride.[0] < 1 || stride.[1] < 1 then failwithf "Expecting all strides (%A) >= 1" stride
-        if dilation.[0] < 1 || dilation.[1] < 1 then failwithf "Expecting all dilations (%A) >= 1" dilation
-        let batchSize = shape1.[0]
-        let inputChannels = shape1.[1]
-        let inputHeight = shape1.[2]
-        let inputWidth = shape1.[3]
-        let outputChannels = shape2.[0]
-        let filtersChannels = shape2.[1]
-        let kernelHeight = shape2.[2]
-        let kernelWidth = shape2.[3]
-        let inputHeightAfterPadding = inputHeight + 2*padding.[0]
-        let inputWidthAfterPadding = inputWidth + 2*padding.[1]
-        if filtersChannels <> inputChannels then failwithf "Input and filters have different number of channels: %A, %A" inputChannels filtersChannels
-        if kernelHeight > inputHeightAfterPadding then failwithf "Expecting kernelHeight (%A) <= inputHeightAfterPadding (%A)" kernelHeight inputHeightAfterPadding
-        if kernelWidth > inputWidthAfterPadding then failwithf "Expecting kernelWidth (%A) <= inputWidthAfterPadding (%A)" kernelWidth inputWidthAfterPadding
-        let outputHeight = int (floor (float (inputHeightAfterPadding - kernelHeight)/(float stride.[0]))) + 1
-        let outputWidth = int (floor (float (inputWidthAfterPadding - kernelWidth)/(float stride.[1]))) + 1
-        let outputShape = [|batchSize; outputChannels; outputHeight; outputWidth|]
-        batchSize, inputChannels, (kernelHeight, kernelWidth), (outputChannels, outputHeight, outputWidth), outputShape
-
-    let checkCanConv3d (deviceType1: DeviceType) (deviceType2: DeviceType) (dtype1: Dtype) (dtype2: Dtype) (shape1: Shape) (shape2: Shape) (stride: int[]) (padding: int[]) (dilation: int[]) =
-        checkDeviceTypes deviceType1 deviceType2
-        checkDtypes dtype1 dtype2
-        checkConvDType "conv3d" dtype1
-        if shape1.Length <> 5 || shape2.Length <> 5 then failwithf "Expecting two 4d Tensors t1, t2 where t1 is input, NxCxDxHxW (batchSize x inputChannels x inputDepth x inputHeight x inputWidth) and t2 is filters, KxCxExFxG (outputChannels x inputChannels x kernelDepth x kernelHeight x kernelWidth), received Tensors with shapes %A, %A" shape1 shape2
-        if stride.Length <> 3 then failwithf "Expecting stride (%A) to be a length-three array" stride
-        if padding.Length <> 3 then failwithf "Expecting padding (%A) to be a length-three array" padding
-        if dilation.Length <> 3 then failwithf "Expecting dilation (%A) to be a length-three array" dilation
-        if padding.[0] < 0 || padding.[1] < 0 || padding.[2] < 0 then failwithf "Expecting all paddings (%A) >= 0" padding
-        if stride.[0] < 1 || stride.[1] < 1 || stride.[2] < 1 then failwithf "Expecting all strides (%A) >= 1" stride
-        if dilation.[0] < 1 || dilation.[1] < 1 || dilation.[2] < 1 then failwithf "Expecting all dilations (%A) >= 1" dilation
-        let batchSize = shape1.[0]
-        let inputChannels = shape1.[1]
-        let inputDepth = shape1.[2]
-        let inputHeight = shape1.[3]
-        let inputWidth = shape1.[4]
-        let outputChannels = shape2.[0]
-        let filtersChannels = shape2.[1]
-        let kernelDepth = shape2.[2]
-        let kernelHeight = shape2.[3]
-        let kernelWidth = shape2.[4]
-        let inputDepthAfterPadding = inputDepth + 2*padding.[0]
-        let inputHeightAfterPadding = inputHeight + 2*padding.[1]
-        let inputWidthAfterPadding = inputWidth + 2*padding.[2]
-        if filtersChannels <> inputChannels then failwithf "Input and filters have different number of channels: %A, %A" inputChannels filtersChannels
-        if kernelDepth > inputDepthAfterPadding then failwithf "Expecting kernelDepth (%A) <= inputDepthAfterPadding (%A)" kernelDepth inputDepthAfterPadding
-        if kernelHeight > inputHeightAfterPadding then failwithf "Expecting kernelHeight (%A) <= inputHeightAfterPadding (%A)" kernelHeight inputHeightAfterPadding
-        if kernelWidth > inputWidthAfterPadding then failwithf "Expecting kernelWidth (%A) <= inputWidthAfterPadding (%A)" kernelWidth inputWidthAfterPadding
-        let outputDepth = int (floor (float (inputDepthAfterPadding - kernelDepth)/(float stride.[0]))) + 1
-        let outputHeight = int (floor (float (inputHeightAfterPadding - kernelHeight)/(float stride.[1]))) + 1
-        let outputWidth = int (floor (float (inputWidthAfterPadding - kernelWidth)/(float stride.[2]))) + 1
-        let outputShape = [|batchSize; outputChannels; outputDepth; outputHeight; outputWidth|]
-        batchSize, inputChannels, (kernelDepth, kernelHeight, kernelWidth), (outputChannels, outputDepth, outputHeight, outputWidth), outputShape
-
-    let checkCanMaxpool1d (dtype: Dtype) (shape: Shape) (kernelSize: int) (stride: int) (padding: int) =
-        match dtype with 
-        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxpool1d" dtype
-        | _ ->
-        if shape.Length <> 3 then failwithf "Expecting a 3d tensor (NxCxL: batchSize x inputChannels x inputLength), received tensor with shape %A" shape
-        if kernelSize < 1 then failwithf "Expecting kernelSize (%A) >= 1" kernelSize
-        if padding < 0 then failwithf "Expecting padding (%A) >= 0" padding
-        if padding > kernelSize/2 then failwithf "Expecting padding (%A) < kernelSize (%A) / 2" padding kernelSize
-        if stride < 1 then failwithf "Expecting stride (%A) >= 1" stride
-        let batchSize = shape.[0]
-        let channels = shape.[1]
-        let inputSize = shape.[2]
-        let inputLengthAfterPadding = inputSize + 2*padding
-        if kernelSize > inputLengthAfterPadding then failwithf "Expecting kernelSize (%A) <= inputLengthAfterPadding (%A)" kernelSize inputLengthAfterPadding
-        let outputSize = int (floor (float (inputSize + 2*padding - kernelSize)/(float stride))) + 1
-        let outputShape = [|batchSize; channels; outputSize|]
-        batchSize, channels, inputSize, outputSize, outputShape
-
-    let checkCanMaxpool2d (dtype: Dtype) (shape: Shape) (kernelSize: int[]) (stride: int[]) (padding: int[]) =
-        match dtype with 
-        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxpool2d" dtype
-        | _ ->
-        if shape.Length <> 4 then failwithf "Expecting a 4d tensor (NxCxHxW: batchSize x inputChannels x inputHeight x inputWidth), received tensor with shape %A" shape
-        if kernelSize.[0] < 1 || kernelSize.[1] < 1 then failwithf "Expecting all kernelSizes (%A) >= 1" kernelSize
-        if padding.[0] < 0 || padding.[1] < 0 then failwithf "Expecting all paddings (%A) >= 0" padding
-        if padding.[0] > kernelSize.[0]/2 || padding.[1] > kernelSize.[1]/2 then failwithf "Expecting all paddings (%A) < kernelSizes (%A) / 2" padding kernelSize
-        if stride.[0] < 1 || stride.[1] < 1 then failwithf "Expecting all strides (%A) >= 1" stride
-        let batchSize = shape.[0]
-        let channels = shape.[1]
-        let inputHeight = shape.[2]
-        let inputWidth = shape.[3]
-        let kernelHeight = kernelSize.[0]
-        let kernelWidth = kernelSize.[1]
-        let inputHeightAfterPadding = inputHeight + 2*padding.[0]
-        let inputWidthAfterPadding = inputWidth + 2*padding.[1]
-        if kernelSize.[0] > inputHeightAfterPadding then failwithf "Expecting kernelSize.[0] (%A) <= inputHeightAfterPadding (%A)" kernelSize.[0] inputHeightAfterPadding
-        if kernelSize.[1] > inputWidthAfterPadding then failwithf "Expecting kernelSize.[1] (%A) <= inputWidthAfterPadding (%A)" kernelSize.[1] inputWidthAfterPadding
-        let outputHeight = int (floor (float (inputHeight + 2*padding.[0] - kernelHeight)/(float stride.[0]))) + 1
-        let outputWidth = int (floor (float (inputWidth + 2*padding.[1] - kernelWidth)/(float stride.[1]))) + 1
-        let outputShape = [|batchSize; channels; outputHeight; outputWidth|]
-        (batchSize, channels, (inputHeight, inputWidth), (kernelHeight, kernelWidth), (outputHeight, outputWidth), outputShape)
-
-    let checkCanMaxpool3d (dtype: Dtype) (shape: Shape) (kernelSize: int[]) (stride: int[]) (padding: int[]) =
-        match dtype with 
-        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxpool3d" dtype
-        | _ ->
-        if shape.Length <> 5 then failwithf "Expecting a 5d tensor (NxCxDxHxW: batchSize x inputChannels x inputDepth x inputHeight x inputWidth), received tensor with shape %A" shape
-        if kernelSize.[0] < 1 || kernelSize.[1] < 1 || kernelSize.[2] < 1 then failwithf "Expecting all kernelSizes (%A) >= 1" kernelSize
-        if padding.[0] < 0 || padding.[1] < 0 || padding.[2] < 0 then failwithf "Expecting all paddings (%A) >= 0" padding
-        if padding.[0] > kernelSize.[0]/2 || padding.[1] > kernelSize.[1]/2 || padding.[2] > kernelSize.[2]/2 then failwithf "Expecting all paddings (%A) < kernelSizes (%A) / 2" padding kernelSize
-        if stride.[0] < 1 || stride.[1] < 1 || stride.[2] < 1 then failwithf "Expecting all strides (%A) >= 1" stride
-        let batchSize = shape.[0]
-        let channels = shape.[1]
-        let inputDepth = shape.[2]
-        let inputHeight = shape.[3]
-        let inputWidth = shape.[4]
-        let kernelDepth = kernelSize.[0]
-        let kernelHeight = kernelSize.[1]
-        let kernelWidth = kernelSize.[2]
-        let inputDepthAfterPadding = inputDepth + 2*padding.[0]
-        let inputHeightAfterPadding = inputHeight + 2*padding.[1]
-        let inputWidthAfterPadding = inputWidth + 2*padding.[2]
-        if kernelSize.[0] > inputDepthAfterPadding then failwithf "Expecting kernelSize.[0] (%A) <= inputDepthAfterPadding (%A)" kernelSize.[0] inputDepthAfterPadding
-        if kernelSize.[1] > inputHeightAfterPadding then failwithf "Expecting kernelSize.[1] (%A) <= inputHeightAfterPadding (%A)" kernelSize.[1] inputHeightAfterPadding
-        if kernelSize.[2] > inputWidthAfterPadding then failwithf "Expecting kernelSize.[1] (%A) <= inputWidthAfterPadding (%A)" kernelSize.[1] inputWidthAfterPadding
-        let outputDepth = int (floor (float (inputDepth + 2*padding.[0] - kernelDepth)/(float stride.[0]))) + 1
-        let outputHeight = int (floor (float (inputHeight + 2*padding.[1] - kernelHeight)/(float stride.[1]))) + 1
-        let outputWidth = int (floor (float (inputWidth + 2*padding.[2] - kernelWidth)/(float stride.[2]))) + 1
-        let outputShape = [|batchSize; channels; outputDepth; outputHeight; outputWidth|]
-        (batchSize, channels, (inputDepth, inputHeight, inputWidth), (kernelDepth, kernelHeight, kernelWidth), (outputDepth, outputHeight, outputWidth), outputShape)
-
-    let checkCanMaxunpool1d (dtype: Dtype) (shape: Shape) (indicesDtype: Dtype) (indicesShape: Shape) (outputSize: int[]) =
-        match dtype with 
-        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxunpool2d" dtype
-        | _ ->
-        if indicesDtype <> Dtype.Int32 then failwithf "Expecting indices to have type %A" Dtype.Int32
-        if outputSize.Length <> 3 then failwithf "Expecting outputSize (%A) to be 3-dimensional" outputSize
-        let batchSize = shape.[0]
-        let channels = shape.[1]
-        let inputSize = shape.[2]
-        if outputSize.[0] <> indicesShape.[0] || outputSize.[1] <> indicesShape.[1] then failwithf "Expecting the first two elements of outputSize (%A) and indicesShape (%A) to be the same" outputSize indicesShape
-        let outputShape = [|batchSize; channels; outputSize.[2]|]
-        batchSize, channels, inputSize, outputShape
-
-    let checkCanMaxunpool2d (dtype: Dtype) (shape: Shape) (indicesDtype: Dtype) (indicesShape: Shape) (outputSize: int[]) =
-        match dtype with 
-        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxunpool2d" dtype
-        | _ ->
-        if indicesDtype <> Dtype.Int32 then failwithf "Expecting indices to have type %A" Dtype.Int32
-        if outputSize.Length <> 4 then failwithf "Expecting outputSize (%A) to be 4-dimensional" outputSize
-        let batchSize = shape.[0]
-        let channels = shape.[1]
-        let inputHeight = shape.[2]
-        let inputWidth = shape.[3]
-        if outputSize.[0] <> indicesShape.[0] || outputSize.[1] <> indicesShape.[1] then failwithf "Expecting the first two elements of outputSize (%A) and indicesShape (%A) to be the same" outputSize indicesShape
-        let outputShape = [|batchSize; channels; outputSize.[2]; outputSize.[3]|]
-        batchSize, channels, (inputHeight, inputWidth), outputShape
-
-    let checkCanMaxunpool3d (dtype: Dtype) (shape: Shape) (indicesDtype: Dtype) (indicesShape: Shape) (outputSize: int[]) =
-        match dtype with 
-        | Dtype.Bool | Dtype.Integral -> opNotSupported "maxunpool2d" dtype
-        | _ ->
-        if indicesDtype <> Dtype.Int32 then failwithf "Expecting indices to have type %A" Dtype.Int32
-        if outputSize.Length <> 5 then failwithf "Expecting outputSize (%A) to be 5-dimensional" outputSize
-        let batchSize = shape.[0]
-        let channels = shape.[1]
-        let inputDepth = shape.[2]
-        let inputHeight = shape.[3]
-        let inputWidth = shape.[4]
-        if outputSize.[0] <> indicesShape.[0] || outputSize.[1] <> indicesShape.[1] then failwithf "Expecting the first two elements of outputSize (%A) and indicesShape (%A) to be the same" outputSize indicesShape
-        let outputShape = [|batchSize; channels; outputSize.[2]; outputSize.[3]; outputSize.[4]|]
-        batchSize, channels, (inputDepth, inputHeight, inputWidth), outputShape
-
-    let canExpand (oldShape: Shape) (newShape: Shape) =
-        newShape.Length >= oldShape.Length &&
-        let trim = newShape.Length - oldShape.Length
-        (oldShape,newShape.[trim..]) ||> Array.forall2 (fun n m -> n = 1 || n = m)
-
-    let checkCanExpand (oldShape: Shape) (newShape: Shape) =
-        let isOK = canExpand oldShape newShape
-        if not isOK then failwithf "can't expand from shape %A to %A - each dimension must either be equal or expand from 1" oldShape newShape
-
-    let checkCanTranspose (shape: Shape) (dim0: int) (dim1: int) =
-        if dim0 < 0 || dim0 >= shape.Length then failwithf "Expecting 0 <= dim0 (%A) < shape.Length (%A)" dim0 shape.Length
-        if dim1 < 0 || dim1 >= shape.Length then failwithf "Expecting 0 <= dim1 (%A) < shape.Length (%A)" dim1 shape.Length
-
-    let checkCanTranspose2d (dim: int) =
-        if dim <> 2 then failwith "Expecting dim=2 when no specific dimensions are given to transpose. Consider using general transpose(dim0, dim1)."
-
-    let checkCanFlip (dim: int) (dims: int[]) =
-        if dims.Length > dim then failwithf "Expecting dims (list of dimension indices to flip) of length less than Tensor's dimensions, received %A, %A" dims.Length dim
-        if hasDuplicates dims then failwithf "Expecting dims (list of dimension indices to flip) without repetition, received %A" dims
-        if (Array.max dims) >= dim then failwithf "Expecting dims (list of dimension indices to flip) where all indices are less than the tensor dimension, received %A, %A" dims dim
-
-    let checkCanRepeat (shape: Shape) (dim: int) =
-        if shape.[dim] <> 1 then failwithf "Expecting Tensor's shape (%A) at dim (%A) to be 1" shape dim
-
-    let checkCanDilate (dim: int) (dilations: int[]) =
-        if dilations.Length <> dim then failwithf "Expecting dilations (dilation to use in each dimension) of same length with Tensor's dimensions, received %A, %A" dilations.Length dim
-        if (Array.min dilations) < 1 then failwithf "Expecting dilations (dilation to use in each dimension) >= 1 where 1 represents no dilation, received %A" dilations
-
-    let checkCanGather (shape: Shape) (dim: int) (indicesShape: Shape) (indicesDtype:Dtype) =
-        if shape.Length <> indicesShape.Length then failwithf "Expecting tensorShape (%A) and indicesShape (%A) to have the same number of dimensions" shape indicesShape
-        if dim < 0 || dim > shape.Length-1 then failwithf "Expecting 0<= dim (%A) < tensorShape.Length (%A)" dim shape.Length
-        if indicesShape.[dim] < 1 then failwithf "Expecting indicesShape.[dim] (%A) >= 1" indicesShape.[dim]
-        if indicesDtype <> Dtype.Int32 then failwithf "Expecting indices to have type %A" Dtype.Int32
-
-    let checkCanView (shape1: Shape) (shape2: Shape) =
-        if shapeLength shape1 <> shapeLength shape2 then failwithf "Cannot view Tensor of shape %A as shape %A" shape1 shape2
-
-    let checkCanFlatten (shape: Shape) (startDim: int) (endDim: int) =
-        if startDim < 0 || startDim >= shape.Length then failwithf "Expecting 0 <= startDim (%A) < %A" startDim shape.Length
-        if endDim < 0 || endDim >= shape.Length then failwithf "Expecting 0 <= endDim (%A) < %A" endDim shape.Length
-        if endDim <= startDim then failwithf "Expecting startDim (%A) < endDim (%A)" startDim endDim
-
-    let checkCanAddSlice (shape1: Shape) (location: int[]) (shape2: Shape) =
-        if not (contains shape1 shape2) then failwithf "Expecting shape1 to contain shape2, received %A, %A" shape1 shape2
-        if location.Length <> shape1.Length then failwithf "Expecting location of the same length as shape1, received %A, %A" (location.Length) shape1
-
-    let checkCanMatmul (shape1: Shape) (shape2: Shape) =
-        if shape1.Length <> 2 || shape2.Length <> 2 then failwithf "Expecting two 2d Tensors, received Tensors with shapes %A, %A" shape1 shape2
-        if shape1.[1] <> shape2.[0] then failwithf "Cannot multiply Tensors with shapes %A, %A" shape1 shape2
-
-    let checkCanDot (shape1: Shape) (shape2: Shape) =
-        if shape1.Length <> 1 || shape2.Length <> 1 then failwithf "Expecting two vectors (1d Tensors), received Tensors with shapes %A, %A" shape1 shape2
-        if shape1.[0] <> shape2.[0] then failwithf "Cannot multiply vectors with different lengths %A, %A" shape1.[0] shape2.[0]
-
-    let checkCanPad (shape: Shape) (paddings: int[]) =
-        if shape.Length <> paddings.Length then failwithf "Expecting shape (%A) and paddings (%A) to have the same length" shape paddings
-        if not (paddings |> Array.forall (fun p -> p >= 0)) then failwithf "Expecting all paddings (%A) >= 0" paddings
-
-    let checkCanDropout (p:double) =
-        if p < 0. || p > 1. then failwithf "Expecting 0 <= p <= 1, but received %A" p
-
-    let checkCanDropout2d (shape: Shape) (p:double) =
-        checkCanDropout p
-        if shape.Length <> 4 then failwithf "Expecting shape (%A) to be 4-dimensional (NxCxHxW: batchSize, inputChannels, inputHeight, inputWidth)" shape
-
-    let checkCanDropout3d (shape: Shape) (p:double) =
-        checkCanDropout p
-        if shape.Length <> 5 then failwithf "Expecting shape (%A) to be 5-dimensional (NxCxDxHxW: batchSize, inputChannels, inputDepth, inputHeight, inputWidth)" shape
-
-    let squeeze (dim: int) (shape: Shape) =
-        if dim = -1 then
-            [|for s in shape do if s <> 1 then yield s|]
-        elif shape.[dim] = 1 then
-            [|for i=0 to shape.Length - 1 do 
-                if i < dim then yield shape.[i]
-                elif i > dim then yield shape.[i]|]
-        else
-            shape
-
-    let checkCanUnsqueeze (dim: int) (shape: Shape) =
-        if dim < 0 || dim > shape.Length then failwithf "Expecting dim in range [0, %A] but received %A" shape.Length dim
-        [|for i=0 to shape.Length - 1 + 1 do 
-            if i < dim then yield shape.[i]
-            elif i = dim then yield 1
-            else yield shape.[i-1]|]
-
-    let unsqueezeAs (shape1: Shape) (shape2: Shape) =
-        if shape1.Length > shape2.Length then failwithf "Expecting shape1.Length (%A) <= shape2.Length (%A)" shape1.Length shape2.Length
-        let ones = Array.create (shape2.Length - shape1.Length) 1
-        Array.append ones shape1
-
-    let locationToBounds (shape: Shape) (location: int[]) =
-        Array2D.init location.Length 3 (fun i j -> if j=0 then location.[i] elif j=1 then location.[i] + shape.[i] - 1 else 1)
-
-    let flatten (startDim: int) (endDim: int) (shape: Shape) =
-        let shape = [|for i in 0..shape.Length-1 do if (i < startDim) || (i > endDim) then shape.[i] else -1|]
-        let mutable emitted = false
-        [|for s in shape do if s <> -1 then s elif not emitted then emitted <- true; -1|]
-
-    /// Find the shape into which shape1 and shape2 can be expanded
-    let broadcast2 (shape1: Shape) (shape2: Shape) =
-        if canExpand shape1 shape2 || canExpand shape2 shape1 then 
-            let n1 = shape1.Length
-            let n2 = shape2.Length
-            let mx = max n1 n2
-            let mn = mx - min n1 n2
-            Array.init mx (fun i -> 
-                if i < mn then (if n1 > n2 then shape1.[i] else shape2.[i])
-                elif n1 > n2 then max shape1.[i] shape2.[i-mn]
-                else max shape1.[i-mn] shape2.[i])
-        else failwithf "shapes %A and %A are not related by broadcasting - each dimension must either be extra, equal, expand from 1" shape1 shape2
-
-    /// Find the shape into which all the shapes can be expanded
-    let broadcastShapes (shapes: Shape[]) = Array.reduce broadcast2 shapes
-
-    let dilated (shape: Shape) (dilations: int[]) =
-        Array.map2 (fun n d -> n + (n - 1) * (d - 1)) shape dilations
-
-    let dilated2 (shape: Shape) (dilations: int[]) =
-        Array.map2 (*) shape dilations
-
-    let undilatedShape (shape: Shape) (dilations: int[]) =
-        Array.map2 (fun n d -> (n + d - 1) / d) shape dilations
-
-    let complete (nelement: int) (shape: Shape) =
-        if (shape |> Array.filter (fun x -> x < -1) |> Array.length) > 0 then failwithf "Invalid shape %A" shape
-        let numUnspecified = shape |> Array.filter ((=) -1) |> Array.length
-        if numUnspecified > 1 then
-            failwithf "Cannot complete shape %A, expecting at most one unspecified dimension (-1)" shape
-        elif numUnspecified = 0 then 
-            shape
-        else
-            let divisor = shape |> Array.filter ((<>) -1) |> shapeLength
-            if nelement % divisor <> 0 then failwithf "Cannot complete shape %A to have %A elements" shape nelement
-            let missing = nelement / divisor
-            [|for d in shape do if d = -1 then yield missing else yield d|]
-
-    let completeDim (dims:int) (dim:int) =
-      if dim < -dims || dim >= dims then failwithf "Invalid choice (%A) for dim (%A)" dim dims
-      if dim < 0 then dims+dim
-      else dim    
-
-
-module Array =
-    [<ExcludeFromCodeCoverage>]
-    let inline allClose (relativeTolerance:'T) (absoluteTolerance:'T) (array1:'T[]) (array2:'T[]) =
-        let dim1 = array1.Length
-        let dim2 = array2.Length
-        if dim1 <> dim2 then false
-        else (array1,array2) ||> Array.forall2 (fun a b -> abs(a-b) <= absoluteTolerance + relativeTolerance*abs(b)) 
-
-let boundsToLocation (bounds: int[,]) =
-    [|for i=0 to bounds.GetLength(0) - 1 do yield bounds.[i, 0]|]
-
-let boundsToShape (bounds: int[,]) =
-    [|for i=0 to bounds.GetLength(0) - 1 do yield bounds.[i, 1] - bounds.[i, 0] + 1|] 
-
-let mirrorCoordinates (coordinates: int[]) (shape: Shape) (mirrorDims: int[]) =
-    if coordinates.Length <> shape.Length then failwithf "Expecting coordinates and shape of the same dimension, received %A, %A" coordinates.Length shape.Length
-    let result = Array.copy coordinates
-    for d=0 to coordinates.Length-1 do
-        if mirrorDims |> Array.contains d then
-            result.[d] <- abs (coordinates.[d] - shape.[d] + 1)
-    result
-
-let dilatedCoordinates (coordinates: int[]) (dilations: int[]) =
-    Array.map2 (*) coordinates dilations
-
-let checkValidIndex (shape: Shape) (index: int[]) =
-    if shape.Length <> index.Length then failwithf "Expecting shape (%A) and index (%A) to have the same length" shape index
-    let valid = Array.forall2 (fun s i -> i < s) shape index
-    if not valid then failwithf "index (%A) is not valid for shape (%A)" index shape
-
-let indexToFlatIndex (shape: Shape) (index: int[]) =
-    checkValidIndex shape index
-    let mutable flatIndex = 0
-    for i=0 to index.Length - 1 do
-        let v = if i = index.Length - 1 then 1 else (Array.reduce (*) shape.[i+1..])
-        flatIndex <- flatIndex + index.[i] * v
-    flatIndex
-
-let flatIndexToIndex (shape: Shape) (flatIndex: int) =
-    let dim = shape.Length
-    let nelement = shapeLength shape
-    let index = Array.create dim 0
-    let mutable mul = nelement
-    let mutable fi = flatIndex
-    for i=dim downto 1 do
-        mul <- mul / shape.[dim-i]
-        index.[i-1] <- fi / mul
-        fi <- fi - index.[i-1] * mul
-    index |> Array.rev
-    
-/// Create a non-jagged 3D array from jagged data
-let array3D data = 
-    let data = data |> Array.ofSeq |> Array.map array2D
-    let r1, r2, r3 = data.Length, data.[0].GetLength(0), data.[0].GetLength(1)
-    for i in 0 .. r1-1 do 
-        let q2 = data.[i].GetLength(0)
-        let q3 = data.[i].GetLength(1)
-        if q2 <> r2 || q3 <> r3 then 
-            invalidArg "data" (sprintf "jagged input at position %d: first is _ x %d x %d, later is _ x _ x %d x %d" i r2 r3 q2 q3)
-    Array3D.init r1 r2 r3 (fun i j k -> data.[i].[j,k])
-
-/// Create a non-jagged 4D array from jagged data
-let array4D data = 
-    let data = data |> array2D |> Array2D.map array2D
-    let r1,r2,r3,r4 = (data.GetLength(0), data.GetLength(1), data.[0,0].GetLength(0),data.[0,0].GetLength(1))
-    for i in 0 .. r1-1 do 
-      for j in 0 .. r2-1 do 
-        let q3 = data.[i,j].GetLength(0)
-        let q4 = data.[i,j].GetLength(1)
-        if q3 <> r3 || q4 <> r4 then 
-            invalidArg "data" (sprintf "jagged input at position (%d,%d): first is _ x _ x %d x %d, later is _ x _ x %d x %d" i j r2 r3 q3 q4)
-    Array4D.init r1 r2 r3 r4 (fun i j k m -> data.[i,j].[k,m])
-
-let arrayND (shape: Shape) f =
-    match shape with 
-    | [| |] -> f [| |] |> box
-    | [| d0 |] -> Array.init d0 (fun i -> f [| i |]) |> box
-    | [| d0; d1 |] -> Array2D.init d0 d1 (fun i1 i2 -> f [| i1; i2 |]) |> box
-    | [| d0; d1; d2 |] -> Array3D.init d0 d1 d2 (fun i1 i2 i3 -> f [| i1; i2; i3 |]) |> box
-    | [| d0; d1; d2; d3 |] -> Array4D.init d0 d1 d2 d3 (fun i1 i2 i3 i4 -> f [| i1; i2; i3; i4 |]) |> box
-    | _ -> failwith "arrayND - nyi for dim > 4"
-
-/// Get the elements of an arbitrary IEnumerble
-let private seqElements (ie: obj) = 
-    let e = (ie :?> IEnumerable).GetEnumerator()
-    [| while e.MoveNext() do yield e.Current |]
-
-/// Match an array type of arbitrary rank
-let private (|ArrayTy|_|) (ty: Type) = 
-    if ty.IsArray && ty.GetArrayRank() <= 4 then
-        Some(ty.GetArrayRank(), ty.GetElementType())
-    else 
-       None
-
-/// Match an tuple type
-let private (|TupleTy|_|) (ty: Type) = 
-    if FSharpType.IsTuple ty then 
-        Some(FSharpType.GetTupleElements ty)
-    else 
-       None
-
-let rec private  (|ListTy|_|) (ty: Type) = 
-    if ty.IsGenericType && ty.GetGenericTypeDefinition().Equals(typedefof<list<int>>) then
-       Some (ty.GetGenericArguments().[0])
-    else   
-        None
-
-/// Match a 1D sequence type (seq<_>) or a subclass
-let rec private  (|SeqTy|_|) (ty: Type) = 
-    if ty.IsGenericType && ty.GetGenericTypeDefinition().Equals(typedefof<seq<int>>) then
-       Some (ty.GetGenericArguments().[0])
-    else   
-        match ty.BaseType with 
-        | null -> None 
-        | _ -> 
+[<AutoOpen>]
+module UtilAutoOpens =
+    let logSqrt2Pi = log(sqrt(2. * Math.PI))
+
+    let log10Val = log 10.
+
+    /// Create a non-jagged 3D array from jagged data
+    let array3D data = 
+        let data = data |> Array.ofSeq |> Array.map array2D
+        let r1, r2, r3 = data.Length, data.[0].GetLength(0), data.[0].GetLength(1)
+        for i in 0 .. r1-1 do 
+            let q2 = data.[i].GetLength(0)
+            let q3 = data.[i].GetLength(1)
+            if q2 <> r2 || q3 <> r3 then 
+                invalidArg "data" (sprintf "jagged input at position %d: first is _ x %d x %d, later is _ x _ x %d x %d" i r2 r3 q2 q3)
+        Array3D.init r1 r2 r3 (fun i j k -> data.[i].[j,k])
+
+    /// Create a non-jagged 4D array from jagged data
+    let array4D data = 
+        let data = data |> array2D |> Array2D.map array2D
+        let r1,r2,r3,r4 = (data.GetLength(0), data.GetLength(1), data.[0,0].GetLength(0),data.[0,0].GetLength(1))
+        for i in 0 .. r1-1 do 
+          for j in 0 .. r2-1 do 
+            let q3 = data.[i,j].GetLength(0)
+            let q4 = data.[i,j].GetLength(1)
+            if q3 <> r3 || q4 <> r4 then 
+                invalidArg "data" (sprintf "jagged input at position (%d,%d): first is _ x _ x %d x %d, later is _ x _ x %d x %d" i j r2 r3 q3 q4)
+        Array4D.init r1 r2 r3 r4 (fun i j k m -> data.[i,j].[k,m])
+
+    let arrayND (shape: Shape) f =
+        match shape with 
+        | [| |] -> f [| |] |> box
+        | [| d0 |] -> Array.init d0 (fun i -> f [| i |]) |> box
+        | [| d0; d1 |] -> Array2D.init d0 d1 (fun i1 i2 -> f [| i1; i2 |]) |> box
+        | [| d0; d1; d2 |] -> Array3D.init d0 d1 d2 (fun i1 i2 i3 -> f [| i1; i2; i3 |]) |> box
+        | [| d0; d1; d2; d3 |] -> Array4D.init d0 d1 d2 d3 (fun i1 i2 i3 i4 -> f [| i1; i2; i3; i4 |]) |> box
+        | _ -> failwith "arrayND - nyi for dim > 4"
+
+    /// Get the elements of an arbitrary IEnumerble
+    let private seqElements (ie: obj) = 
+        let e = (ie :?> IEnumerable).GetEnumerator()
+        [| while e.MoveNext() do yield e.Current |]
+
+    /// Match an array type of arbitrary rank
+    let private (|ArrayTy|_|) (ty: Type) = 
+        if ty.IsArray && ty.GetArrayRank() <= 4 then
+            Some(ty.GetArrayRank(), ty.GetElementType())
+        else 
+           None
+
+    /// Match an tuple type
+    let private (|TupleTy|_|) (ty: Type) = 
+        if FSharpType.IsTuple ty then 
+            Some(FSharpType.GetTupleElements ty)
+        else 
+           None
+
+    let rec private  (|ListTy|_|) (ty: Type) = 
+        if ty.IsGenericType && ty.GetGenericTypeDefinition().Equals(typedefof<list<int>>) then
+           Some (ty.GetGenericArguments().[0])
+        else   
+            None
+
+    /// Match a 1D sequence type (seq<_>) or a subclass
+    let rec private  (|SeqTy|_|) (ty: Type) = 
+        if ty.IsGenericType && ty.GetGenericTypeDefinition().Equals(typedefof<seq<int>>) then
+           Some (ty.GetGenericArguments().[0])
+        else   
             match ty.BaseType with 
-            | SeqTy ety -> Some ety
+            | null -> None 
             | _ -> 
-                ty.GetInterfaces() |> Array.tryPick (|SeqTy|_|)
+                match ty.BaseType with 
+                | SeqTy ety -> Some ety
+                | _ -> 
+                    ty.GetInterfaces() |> Array.tryPick (|SeqTy|_|)
 
-let rec formatType (ty: Type) = 
-    match ty with 
-    | ListTy ety -> sprintf "list<%s>" (formatType ety)
-    | ArrayTy (_,ety) -> sprintf "%s[]" (formatType ety)
-    | SeqTy ety -> sprintf "seq<%s>" (formatType ety)
-    | TupleTy etys -> String.concat "*" (Array.map formatType etys)
-    | ty when ty = typeof<int64> -> "int64"
-    | ty when ty = typeof<int> -> "int"
-    | ty when ty = typeof<double> -> "double"
-    | ty when ty = typeof<float32> -> "float32"
-    | _ -> ty.ToString()
+    let rec formatType (ty: Type) = 
+        match ty with 
+        | ListTy ety -> sprintf "list<%s>" (formatType ety)
+        | ArrayTy (_,ety) -> sprintf "%s[]" (formatType ety)
+        | SeqTy ety -> sprintf "seq<%s>" (formatType ety)
+        | TupleTy etys -> String.concat "*" (Array.map formatType etys)
+        | ty when ty = typeof<int64> -> "int64"
+        | ty when ty = typeof<int> -> "int"
+        | ty when ty = typeof<double> -> "double"
+        | ty when ty = typeof<float32> -> "float32"
+        | _ -> ty.ToString()
 
-let private (|SeqTupleTy|_|) (ty: Type) = 
-    match ty with 
-    | SeqTy (TupleTy etys) -> 
-        match etys |> Array.tryFind (fun ety -> ety <> etys.[0]) with
-        | None -> ()
-        | Some ety2 -> failwithf "jagged input: unexpected mixed types in tuple being used as sequence notation, %s and %s" (formatType etys.[0]) (formatType ety2)
-        Some (etys.[0])
-    | _ -> None
+    let private (|SeqTupleTy|_|) (ty: Type) = 
+        match ty with 
+        | SeqTy (TupleTy etys) -> 
+            match etys |> Array.tryFind (fun ety -> ety <> etys.[0]) with
+            | None -> ()
+            | Some ety2 -> failwithf "jagged input: unexpected mixed types in tuple being used as sequence notation, %s and %s" (formatType etys.[0]) (formatType ety2)
+            Some (etys.[0])
+        | _ -> None
 
-let private (|TupleLeafTy|_|) (tgt: Type) (ty: Type) = 
-    match ty with 
-    | TupleTy etys when etys |> Array.forall (fun ety -> ety = tgt) -> Some ()
-    | _ -> None
+    let private (|TupleLeafTy|_|) (tgt: Type) (ty: Type) = 
+        match ty with 
+        | TupleTy etys when etys |> Array.forall (fun ety -> ety = tgt) -> Some ()
+        | _ -> None
 
-let private (|SeqTupleLeafTy|_|) (tgt: Type) (ty: Type) = 
-    match ty with 
-    | SeqTy (TupleLeafTy tgt) -> Some ()
-    | _ -> None
+    let private (|SeqTupleLeafTy|_|) (tgt: Type) (ty: Type) = 
+        match ty with 
+        | SeqTy (TupleLeafTy tgt) -> Some ()
+        | _ -> None
 
-let private flatArrayAndShape1D<'T> (v: 'T[]) =
-    v, [|Array.length v|]
+    let private flatArrayAndShape1D<'T> (v: 'T[]) =
+        v, [|Array.length v|]
 
-let private flatArrayAndShape2D<'T> (v: 'T[,]) =
-    let n1 = Array2D.length1 v
-    let n2 = Array2D.length2 v
-    let arr =
-        [|  for i=0 to n1-1 do
-                for j=0 to n2-1 do
-                   yield v.[i, j] |]
-    arr, [| n1;n2|]
+    let private flatArrayAndShape2D<'T> (v: 'T[,]) =
+        let n1 = Array2D.length1 v
+        let n2 = Array2D.length2 v
+        let arr =
+            [|  for i=0 to n1-1 do
+                    for j=0 to n2-1 do
+                       yield v.[i, j] |]
+        arr, [| n1;n2|]
 
-let private flatArrayAndShape3D<'T> (v: 'T[,,]) =
-    let n1 = Array3D.length1 v
-    let n2 = Array3D.length2 v
-    let n3 = Array3D.length3 v
-    let arr =
-        [|  for i=0 to n1-1 do
-                for j=0 to n2-1 do
-                    for k=0 to n3-1 do
-                        yield v.[i, j, k] |]
-    arr, [| n1;n2;n3 |]
+    let private flatArrayAndShape3D<'T> (v: 'T[,,]) =
+        let n1 = Array3D.length1 v
+        let n2 = Array3D.length2 v
+        let n3 = Array3D.length3 v
+        let arr =
+            [|  for i=0 to n1-1 do
+                    for j=0 to n2-1 do
+                        for k=0 to n3-1 do
+                            yield v.[i, j, k] |]
+        arr, [| n1;n2;n3 |]
 
-let private flatArrayAndShape4D<'T> (v: 'T[,,,]) =
-    let n1 = Array4D.length1 v
-    let n2 = Array4D.length2 v
-    let n3 = Array4D.length3 v
-    let n4 = Array4D.length4 v
-    let arr =
-        [|  for i=0 to n1-1 do
-                for j=0 to n2-1 do
-                    for k=0 to n3-1 do
-                        for m=0 to n4-1 do
-                            yield v.[i, j, k, m] |]
-    arr, [| n1;n2;n3;n4 |]
+    let private flatArrayAndShape4D<'T> (v: 'T[,,,]) =
+        let n1 = Array4D.length1 v
+        let n2 = Array4D.length2 v
+        let n3 = Array4D.length3 v
+        let n4 = Array4D.length4 v
+        let arr =
+            [|  for i=0 to n1-1 do
+                    for j=0 to n2-1 do
+                        for k=0 to n3-1 do
+                            for m=0 to n4-1 do
+                                yield v.[i, j, k, m] |]
+        arr, [| n1;n2;n3;n4 |]
 
-let private seqTupleElements (els: obj) =
-    match seqElements els with 
-    | [| el |] -> FSharpValue.GetTupleFields(el) 
-    | tup -> failwithf "unexpected multiple values in tuple list input: %A" (Array.toList tup)
+    let private seqTupleElements (els: obj) =
+        match seqElements els with 
+        | [| el |] -> FSharpValue.GetTupleFields(el) 
+        | tup -> failwithf "unexpected multiple values in tuple list input: %A" (Array.toList tup)
 
-let private arrayCast<'T> (els: obj[]) = els |> Array.map (fun v -> v :?> 'T)
+    let private arrayCast<'T> (els: obj[]) = els |> Array.map (fun v -> v :?> 'T)
 
-let private (|SeqOrSeqTupleTy|_|) ty =
-    match ty with 
-    | SeqTupleTy ety -> Some (seqTupleElements, ety)
-    | SeqTy ety -> Some (seqElements, ety)
-    | _ -> None
+    let private (|SeqOrSeqTupleTy|_|) ty =
+        match ty with 
+        | SeqTupleTy ety -> Some (seqTupleElements, ety)
+        | SeqTy ety -> Some (seqElements, ety)
+        | _ -> None
 
-let private (|SeqOrSeqTupleLeafTy|_|) tgt ty =
-    match ty with 
-    | SeqTupleLeafTy tgt -> Some (seqTupleElements)
-    | SeqTy ety when ety = tgt -> Some (seqElements)
-    | _ -> None
+    let private (|SeqOrSeqTupleLeafTy|_|) tgt ty =
+        match ty with 
+        | SeqTupleLeafTy tgt -> Some (seqTupleElements)
+        | SeqTy ety when ety = tgt -> Some (seqElements)
+        | _ -> None
 
-let rec tryFlatArrayAndShape<'T> (value:obj) : ('T[] * int[]) option =
+    let rec tryFlatArrayAndShape<'T> (value:obj) : ('T[] * int[]) option =
 
-    match value with
-    | :? 'T as v -> Some ([|v|], [||])
-    | :? ('T[]) as v -> Some (flatArrayAndShape1D v)
-    | :? ('T[,]) as v -> Some (flatArrayAndShape2D<'T> v)
-    | :? ('T[,,]) as v -> Some (flatArrayAndShape3D<'T> v)
-    | :? ('T[,,,]) as v -> Some (flatArrayAndShape4D<'T> v)
-    | :? seq<'T> as v -> Some (flatArrayAndShape1D (Seq.toArray v))
-    | :? seq<seq<'T>> as v -> Some (flatArrayAndShape2D (array2D v))
-    | :? seq<seq<seq<'T>>> as v -> Some (flatArrayAndShape3D (array3D v))
-    | :? seq<seq<seq<seq<'T>>>> as v -> Some (flatArrayAndShape4D (array4D v))
-    | _ -> 
-    let vty = value.GetType()
-    let tgt = (typeof<'T>)
-    match vty with
-    // list<int * int> -> dim 1
-    | SeqTupleLeafTy tgt -> 
-        let arr = value |> seqTupleElements |> arrayCast<'T>
-        Some (arr, [| arr.Length |])
-    // list<list<int * int>> etc. -> dim 2
-    | SeqOrSeqTupleTy (fetcher, (SeqOrSeqTupleLeafTy tgt fetcher2)) -> 
-        let els = value |> fetcher |> Array.map (fetcher2 >> arrayCast<'T>) |> array2D
-        Some (flatArrayAndShape2D<'T> els)
-    // ... -> dim 3
-    | SeqOrSeqTupleTy (fetcher1, SeqOrSeqTupleTy (fetcher2, SeqOrSeqTupleLeafTy tgt fetcher3)) -> 
-        let els = value |> fetcher1 |> Array.map (fetcher2 >> Array.map (fetcher3 >> arrayCast<'T>)) |> array3D
-        Some (flatArrayAndShape3D<'T> els)
-    // ... -> dim 4
-    | SeqOrSeqTupleTy (fetcher1, SeqOrSeqTupleTy (fetcher2, SeqOrSeqTupleTy (fetcher3, SeqOrSeqTupleLeafTy tgt fetcher4))) -> 
-        let els = value |> fetcher1 |> Array.map (fetcher2 >> Array.map (fetcher3 >> Array.map (fetcher4 >> arrayCast<'T>))) |> array4D
-        Some (flatArrayAndShape4D<'T> els)
-    | _ -> None
+        match value with
+        | :? 'T as v -> Some ([|v|], [||])
+        | :? ('T[]) as v -> Some (flatArrayAndShape1D v)
+        | :? ('T[,]) as v -> Some (flatArrayAndShape2D<'T> v)
+        | :? ('T[,,]) as v -> Some (flatArrayAndShape3D<'T> v)
+        | :? ('T[,,,]) as v -> Some (flatArrayAndShape4D<'T> v)
+        | :? seq<'T> as v -> Some (flatArrayAndShape1D (Seq.toArray v))
+        | :? seq<seq<'T>> as v -> Some (flatArrayAndShape2D (array2D v))
+        | :? seq<seq<seq<'T>>> as v -> Some (flatArrayAndShape3D (array3D v))
+        | :? seq<seq<seq<seq<'T>>>> as v -> Some (flatArrayAndShape4D (array4D v))
+        | _ -> 
+        let vty = value.GetType()
+        let tgt = (typeof<'T>)
+        match vty with
+        // list<int * int> -> dim 1
+        | SeqTupleLeafTy tgt -> 
+            let arr = value |> seqTupleElements |> arrayCast<'T>
+            Some (arr, [| arr.Length |])
+        // list<list<int * int>> etc. -> dim 2
+        | SeqOrSeqTupleTy (fetcher, (SeqOrSeqTupleLeafTy tgt fetcher2)) -> 
+            let els = value |> fetcher |> Array.map (fetcher2 >> arrayCast<'T>) |> array2D
+            Some (flatArrayAndShape2D<'T> els)
+        // ... -> dim 3
+        | SeqOrSeqTupleTy (fetcher1, SeqOrSeqTupleTy (fetcher2, SeqOrSeqTupleLeafTy tgt fetcher3)) -> 
+            let els = value |> fetcher1 |> Array.map (fetcher2 >> Array.map (fetcher3 >> arrayCast<'T>)) |> array3D
+            Some (flatArrayAndShape3D<'T> els)
+        // ... -> dim 4
+        | SeqOrSeqTupleTy (fetcher1, SeqOrSeqTupleTy (fetcher2, SeqOrSeqTupleTy (fetcher3, SeqOrSeqTupleLeafTy tgt fetcher4))) -> 
+            let els = value |> fetcher1 |> Array.map (fetcher2 >> Array.map (fetcher3 >> Array.map (fetcher4 >> arrayCast<'T>))) |> array4D
+            Some (flatArrayAndShape4D<'T> els)
+        | _ -> None
 
-[<ExcludeFromCodeCoverage>]
-let inline dataOfValues ofFloat32 ofFloat64 ofInt8 ofInt16 ofInt32 ofInt64 ofBool ofByte (value:obj) : (^T[] * int[]) = 
-    match value |> tryFlatArrayAndShape<float32> with
-    | Some (values, shape) -> (values |> Array.map ofFloat32, shape)
-    | None -> 
-    match value |> tryFlatArrayAndShape<double> with
-    | Some (values, shape) -> (values |> Array.map ofFloat64, shape) 
-    | None -> 
-    match value |> tryFlatArrayAndShape<int32> with
-    | Some (values, shape) -> (values |> Array.map ofInt32, shape) 
-    | None -> 
-    match value |> tryFlatArrayAndShape<int64> with
-    | Some (values, shape) -> (values |> Array.map ofInt64, shape)
-    | None -> 
-    match value |> tryFlatArrayAndShape<int8>  with
-    | Some (values, shape) -> (values |> Array.map ofInt8, shape)
-    | None -> 
-    match value |> tryFlatArrayAndShape<byte>  with
-    | Some (values, shape) -> (values |> Array.map ofByte, shape)
-    | None -> 
-    match value |> tryFlatArrayAndShape<int16>  with
-    | Some (values, shape) -> (values |> Array.map ofInt16, shape)
-    | None -> 
-    match value |> tryFlatArrayAndShape<bool> with
-    | Some (values, shape) ->(values |> Array.map ofBool, shape) 
-    | _ -> failwithf "Cannot convert value of type %A to RawTensorCPU" (value.GetType())
+    [<ExcludeFromCodeCoverage>]
+    let inline dataOfValues ofFloat32 ofFloat64 ofInt8 ofInt16 ofInt32 ofInt64 ofBool ofByte (value:obj) : (^T[] * int[]) = 
+        match value |> tryFlatArrayAndShape<float32> with
+        | Some (values, shape) -> (values |> Array.map ofFloat32, shape)
+        | None -> 
+        match value |> tryFlatArrayAndShape<double> with
+        | Some (values, shape) -> (values |> Array.map ofFloat64, shape) 
+        | None -> 
+        match value |> tryFlatArrayAndShape<int32> with
+        | Some (values, shape) -> (values |> Array.map ofInt32, shape) 
+        | None -> 
+        match value |> tryFlatArrayAndShape<int64> with
+        | Some (values, shape) -> (values |> Array.map ofInt64, shape)
+        | None -> 
+        match value |> tryFlatArrayAndShape<int8>  with
+        | Some (values, shape) -> (values |> Array.map ofInt8, shape)
+        | None -> 
+        match value |> tryFlatArrayAndShape<byte>  with
+        | Some (values, shape) -> (values |> Array.map ofByte, shape)
+        | None -> 
+        match value |> tryFlatArrayAndShape<int16>  with
+        | Some (values, shape) -> (values |> Array.map ofInt16, shape)
+        | None -> 
+        match value |> tryFlatArrayAndShape<bool> with
+        | Some (values, shape) ->(values |> Array.map ofBool, shape) 
+        | _ -> failwithf "Cannot convert value of type %A to RawTensorCPU" (value.GetType())
 
-let dataOfValuesForFloat32 (value:obj) =
-    dataOfValues float32 float32 float32 float32 float32 float32 (fun x -> if x then 1.0f else 0.0f) float32 value 
+    let dataOfValuesForFloat32 (value:obj) =
+        dataOfValues float32 float32 float32 float32 float32 float32 (fun x -> if x then 1.0f else 0.0f) float32 value 
 
-let dataOfValuesForFloat64 (value:obj) =
-    dataOfValues double double double double double double (fun x -> if x then 1.0 else 0.0) double value 
+    let dataOfValuesForFloat64 (value:obj) =
+        dataOfValues double double double double double double (fun x -> if x then 1.0 else 0.0) double value 
 
-let dataOfValuesForByte (value:obj) =
-    dataOfValues byte byte byte byte byte byte (fun x -> if x then 1uy else 0uy) id value 
+    let dataOfValuesForByte (value:obj) =
+        dataOfValues byte byte byte byte byte byte (fun x -> if x then 1uy else 0uy) id value 
 
-let dataOfValuesForInt8 (value:obj) =
-    dataOfValues int8 int8 int8 int8 int8 int8 (fun x -> if x then 1y else 0y) int8 value 
+    let dataOfValuesForInt8 (value:obj) =
+        dataOfValues int8 int8 int8 int8 int8 int8 (fun x -> if x then 1y else 0y) int8 value 
 
-let dataOfValuesForInt16 (value:obj) =
-    dataOfValues int16 int16 int16 int16 int16 int16 (fun x -> if x then 1s else 0s) int16 value 
+    let dataOfValuesForInt16 (value:obj) =
+        dataOfValues int16 int16 int16 int16 int16 int16 (fun x -> if x then 1s else 0s) int16 value 
 
-let dataOfValuesForInt32 (value:obj) =
-    dataOfValues int32 int32 int32 int32 int32 int32 (fun x -> if x then 1 else 0) int32 value
+    let dataOfValuesForInt32 (value:obj) =
+        dataOfValues int32 int32 int32 int32 int32 int32 (fun x -> if x then 1 else 0) int32 value
 
-let dataOfValuesForInt64 (value:obj) =
-    dataOfValues int64 int64 int64 int64 int64 int64 (fun x -> if x then 1L else 0L) int64 value
+    let dataOfValuesForInt64 (value:obj) =
+        dataOfValues int64 int64 int64 int64 int64 int64 (fun x -> if x then 1L else 0L) int64 value
 
-let dataOfValuesForBool (value:obj) =
-    dataOfValues (fun i -> abs i >= 1.0f) (fun i -> abs i >= 1.0) (fun i -> abs i > 0y) (fun i -> abs i > 0s) (fun i -> abs i > 0) (fun i -> abs i > 0L) id (fun i -> i > 0uy) value 
+    let dataOfValuesForBool (value:obj) =
+        dataOfValues (fun i -> abs i >= 1.0f) (fun i -> abs i >= 1.0) (fun i -> abs i > 0y) (fun i -> abs i > 0s) (fun i -> abs i > 0) (fun i -> abs i > 0L) id (fun i -> i > 0uy) value 
 
-let toInt a =
-    match box a with
-    | :? float as a -> a |> int
-    | :? float32 as a -> a |> int
-    | :? int as a -> a
-    | _ -> failwith "Cannot convert to int"
+    let toInt a =
+        match box a with
+        | :? float as a -> a |> int
+        | :? float32 as a -> a |> int
+        | :? int as a -> a
+        | _ -> failwith "Cannot convert to int"
 
-let maxIndex seq =  seq |> Seq.mapi (fun i x -> i, x) |> Seq.maxBy snd |> fst
+    let getUniqueCounts (values:'a[]) (sorted:bool) =
+        let counts = Dictionary<'a, int>()
+        for v in values do
+            if counts.ContainsKey(v) then counts.[v] <- counts.[v] + 1 else counts.[v] <- 1
+        if sorted then
+            counts |> Array.ofSeq |> Array.sortByDescending (fun (KeyValue(_, v)) -> v) |> Array.map (fun (KeyValue(k, v)) -> k, v) |> Array.unzip
+        else
+            counts |> Array.ofSeq |> Array.map (fun (KeyValue(k, v)) -> k, v) |> Array.unzip
 
-let minIndex seq =  seq |> Seq.mapi (fun i x -> i, x) |> Seq.minBy snd |> fst
+    let download (url:string) (localFileName:string) =
+        let wc = new WebClient()
+        printfn "Downloading %A to %A" url localFileName
+        wc.DownloadFile(url, localFileName)
+        wc.Dispose()
 
-let memoize fn =
-    let cache = new Dictionary<_,_>()
-    fun x ->
-        match cache.TryGetValue x with
-        | true, v -> v
-        | false, _ ->
-            let v = fn x
-            cache.Add(x,v)
-            v
+    let saveBinary (object:'a) (fileName:string) =
+        let formatter = BinaryFormatter()
+        let fs = new FileStream(fileName, FileMode.Create)
+        let cs = new GZipStream(fs, CompressionMode.Compress)
+        try
+            formatter.Serialize(cs, object)
+            cs.Flush()
+            cs.Close()
+            fs.Close()
+        with
+        | :? SerializationException as e -> failwithf "Cannot save to file. %A" e.Message
 
-let getUniqueCounts (values:'a[]) (sorted:bool) =
-    let counts = Dictionary<'a, int>()
-    for v in values do
-        if counts.ContainsKey(v) then counts.[v] <- counts.[v] + 1 else counts.[v] <- 1
-    if sorted then
-        counts |> Array.ofSeq |> Array.sortByDescending (fun (KeyValue(_, v)) -> v) |> Array.map (fun (KeyValue(k, v)) -> k, v) |> Array.unzip
-    else
-        counts |> Array.ofSeq |> Array.map (fun (KeyValue(k, v)) -> k, v) |> Array.unzip
+    let loadBinary (fileName:string):'a =
+        let formatter = BinaryFormatter()
+        let fs = new FileStream(fileName, FileMode.Open)
+        let cs = new GZipStream(fs, CompressionMode.Decompress)
+        try
+            let object = formatter.Deserialize(cs) :?> 'a
+            cs.Close()
+            fs.Close()
+            object
+        with
+        | :? SerializationException as e -> failwithf "Cannot load from file. %A" e.Message
 
-let inline copyKeys (dictionary:Dictionary<'a, 'b>) =
-    let keys = Array.zeroCreate dictionary.Count
-    dictionary.Keys.CopyTo(keys, 0)
-    keys
+    let shuffledIndices (length: int) =
+        let indices = Array.init length id
+        let indicesShuffled = Random.Shuffle(indices)
+        fun (i: int) -> indicesShuffled.[i]
 
-let inline copyValues (dictionary:Dictionary<'a, 'b>) =
-    let values = Array.zeroCreate dictionary.Count
-    dictionary.Values.CopyTo(values, 0)
-    values
+    let indentNewLines (str:String) numSpaces =
+        let mutable ret = ""
+        let spaces = String.replicate numSpaces " "
+        str |> Seq.toList |> List.iter (fun c -> 
+                            if c = '\n' then 
+                                ret <- ret + "\n" + spaces
+                            else ret <- ret + string c)
+        ret
 
-let download (url:string) (localFileName:string) =
-    let wc = new WebClient()
-    printfn "Downloading %A to %A" url localFileName
-    wc.DownloadFile(url, localFileName)
-    wc.Dispose()
+    let stringPad (s:string) (width:int) =
+        if s.Length > width then s
+        else String.replicate (width - s.Length) " " + s
 
-let saveBinary (object:'a) (fileName:string) =
-    let formatter = BinaryFormatter()
-    let fs = new FileStream(fileName, FileMode.Create)
-    let cs = new GZipStream(fs, CompressionMode.Compress)
-    try
-        formatter.Serialize(cs, object)
-        cs.Flush()
-        cs.Close()
-        fs.Close()
-    with
-    | :? SerializationException as e -> failwithf "Cannot save to file. %A" e.Message
-
-let loadBinary (fileName:string):'a =
-    let formatter = BinaryFormatter()
-    let fs = new FileStream(fileName, FileMode.Open)
-    let cs = new GZipStream(fs, CompressionMode.Decompress)
-    try
-        let object = formatter.Deserialize(cs) :?> 'a
-        cs.Close()
-        fs.Close()
-        object
-    with
-    | :? SerializationException as e -> failwithf "Cannot load from file. %A" e.Message
-
-let shuffledIndices (length: int) =
-    let indices = Array.init length id
-    let indicesShuffled = Random.Shuffle(indices)
-    fun (i: int) -> indicesShuffled.[i]
-
-let indentNewLines (str:String) numSpaces =
-    let mutable ret = ""
-    let spaces = String.replicate numSpaces " "
-    str |> Seq.toList |> List.iter (fun c -> 
-                        if c = '\n' then 
-                            ret <- ret + "\n" + spaces
-                        else ret <- ret + string c)
-    ret
-
-let stringPad (s:string) (width:int) =
-    if s.Length > width then s
-    else String.replicate (width - s.Length) " " + s
-
-let stringPadAs (s1:string) (s2:string) = stringPad s1 s2.Length
+    let stringPadAs (s1:string) (s2:string) = stringPad s1 s2.Length

--- a/src/DiffSharp.Core/Util.fs
+++ b/src/DiffSharp.Core/Util.fs
@@ -2,18 +2,11 @@
 namespace DiffSharp.Util
 
 open System
-open System.Net
 open System.Collections
 open System.Collections.Generic
 open System.Diagnostics.CodeAnalysis
-open System.IO
-open System.IO.Compression
-open System.Runtime.Serialization
-open System.Runtime.Serialization.Formatters.Binary
-
-open DiffSharp
-
 open FSharp.Reflection
+open DiffSharp
 
 /// Represents a nesting level with a differentiation operation.
 type NestingLevel =
@@ -322,45 +315,6 @@ module UtilAutoOpens =
         | :? float32 as a -> a |> int
         | :? int as a -> a
         | _ -> failwith "Cannot convert to int"
-
-    let getUniqueCounts (values:'a[]) (sorted:bool) =
-        let counts = Dictionary<'a, int>()
-        for v in values do
-            if counts.ContainsKey(v) then counts.[v] <- counts.[v] + 1 else counts.[v] <- 1
-        if sorted then
-            counts |> Array.ofSeq |> Array.sortByDescending (fun (KeyValue(_, v)) -> v) |> Array.map (fun (KeyValue(k, v)) -> k, v) |> Array.unzip
-        else
-            counts |> Array.ofSeq |> Array.map (fun (KeyValue(k, v)) -> k, v) |> Array.unzip
-
-    let download (url:string) (localFileName:string) =
-        let wc = new WebClient()
-        printfn "Downloading %A to %A" url localFileName
-        wc.DownloadFile(url, localFileName)
-        wc.Dispose()
-
-    let saveBinary (object:'a) (fileName:string) =
-        let formatter = BinaryFormatter()
-        let fs = new FileStream(fileName, FileMode.Create)
-        let cs = new GZipStream(fs, CompressionMode.Compress)
-        try
-            formatter.Serialize(cs, object)
-            cs.Flush()
-            cs.Close()
-            fs.Close()
-        with
-        | :? SerializationException as e -> failwithf "Cannot save to file. %A" e.Message
-
-    let loadBinary (fileName:string):'a =
-        let formatter = BinaryFormatter()
-        let fs = new FileStream(fileName, FileMode.Open)
-        let cs = new GZipStream(fs, CompressionMode.Decompress)
-        try
-            let object = formatter.Deserialize(cs) :?> 'a
-            cs.Close()
-            fs.Close()
-            object
-        with
-        | :? SerializationException as e -> failwithf "Cannot load from file. %A" e.Message
 
     let shuffledIndices (length: int) =
         let indices = Array.init length id

--- a/tests/DiffSharp.Tests/TestDerivatives.fs
+++ b/tests/DiffSharp.Tests/TestDerivatives.fs
@@ -2,6 +2,7 @@ namespace Tests
 
 open NUnit.Framework
 open DiffSharp
+open DiffSharp.Util
 
 #nowarn "0058"
 
@@ -288,9 +289,9 @@ type TestDerivatives () =
 
             // For each shape, create a broadcasting addition and take forward and reverse derivatives
             for shape in shapes do 
-                let t1b = combo.tensor( Util.arrayND shape (fun is -> double (Array.sum is) + 2.0))
+                let t1b = combo.tensor( arrayND shape (fun is -> double (Array.sum is) + 2.0))
                 let t1a_deriv = t1a + 1.0
-                let t1b_delta = combo.tensor( Util.arrayND shape (fun is -> double (Array.sum is) - 2.0))
+                let t1b_delta = combo.tensor( arrayND shape (fun is -> double (Array.sum is) - 2.0))
                 let fwda = t1a.forwardDiff(t1a_deriv)
                 let fwdb = t1b.forwardDiff(t1b_delta)
                 let fwdz = fwda + fwdb
@@ -306,8 +307,8 @@ type TestDerivatives () =
 
                 // In the simple case of broadcasting a constant, check the result against the non-broadcast case
                 if t1b.sum() = combo.tensor(2.0) then 
-                    let t1c = combo.tensor( Util.arrayND [| 2;3;4 |] (fun _idxs -> 2.0))
-                    let t1c_deriv = combo.tensor( Util.arrayND [| 2;3;4 |] (fun _idxs -> -2.0))
+                    let t1c = combo.tensor( arrayND [| 2;3;4 |] (fun _idxs -> 2.0))
+                    let t1c_deriv = combo.tensor( arrayND [| 2;3;4 |] (fun _idxs -> -2.0))
                     let fwda = t1a.forwardDiff(t1a_deriv)
                     let fwdc = t1c.forwardDiff(t1c_deriv)
                     let fwdz2 = fwda + fwdc

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -2,6 +2,7 @@ namespace Tests
 
 open NUnit.Framework
 open DiffSharp
+open DiffSharp.Util
 open System
 
 [<TestFixture>]
@@ -220,7 +221,7 @@ type TestTensor () =
         let t3 = combo.tensor(t3Values)
         let t3ShapeCorrect = [|1; 2; 3|]
         let t3DimCorrect = 3
-        let t3ValuesCorrect = Util.array3D (List.map (List.map (List.map float32)) t3Values)
+        let t3ValuesCorrect = array3D (List.map (List.map (List.map float32)) t3Values)
 
         Assert.AreEqual(t3ShapeCorrect, t3.shape)
         Assert.AreEqual(t3DimCorrect, t3.dim)
@@ -233,7 +234,7 @@ type TestTensor () =
         let t4 = combo.tensor(t4Values)
         let t4ShapeCorrect = [|1; 1; 1; 2|]
         let t4DimCorrect = 4
-        let t4ValuesCorrect = Util.array4D (List.map (List.map (List.map (List.map float32))) t4Values)
+        let t4ValuesCorrect = array4D (List.map (List.map (List.map (List.map float32))) t4Values)
 
         Assert.AreEqual(t4ShapeCorrect, t4.shape)
         Assert.AreEqual(t4DimCorrect, t4.dim)
@@ -1183,7 +1184,7 @@ type TestTensor () =
 
         let t7Results, t7CommuteResults = 
             [| for shape in t7Shapes do 
-                  let t7b = combo.tensor( Util.arrayND shape (fun is -> double (Array.sum is) + 2.0))
+                  let t7b = combo.tensor(arrayND shape (fun is -> double (Array.sum is) + 2.0))
                   let t7 = t7a + t7b
                   let t7Commute = t7b + t7a
                   yield (t7b, t7), (t7b, t7Commute) |]
@@ -1576,7 +1577,7 @@ type TestTensor () =
 
         let t6Results, t6CommuteResults = 
             [| for shape in t6Shapes do 
-                  let t6b = combo.tensor( Util.arrayND shape (fun is -> double (Array.sum is) + 2.0))
+                  let t6b = combo.tensor( arrayND shape (fun is -> double (Array.sum is) + 2.0))
                   let t6 = t6a * t6b
                   let t6Commute = t6b * t6a
                   yield (t6b, t6 ), (t6b, t6Commute ) |]


### PR DESCRIPTION

* Start adding the `///` docs across the API

* `Shape` is moved into `DiffSharp` namespace and add Shape.fs to hold all shape-related logic

* `DiffSharp.Util` becomes a namespace 

Separately I think we should rename

    DiffSharp.Util --> DiffSharp.Utilities
    DiffSharp.Optim --> DiffSharp.Optimizers

and make some of DiffSharp.Utilities internal
