### PR TITLE
Placeholders for documentation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
 
      <LibTorchNugetVersion>1.5.6</LibTorchNugetVersion>
      <TorchSharpVersion>0.3.52267</TorchSharpVersion>
+	 <FSharpCoreVersion>4.7.2</FSharpCoreVersion>
       <!-- Standard nuget.org location -->
     <RestoreSources>https://api.nuget.org/v3/index.json</RestoreSources>
 
@@ -23,7 +24,7 @@
         https://donsyme.pkgs.visualstudio.com/TorchSharp/_packaging/packages2/nuget/v3/index.json
     </RestoreSources>
     -->
-    <OtherFlags>--warnon:1182 $(OtherFlags)</OtherFlags>
+    <OtherFlags>--warnon:1182 --warnon:3390 $(OtherFlags)</OtherFlags>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/bundles/DiffSharp-cpu/DiffSharp-cpu.fsproj
+++ b/bundles/DiffSharp-cpu/DiffSharp-cpu.fsproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Torch\DiffSharp.Backends.Torch.fsproj" />
     <!--  reference a libtorch runtime redist -->
     <PackageReference Include="libtorch-cpu" Version="$(LibTorchNugetVersion)" />
+	<PackageReference Update="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/bundles/DiffSharp-lite/DiffSharp-lite.fsproj
+++ b/bundles/DiffSharp-lite/DiffSharp-lite.fsproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\DiffSharp.Core\DiffSharp.Core.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Reference\DiffSharp.Backends.Reference.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Torch\DiffSharp.Backends.Torch.fsproj" />
+	<PackageReference Update="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/DiffSharp.Backends.Reference/DiffSharp.Backends.Reference.fsproj
+++ b/src/DiffSharp.Backends.Reference/DiffSharp.Backends.Reference.fsproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiffSharp.Core\DiffSharp.Core.fsproj" />
+	<PackageReference Update="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/DiffSharp.Backends.Torch/DiffSharp.Backends.Torch.fsproj
+++ b/src/DiffSharp.Backends.Torch/DiffSharp.Backends.Torch.fsproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DiffSharp.Core\DiffSharp.Core.fsproj" />
     <PackageReference Include="TorchSharp" Version="$(TorchSharpVersion)" />
+	<PackageReference Update="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/DiffSharp.Core/DiffSharp.Core.fsproj
+++ b/src/DiffSharp.Core/DiffSharp.Core.fsproj
@@ -15,5 +15,6 @@
     <Compile Include="Data.fs" />
     <Compile Include="Model.fs" />
     <Compile Include="Optim.fs" />
+	<PackageReference Update="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/DiffSharp.Core/DiffSharp.fs
+++ b/src/DiffSharp.Core/DiffSharp.fs
@@ -6,18 +6,56 @@ open DiffSharp.Util
 /// Tensor operations
 
 type dsharp =
+
+    /// <summary>
+    /// Creates a new tensor from the given data, using the given element type and configuration.
+    /// </summary>
+    /// 
+    /// <example><code>
+    ///    let t1 = dsharp.tensor [ 1 .. 10 ]
+    ///    let t2 = dsharp.tensor [ [ 1.0; 3.0; 4.0 ];
+    ///                             [ 1.02; 3.04; 4.01 ] ]
+    /// </code></example>
+    /// 
+    /// <remarks>
+    ///  The data is converted from arrays, sequences, lists and tuples of primitive values to a tensor whose shape is inferred from the data.
+    /// </remarks>
     static member tensor(value:obj, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor.create(value=value, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>Seeds all backends with the given random seed, or a new seed based on the current time if no seed is specified.</summary>
     static member seed(?seed:int) = BackendStatics.Seed(?seed=seed)
+
+    /// <summary>Indicates if an object is a tensor</summary>
     static member isTensor(value:obj) = value :? Tensor
+
+    /// <summary>Saves the tensor to the given file paath</summary>
     static member save(tensor:Tensor, fileName) = tensor.save(fileName)
+
+    /// <summary>Loads the tensor from the given file path</summary>
     static member load(fileName) = Tensor.load(fileName)
+
+    /// <summary>Get the scalar zero tensor for the given configuration</summary>
     static member zero(?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Zero(?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>Returns a new tensor filled with '0' values for the given shape, element type and configuration</summary>
     static member zeros(shape:seq<int>, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Zeros(shape|>Seq.toArray, ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>Returns a new tensor filled with '0' values for the given length, element type and configuration</summary>
     static member zeros(length:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Zeros([|length|], ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>Get the scalar '1' tensor for the given configuration</summary>
     static member one(?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.One(?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>Returns a new tensor filled with '1' values for the given shape, element type and configuration</summary>
     static member ones(shape:seq<int>, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Ones(shape|>Seq.toArray, ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>Returns a new tensor of the given length filled with '1' values for the given element type and configuration</summary>
     static member ones(length:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Ones([|length|], ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>Returns a new tensor filled with the scalar <paramref name="value" />, for the given shape, element type and configuration</summary>
     static member full(shape:seq<int>, value:obj, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Full(shape|>Seq.toArray, value, ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>Returns a new tensor of the given length filled with <paramref name="value" />, for the given element type and configuration</summary>
     static member full(length:int, value:scalar, ?dtype:Dtype, ?device:Device, ?backend:Backend) = dsharp.zero(?dtype=dtype, ?device=device, ?backend=backend).fullLike(value, [|length|])
 
     /// <summary>
@@ -30,228 +68,641 @@ type dsharp =
     /// </remarks>
     static member arange(endVal:float, ?startVal:float, ?step:float, ?dtype:Dtype, ?device:Device, ?backend:Backend) = dsharp.zero(?dtype=dtype, ?device=device, ?backend=backend).arangeLike(endVal=endVal, ?startVal=startVal, ?step=step)
 
+    /// <summary>TBD</summary>
     static member arange(endVal:int, ?startVal:int, ?step:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = dsharp.zero(?dtype=dtype, ?device=device, ?backend=backend).arangeLike(endVal=endVal, ?startVal=startVal, ?step=step)
+
+    /// <summary>TBD</summary>
     static member onehot(length:int, hot:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = dsharp.zero(?dtype=dtype, ?device=device, ?backend=backend).onehotLike(length, hot)
+
+    /// <summary>TBD</summary>
     static member rand(shape:seq<int>, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Random(shape|>Seq.toArray, ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>TBD</summary>
     static member rand(length:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Random([|length|], ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>TBD</summary>
     static member randn(shape:seq<int>, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.RandomNormal(shape|>Seq.toArray, ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>TBD</summary>
     static member randn(length:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.RandomNormal([|length|], ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>TBD</summary>
     static member randint(low:int, high:int, shape:seq<int>, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.RandomInt(shape|>Seq.toArray, low, high, ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>TBD</summary>
     static member randint(low:int, high:int, length:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.RandomInt([|length|], low, high, ?dtype=dtype, ?device=device, ?backend=backend))
+
+    /// <summary>TBD</summary>
     static member multinomial(probs:Tensor, numSamples:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = probs.multinomial(numSamples, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member multinomial(numSamples:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = fun (probs:Tensor) -> probs.multinomial(numSamples, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member bernoulli(probs:Tensor, ?dtype:Dtype, ?device:Device, ?backend:Backend) = probs.bernoulli(?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member bernoulli(?dtype:Dtype, ?device:Device, ?backend:Backend) = fun (probs:Tensor) -> probs.bernoulli(?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member dropout(a:Tensor, ?p:double) = a.dropout(?p=p)
+
+    /// <summary>TBD</summary>
     static member dropout(?p:double) = fun (a:Tensor) -> a.dropout(?p=p)
+
+    /// <summary>TBD</summary>
     static member dropout2d(a:Tensor, ?p:double) = a.dropout2d(?p=p)
+
+    /// <summary>TBD</summary>
     static member dropout2d(?p:double) = fun (a:Tensor) -> a.dropout2d(?p=p)
+
+    /// <summary>TBD</summary>
     static member dropout3d(a:Tensor, ?p:double) = a.dropout3d(?p=p)
+
+    /// <summary>TBD</summary>
     static member dropout3d(?p:double) = fun (a:Tensor) -> a.dropout3d(?p=p)
+
+    /// <summary>TBD</summary>
     static member zerosLike(a:Tensor, ?shape:seq<int>, ?dtype, ?device, ?backend) = a.zerosLike(?shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member zerosLike(shape:seq<int>, ?dtype, ?device, ?backend) = fun (a:Tensor) -> a.zerosLike(shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member onesLike(a:Tensor, ?shape:seq<int>, ?dtype, ?device, ?backend) = a.onesLike(?shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member onesLike(shape:seq<int>, ?dtype, ?device, ?backend) = fun (a:Tensor) -> a.onesLike(shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member fullLike(a:Tensor, value:scalar, ?shape:seq<int>, ?dtype, ?device, ?backend) = a.fullLike(value, ?shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member fullLike(value:scalar, ?shape, ?dtype, ?device, ?backend) = fun (a:Tensor) -> a.fullLike(value, ?shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member arangeLike(a:Tensor, endVal:float, ?startVal:float, ?step:float, ?dtype:Dtype, ?device:Device, ?backend:Backend) = a.arangeLike(endVal=endVal, ?startVal=startVal, ?step=step, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member arangeLike(endVal:float, ?startVal:float, ?step:float, ?dtype:Dtype, ?device:Device, ?backend:Backend) = fun (a:Tensor) -> a.arangeLike(endVal=endVal, ?startVal=startVal, ?step=step, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member arangeLike(a:Tensor, endVal:int, ?startVal:int, ?step:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = a.arangeLike(endVal=endVal, ?startVal=startVal, ?step=step, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member arangeLike(endVal:int, ?startVal:int, ?step:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = fun (a:Tensor) -> a.arangeLike(endVal=endVal, ?startVal=startVal, ?step=step, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member onehotLike(a:Tensor, length:int, hot:int, ?dtype, ?device, ?backend) = a.onehotLike(length, hot, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member onehotLike(length:int, hot:int, ?dtype, ?device, ?backend) = fun (a:Tensor) -> a.onehotLike(length, hot, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member randLike(a:Tensor, ?shape:seq<int>, ?dtype, ?device, ?backend) = a.randLike(?shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member randLike(shape:seq<int>, ?dtype, ?device, ?backend) = fun (a:Tensor) -> a.randLike(shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member randnLike(a:Tensor, ?shape:seq<int>, ?dtype, ?device, ?backend) = a.randnLike(?shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member randnLike(shape:seq<int>, ?dtype, ?device, ?backend) = fun (a:Tensor) -> a.randnLike(shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member randintLike(a:Tensor, low:int, high:int, ?shape:seq<int>, ?dtype, ?device, ?backend) = a.randintLike(low=low, high=high, ?shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member randintLike(low:int, high:int, ?shape:seq<int>, ?dtype, ?device, ?backend) = fun (a:Tensor) -> a.randintLike(low=low, high=high, ?shape=shape, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member zeroLike(a:Tensor, ?dtype, ?device, ?backend) = a.zeroLike(?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member oneLike(a:Tensor, ?dtype, ?device, ?backend) = a.oneLike(?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member nelement(a:Tensor) = a.nelement
+
+    /// <summary>TBD</summary>
     static member like(a:Tensor, value:obj, ?dtype, ?device, ?backend) = a.like(value, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member like(value:obj, ?dtype, ?device, ?backend) = fun (a:Tensor) -> a.like(value, ?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member clone(a:Tensor) = a.clone()
+
+    /// <summary>TBD</summary>
     static member lt(a:Tensor, b:Tensor) = a.lt(b)
+
+    /// <summary>TBD</summary>
     static member lt(b:Tensor) = fun (a:Tensor) -> a.lt(b)
+
+    /// <summary>TBD</summary>
     static member gt(a:Tensor, b:Tensor) = a.gt(b)
+
+    /// <summary>TBD</summary>
     static member gt(b:Tensor) = fun (a:Tensor) -> a.gt(b)
+
+    /// <summary>TBD</summary>
     static member le(a:Tensor, b:Tensor) = a.le(b)
+
+    /// <summary>TBD</summary>
     static member le(b:Tensor) = fun (a:Tensor) -> a.le(b)
+
+    /// <summary>TBD</summary>
     static member ge(a:Tensor, b:Tensor) = a.ge(b)
+
+    /// <summary>TBD</summary>
     static member ge(b:Tensor) = fun (a:Tensor) -> a.ge(b)
+
+    /// <summary>TBD</summary>
     static member isinf(a:Tensor) = a.isinf()
+
+    /// <summary>TBD</summary>
     static member isnan(a:Tensor) = a.isnan()
+
+    /// <summary>TBD</summary>
     static member hasinf(a:Tensor) = a.hasinf()
+
+    /// <summary>TBD</summary>
     static member hasnan(a:Tensor) = a.hasnan()
+
+    /// <summary>TBD</summary>
     static member argmax(a:Tensor) = a.argmax()
+
+    /// <summary>TBD</summary>
     static member argmin(a:Tensor) = a.argmin()
+
+    /// <summary>TBD</summary>
     static member max(a:Tensor) = a.max()
+
+    /// <summary>TBD</summary>
     static member min(a:Tensor) = a.min()
+
+    /// <summary>TBD</summary>
     static member max(a:Tensor, b:Tensor) = a.max(b)
+
+    /// <summary>TBD</summary>
     static member min(a:Tensor, b:Tensor) = a.min(b)
+
+    /// <summary>TBD</summary>
     static member clamp(a:Tensor, ?low:scalar, ?high:scalar) = a.clamp(?low=low, ?high=high)
+
+    /// <summary>TBD</summary>
     static member clamp(?low:scalar, ?high:scalar) = fun (a:Tensor) -> a.clamp(?low=low, ?high=high)
+
+    /// <summary>TBD</summary>
     static member diagonal(a:Tensor, ?offset:int, ?dim1:int, ?dim2:int) = a.diagonal(?offset=offset, ?dim1=dim1, ?dim2=dim2)
+
+    /// <summary>TBD</summary>
     static member diagonal(offset:int, ?dim1:int, ?dim2:int) = fun (a:Tensor) -> a.diagonal(offset=offset, ?dim1=dim1, ?dim2=dim2)
+
+    /// <summary>TBD</summary>
     static member trace(a:Tensor) = a.trace()
+
+    /// <summary>TBD</summary>
     static member expand(a:Tensor, shape:seq<int>) = a.expand(shape)
+
+    /// <summary>TBD</summary>
     static member expand(shape:seq<int>) = fun (a:Tensor) -> a.expand(shape)
+
+    /// <summary>TBD</summary>
     static member stack(tensors:seq<Tensor>, ?dim:int) = Tensor.stack(tensors, ?dim=dim)
+
+    /// <summary>TBD</summary>
     static member stack(dim:int) = fun (tensors:seq<Tensor>) -> Tensor.stack(tensors, dim=dim)
+
+    /// <summary>TBD</summary>
     static member unstack(a:Tensor, ?dim:int) = a.unstack(?dim=dim)
+
+    /// <summary>TBD</summary>
     static member unstack(dim:int) = fun (a:Tensor) -> a.unstack(dim=dim)
+
+    /// <summary>TBD</summary>
     static member cat(tensors:seq<Tensor>, ?dim:int) = Tensor.cat(tensors, ?dim=dim)
+
+    /// <summary>TBD</summary>
     static member cat(dim:int) = fun (tensors:seq<Tensor>) -> Tensor.cat(tensors, dim=dim)
+
+    /// <summary>TBD</summary>
     static member split(a:Tensor, sizes:seq<int>, ?dim:int) = a.split(sizes, ?dim=dim)
+
+    /// <summary>TBD</summary>
     static member split(sizes:seq<int>, ?dim:int) = fun (a:Tensor) -> a.split(sizes, ?dim=dim)
+
+    /// <summary>TBD</summary>
     static member add(a:Tensor, b:Tensor) = a.add(b)
+
+    /// <summary>TBD</summary>
     static member add(b:Tensor) = fun (a:Tensor) -> a.add(b)
+
+    /// <summary>TBD</summary>
     static member sub(a:Tensor, b:Tensor) = a.sub(b)
+
+    /// <summary>TBD</summary>
     static member sub(b:Tensor) = fun (a:Tensor) -> a.sub(b)
+
+    /// <summary>TBD</summary>
     static member mul(a:Tensor, b:Tensor) = a.mul(b)
+
+    /// <summary>TBD</summary>
     static member mul(b:Tensor) = fun (a:Tensor) -> a.mul(b)
+
+    /// <summary>TBD</summary>
     static member div(a:Tensor, b:Tensor) = a.div(b)
+
+    /// <summary>TBD</summary>
     static member div(b:Tensor) = fun (a:Tensor) -> a.div(b)
+
+    /// <summary>TBD</summary>
     static member pow(a:Tensor, b:Tensor) = a.pow(b)
+
+    /// <summary>TBD</summary>
     static member pow(b:Tensor) = fun (a:Tensor) -> a.pow(b)
+
+    /// <summary>TBD</summary>
     static member matmul(a:Tensor, b:Tensor) = a.matmul(b)
+
+    /// <summary>TBD</summary>
     static member matmul(b:Tensor) = fun (a:Tensor) -> a.matmul(b)
+
+    /// <summary>TBD</summary>
     static member dot(a:Tensor, b:Tensor) = a.dot(b)
+
+    /// <summary>TBD</summary>
     static member dot(b:Tensor) = fun (a:Tensor) -> a.dot(b)
+
+    /// <summary>TBD</summary>
     static member neg(a:Tensor) = a.neg()
+
+    /// <summary>TBD</summary>
     static member sum(a:Tensor) = a.sum()
+
+    /// <summary>TBD</summary>
     static member sum(a:Tensor, dim:int, ?keepDim:bool) = a.sum(dim, ?keepDim=keepDim)
+
+    /// <summary>TBD</summary>
     static member sum(dim:int, ?keepDim:bool) = fun (a:Tensor) -> a.sum(dim, ?keepDim=keepDim)
+
+    /// <summary>TBD</summary>
     static member mean(a:Tensor) = a.mean()
+
+    /// <summary>TBD</summary>
     static member mean(a:Tensor, dim:int, ?keepDim:bool) = a.mean(dim, ?keepDim=keepDim)
+
+    /// <summary>TBD</summary>
     static member mean(dim:int, ?keepDim:bool) = fun (a:Tensor) -> a.mean(dim, ?keepDim=keepDim)
+
+    /// <summary>TBD</summary>
     static member variance(a:Tensor, ?unbiased:bool) = a.variance(?unbiased=unbiased)
+
+    /// <summary>TBD</summary>
     static member variance(a:Tensor, dim:int, ?keepDim:bool, ?unbiased:bool) = a.variance(dim, ?keepDim=keepDim, ?unbiased=unbiased)
+
+    /// <summary>TBD</summary>
     static member variance(dim:int, ?keepDim:bool, ?unbiased:bool) = fun (a:Tensor) -> a.variance(dim, ?keepDim=keepDim, ?unbiased=unbiased)
+
+    /// <summary>TBD</summary>
     static member stddev(a:Tensor, ?unbiased:bool) = a.stddev(?unbiased=unbiased)
+
+    /// <summary>TBD</summary>
     static member stddev(a:Tensor, dim:int, ?keepDim:bool, ?unbiased:bool) = a.stddev(dim, ?keepDim=keepDim, ?unbiased=unbiased)
+
+    /// <summary>TBD</summary>
     static member stddev(dim:int, ?keepDim:bool, ?unbiased:bool) = fun (a:Tensor) -> a.stddev(dim, ?keepDim=keepDim, ?unbiased=unbiased)
+
+    /// <summary>TBD</summary>
     static member gather(a:Tensor, dim:int, indices:Tensor) = a.gather(dim, indices)
+
+    /// <summary>TBD</summary>
     static member gather(dim:int, indices:Tensor) = fun (a:Tensor) -> a.gather(dim, indices)
+
+    /// <summary>TBD</summary>
     static member transpose(a:Tensor, dim0:int, dim1:int) = a.transpose(dim0, dim1)
+
+    /// <summary>TBD</summary>
     static member transpose(dim0:int, dim1:int) = fun (a:Tensor) -> a.transpose(dim0, dim1)
+
+    /// <summary>TBD</summary>
     static member transpose(a:Tensor) = a.transpose()
+
+    /// <summary>TBD</summary>
     static member squeeze(a:Tensor, ?dim:int) = a.squeeze(?dim=dim)
+
+    /// <summary>TBD</summary>
     static member squeeze(dim:int) = fun (a:Tensor) -> a.squeeze(dim=dim)
+
+    /// <summary>TBD</summary>
     static member unsqueeze(a:Tensor, dim:int) = a.unsqueeze(dim)
+
+    /// <summary>TBD</summary>
     static member unsqueeze(dim:int) = fun (a:Tensor) -> a.unsqueeze(dim)
+
+    /// <summary>TBD</summary>
     static member flip(a:Tensor, dims:seq<int>) = a.flip(dims)
+
+    /// <summary>TBD</summary>
     static member flip(dims:seq<int>) = fun (a:Tensor) -> a.flip(dims)
+
+    /// <summary>TBD</summary>
     static member dilate(a:Tensor, dilations:seq<int>) = a.dilate(dilations)
+
+    /// <summary>TBD</summary>
     static member dilate(dilations:seq<int>) = fun (a:Tensor) -> a.dilate(dilations)
+
+    /// <summary>TBD</summary>
     static member undilate(a:Tensor, dilations:seq<int>) = a.undilate(dilations)
+
+    /// <summary>TBD</summary>
     static member undilate(dilations:seq<int>) = fun (a:Tensor) -> a.undilate(dilations)
+
+    /// <summary>TBD</summary>
     static member repeat(a:Tensor, dim:int, times:int) = a.repeat(dim, times)
+
+    /// <summary>TBD</summary>
     static member repeat(dim:int, times:int) = fun (a:Tensor) -> a.repeat(dim, times)
+
+    /// <summary>TBD</summary>
     static member view(a:Tensor, shape:seq<int>) = a.view(shape)
+
+    /// <summary>TBD</summary>
     static member view(shape:seq<int>) = fun (a:Tensor) -> a.view(shape)
+
+    /// <summary>TBD</summary>
     static member view(a:Tensor, shape:int) = a.view(shape)
+
+    /// <summary>TBD</summary>
     static member view(shape:int) = fun (a:Tensor) -> a.view(shape)
+
+    /// <summary>TBD</summary>
     static member viewAs(a:Tensor, b:Tensor) = a.viewAs(b)
+
+    /// <summary>TBD</summary>
     static member viewAs(b:Tensor) = fun (a:Tensor) -> a.viewAs(b)
+
+    /// <summary>TBD</summary>
     static member flatten(a:Tensor, ?startDim:int, ?endDim:int) = a.flatten(?startDim=startDim, ?endDim=endDim)
+
+    /// <summary>TBD</summary>
     static member flatten(startDim:int, ?endDim:int) = fun (a:Tensor) -> a.flatten(startDim=startDim, ?endDim=endDim)
+
+    /// <summary>TBD</summary>
     static member sign(a:Tensor) = a.sign()
+
+    /// <summary>TBD</summary>
     static member floor(a:Tensor) = a.floor()
+
+    /// <summary>TBD</summary>
     static member ceil(a:Tensor) = a.ceil()
+
+    /// <summary>TBD</summary>
     static member round(a:Tensor) = a.round()
+
+    /// <summary>TBD</summary>
     static member abs(a:Tensor) = a.abs()
+
+    /// <summary>TBD</summary>
     static member relu(a:Tensor) = a.relu()
+
+    /// <summary>TBD</summary>
     static member leakyRelu(a:Tensor, ?negativeSlope:float) = a.leakyRelu(?negativeSlope=negativeSlope)
+
+    /// <summary>TBD</summary>
     static member leakyRelu(negativeSlope:float) = fun (a:Tensor) -> a.leakyRelu(negativeSlope=negativeSlope)
+
+    /// <summary>TBD</summary>
     static member sigmoid(a:Tensor) = a.sigmoid()
+
+    /// <summary>TBD</summary>
     static member softplus(a:Tensor) = a.softplus()
+
+    /// <summary>TBD</summary>
     static member exp(a:Tensor) = a.exp()
+
+    /// <summary>TBD</summary>
     static member log(a:Tensor) = a.log()
+
+    /// <summary>TBD</summary>
     static member log10(a:Tensor) = a.log10()
+
+    /// <summary>TBD</summary>
     static member sqrt(a:Tensor) = a.sqrt()
+
+    /// <summary>TBD</summary>
     static member sin(a:Tensor) = a.sin()
+
+    /// <summary>TBD</summary>
     static member cos(a:Tensor) = a.cos()
+
+    /// <summary>TBD</summary>
     static member tan(a:Tensor) = a.tan()
+
+    /// <summary>TBD</summary>
     static member sinh(a:Tensor) = a.sinh()
+
+    /// <summary>TBD</summary>
     static member cosh(a:Tensor) = a.cosh()
+
+    /// <summary>TBD</summary>
     static member tanh(a:Tensor) = a.tanh()
+
+    /// <summary>TBD</summary>
     static member asin(a:Tensor) = a.asin()
+
+    /// <summary>TBD</summary>
     static member acos(a:Tensor) = a.acos()
+    
+    /// <summary>TBD</summary>
     static member atan(a:Tensor) = a.atan()
+
+    /// <summary>TBD</summary>
+
+    /// <summary>TBD</summary>
     static member softmax(a:Tensor, dim:int) = a.softmax(dim)
+
+    /// <summary>TBD</summary>
     static member softmax(dim:int) = fun (a:Tensor) -> a.softmax(dim)
+
+    /// <summary>TBD</summary>
     static member logsoftmax(a:Tensor, dim:int) = a.logsoftmax(dim)
+
+    /// <summary>TBD</summary>
     static member logsoftmax(dim:int) = fun (a:Tensor) -> a.logsoftmax(dim)
+
+    /// <summary>TBD</summary>
     static member logsumexp(a:Tensor, dim:int, ?keepDim:bool) = a.logsumexp(dim, ?keepDim=keepDim)
+
+    /// <summary>TBD</summary>
     static member logsumexp(dim:int, ?keepDim:bool) = fun (a:Tensor) -> a.logsumexp(dim, ?keepDim=keepDim)
+
+    /// <summary>TBD</summary>
     static member mseLoss(input:Tensor, target:Tensor, ?reduction:string) = input.mseLoss(target, ?reduction=reduction)
+
+    /// <summary>TBD</summary>
     static member mseLoss(target:Tensor) = fun (input:Tensor) -> input.mseLoss(target)
+
+    /// <summary>TBD</summary>
     static member bceLoss(input:Tensor, target:Tensor, ?weight:Tensor, ?reduction:string) = input.bceLoss(target, ?weight=weight, ?reduction=reduction)
+
+    /// <summary>TBD</summary>
     static member bceLoss(target:Tensor) = fun (input:Tensor) -> input.bceLoss(target)
+
+    /// <summary>TBD</summary>
     static member nllLoss(input:Tensor, target:Tensor, ?weight:Tensor, ?reduction:string) = input.nllLoss(target, ?weight=weight, ?reduction=reduction)
+
+    /// <summary>TBD</summary>
     static member nllLoss(target:Tensor) = fun (input:Tensor) -> input.nllLoss(target)
+
+    /// <summary>TBD</summary>
     static member crossEntropyLoss(input:Tensor, target:Tensor, ?weight:Tensor, ?reduction:string) = input.crossEntropyLoss(target, ?weight=weight, ?reduction=reduction)
+
+    /// <summary>TBD</summary>
     static member crossEntropyLoss(target:Tensor) = fun (input:Tensor) -> input.crossEntropyLoss(target)
+
+    /// <summary>TBD</summary>
     static member maxpool1d(a:Tensor, kernelSize:int, ?stride:int, ?padding:int) = a.maxpool1d(kernelSize, ?stride=stride, ?padding=padding)
+
+    /// <summary>TBD</summary>
     static member maxpool1d(kernelSize:int, ?stride:int, ?padding:int) = fun (a:Tensor) -> a.maxpool1d(kernelSize, ?stride=stride, ?padding=padding)
+
+    /// <summary>TBD</summary>
     static member maxpool1di(a:Tensor, kernelSize:int, ?stride:int, ?padding:int) = a.maxpool1di(kernelSize, ?stride=stride, ?padding=padding)
+
+    /// <summary>TBD</summary>
     static member maxpool2d(a:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) = a.maxpool2d(?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings)
+
+    /// <summary>TBD</summary>
     static member maxpool2d(?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) = fun (a:Tensor) -> a.maxpool2d(?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings)
+
+    /// <summary>TBD</summary>
     static member maxpool2di(a:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) = a.maxpool2di(?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings)
+
+    /// <summary>TBD</summary>
     static member maxpool3d(a:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) = a.maxpool3d(?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings)
+
+    /// <summary>TBD</summary>
     static member maxpool3d(?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) = fun (a:Tensor) -> a.maxpool3d(?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings)
+
+    /// <summary>TBD</summary>
     static member maxpool3di(a:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) = a.maxpool3di(?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings)
+
+    /// <summary>TBD</summary>
     static member maxunpool1d(a:Tensor, indices:Tensor, kernelSize:int, ?stride:int, ?padding:int, ?outputSize:seq<int>) = a.maxunpool1d(indices, kernelSize, ?stride=stride, ?padding=padding, ?outputSize=outputSize)
+
+    /// <summary>TBD</summary>
     static member maxunpool1d(indices:Tensor, kernelSize:int, ?stride:int, ?padding:int, ?outputSize:seq<int>) = fun (a:Tensor) -> a.maxunpool1d(indices, kernelSize, ?stride=stride, ?padding=padding, ?outputSize=outputSize)
+
+    /// <summary>TBD</summary>
     static member maxunpool2d(a:Tensor, indices:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?outputSize:seq<int>) = a.maxunpool2d(indices, ?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings, ?outputSize=outputSize)
+
+    /// <summary>TBD</summary>
     static member maxunpool2d(indices:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?outputSize:seq<int>) = fun (a:Tensor) -> a.maxunpool2d(indices, ?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings, ?outputSize=outputSize)
+
+    /// <summary>TBD</summary>
     static member maxunpool3d(a:Tensor, indices:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?outputSize:seq<int>) = a.maxunpool3d(indices, ?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings, ?outputSize=outputSize)
+
+    /// <summary>TBD</summary>
     static member maxunpool3d(indices:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?outputSize:seq<int>) = fun (a:Tensor) -> a.maxunpool3d(indices, ?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings, ?outputSize=outputSize)
+
+    /// <summary>TBD</summary>
     static member conv1d(a:Tensor, b:Tensor, ?stride:int, ?padding:int, ?dilation:int) = a.conv1d(b, ?stride=stride, ?padding=padding, ?dilation=dilation)
+
+    /// <summary>TBD</summary>
     static member conv1d(b:Tensor, ?stride:int, ?padding:int, ?dilation:int) = fun (a:Tensor) -> a.conv1d(b, ?stride=stride, ?padding=padding, ?dilation=dilation)
+
+    /// <summary>TBD</summary>
     static member conv2d(a:Tensor, b:Tensor, ?stride:int, ?strides:seq<int>, ?padding:int, ?paddings:seq<int>, ?dilation:int, ?dilations:seq<int>) = a.conv2d(b, ?stride=stride, ?strides=strides, ?padding=padding, ?paddings=paddings, ?dilation=dilation, ?dilations=dilations)
+
+    /// <summary>TBD</summary>
     static member conv2d(b:Tensor, ?stride:int, ?strides:seq<int>, ?padding:int, ?paddings:seq<int>, ?dilation:int, ?dilations:seq<int>) = fun (a:Tensor) -> a.conv2d(b, ?stride=stride, ?strides=strides, ?padding=padding, ?paddings=paddings, ?dilation=dilation, ?dilations=dilations)
+
+    /// <summary>TBD</summary>
     static member conv3d(a:Tensor, b:Tensor, ?stride:int, ?strides:seq<int>, ?padding:int, ?paddings:seq<int>, ?dilation:int, ?dilations:seq<int>) = a.conv3d(b, ?stride=stride, ?strides=strides, ?padding=padding, ?paddings=paddings, ?dilation=dilation, ?dilations=dilations)
+
+    /// <summary>TBD</summary>
     static member conv3d(b:Tensor, ?stride:int, ?strides:seq<int>, ?padding:int, ?paddings:seq<int>, ?dilation:int, ?dilations:seq<int>) = fun (a:Tensor) -> a.conv3d(b, ?stride=stride, ?strides=strides, ?padding=padding, ?paddings=paddings, ?dilation=dilation, ?dilations=dilations)
+
+    /// <summary>TBD</summary>
     static member pad(a:Tensor, paddings:seq<int>) = a.pad(paddings)
+
+    /// <summary>TBD</summary>
     static member pad(paddings:seq<int>) = fun (a:Tensor) -> a.pad(paddings)
+
+    /// <summary>TBD</summary>
     static member cast(a:Tensor, dtype:Dtype) = a.cast(dtype)
+
+    /// <summary>TBD</summary>
     static member cast(dtype:Dtype) = fun (a:Tensor) -> a.cast(dtype)
+
+    /// <summary>TBD</summary>
     static member move(a:Tensor, ?dtype, ?device, ?backend) = a.move(?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member move(?dtype, ?device, ?backend) = fun (a:Tensor) -> a.move(?dtype=dtype, ?device=device, ?backend=backend)
+
+    /// <summary>TBD</summary>
     static member config(?dtype: Dtype, ?device: Device, ?backend: Backend) = 
         dtype |> Option.iter (fun d -> Dtype.Default <- d)
         device |> Option.iter (fun d -> Device.Default <- d)
         backend |> Option.iter (fun d -> Backend.Default <- d)
         dsharp.tensor(0.) |> ignore // We need this to ensure the backend assemblies are loaded and backend is ready to set the random seed immediately after config
 
+    /// <summary>TBD</summary>
     static member config() = Dtype.Default, Device.Default, Backend.Default
+
+    /// <summary>TBD</summary>
     static member config((dtype,device,backend)) = dsharp.config(dtype, device, backend)
+
+    /// <summary>TBD</summary>
     static member devices(?deviceType, ?backend) = BackendStatics.Get(?backend=backend).GetDevices(?deviceType=deviceType)
+
+    /// <summary>TBD</summary>
     static member isDeviceTypeSupported(deviceType, ?backend) = BackendStatics.Get(?backend=backend).IsDeviceTypeSupported(deviceType)
+
+    /// <summary>TBD</summary>
     static member isCudaSupported(?backend) = BackendStatics.Get(?backend=backend).IsDeviceTypeSupported(DeviceType.CUDA)
 
 // Methods mirroring F# array modules
 // TODO: implement more differentiable higher-order functions and corresponding unit tests for their derivatives
 type dsharp with
+
+    /// <summary>TBD</summary>
     static member init (count:int) (initializer:int->'a) = Array.init count initializer |> dsharp.tensor
+
+    /// <summary>TBD</summary>
     static member init2d (length1:int) (length2:int) (initializer:int->int->'a) = Array2D.init length1 length2 initializer |> dsharp.tensor
+
+    /// <summary>TBD</summary>
     static member init3d (length1:int) (length2:int) (length3:int) (initializer:int->int->int->'a) = Array3D.init length1 length2 length3 initializer |> dsharp.tensor
+
+    /// <summary>TBD</summary>
     static member init4d (length1:int) (length2:int) (length3:int) (length4:int) (initializer:int->int->int->int->'a) = Array4D.init length1 length2 length3 length4 initializer |> dsharp.tensor
+
+    /// <summary>TBD</summary>
     static member create (count:int) (value:'a) = Array.create count value |> dsharp.tensor
+
+    /// <summary>TBD</summary>
     static member zeroCreate (count:int) = Array.zeroCreate count |> dsharp.tensor
+
+    /// <summary>TBD</summary>
     static member mapi (mapping:int[]->Tensor->Tensor) (tensor:Tensor) = // Differentiable map
         let tflat = tensor.view(-1)
         let items = Array.init (tflat.nelement) (fun i -> mapping (flatIndexToIndex tensor.shape i) tflat.[i])
         dsharp.stack(items).view(tensor.shape)
+
+
+    /// <summary>TBD</summary>
     static member mapi2 (mapping:int[]->Tensor->Tensor->Tensor) (tensor1:Tensor) (tensor2:Tensor) =  // Differentiable map2
         if tensor1.shape <> tensor2.shape then failwithf "Expecting tensor1.shape (%A) and tensor2.shape (%A) to be the same" tensor1.shape tensor2.shape
         let tflat1 = tensor1.view(-1)
         let tflat2 = tensor2.view(-1)
         let items = Array.init (tflat1.nelement) (fun i -> mapping (flatIndexToIndex tensor1.shape i) tflat1.[i] tflat2.[i])
         dsharp.stack(items).view(tensor1.shape)
+
+    /// <summary>TBD</summary>
     static member mapi3 (mapping:int[]->Tensor->Tensor->Tensor->Tensor) (tensor1:Tensor) (tensor2:Tensor) (tensor3:Tensor) =  // Differentiable map3
         if (tensor1.shape <> tensor2.shape) || (tensor2.shape <> tensor3.shape) then failwithf "Expecting tensor1.shape (%A), tensor2.shape (%A), tensor3.shape (%A) to be the same" tensor1.shape tensor2.shape tensor3.shape
         let tflat1 = tensor1.view(-1)
@@ -259,31 +710,66 @@ type dsharp with
         let tflat3 = tensor3.view(-1)
         let items = Array.init (tflat1.nelement) (fun i -> mapping (flatIndexToIndex tensor1.shape i) tflat1.[i] tflat2.[i] tflat3.[i])
         dsharp.stack(items).view(tensor1.shape)
-    static member map (mapping:Tensor->Tensor) (tensor:Tensor) = tensor |> dsharp.mapi (fun _ v -> mapping v)
-    static member map2 (mapping:Tensor->Tensor->Tensor) (tensor1:Tensor) (tensor2:Tensor) = dsharp.mapi2 (fun _ v1 v2 -> mapping v1 v2) tensor1 tensor2
-    static member map3 (mapping:Tensor->Tensor->Tensor->Tensor) (tensor1:Tensor) (tensor2:Tensor) (tensor3:Tensor) = dsharp.mapi3 (fun _ v1 v2 v3 -> mapping v1 v2 v3) tensor1 tensor2 tensor3
 
+    /// <summary>TBD</summary>
+    static member map (mapping:Tensor->Tensor) (tensor:Tensor) = tensor |> dsharp.mapi (fun _ v -> mapping v)
+
+    /// <summary>TBD</summary>
+    static member map2 (mapping:Tensor->Tensor->Tensor) (tensor1:Tensor) (tensor2:Tensor) = dsharp.mapi2 (fun _ v1 v2 -> mapping v1 v2) tensor1 tensor2
+
+    /// <summary>TBD</summary>
+    static member map3 (mapping:Tensor->Tensor->Tensor->Tensor) (tensor1:Tensor) (tensor2:Tensor) (tensor3:Tensor) = dsharp.mapi3 (fun _ v1 v2 v3 -> mapping v1 v2 v3) tensor1 tensor2 tensor3
 
 // Functional automatic differentiation API
 type dsharp with
+
+    /// <summary>TBD</summary>
     static member nest() = GlobalNestingLevel.Next() |> ignore
+
+    /// <summary>TBD</summary>
     static member nest(level) = GlobalNestingLevel.Set(level)
+
+    /// <summary>TBD</summary>
     static member nestLevel() = GlobalNestingLevel.Current
+
+    /// <summary>TBD</summary>
     static member nestReset() = GlobalNestingLevel.Reset()
+
+    /// <summary>TBD</summary>
     static member primal (tensor:Tensor) = tensor.primal
+
+    /// <summary>TBD</summary>
     static member derivative (tensor:Tensor) = tensor.derivative
+
+    /// <summary>TBD</summary>
     static member primalDerivative (tensor:Tensor) = tensor.primal, tensor.derivative
+
+    /// <summary>TBD</summary>
     static member forwardDiff (tag:uint32) (derivative:Tensor) (tensor:Tensor) = tensor.forwardDiff(derivative, tag)
+
+    /// <summary>TBD</summary>
     static member reverseDiff (tag:uint32) (tensor:Tensor) = tensor.reverseDiff(tag)
+
+    /// <summary>TBD</summary>
     static member reverseReset (tensor:Tensor) = tensor.reverseReset(true)
+
+    /// <summary>TBD</summary>
     static member reversePush (value:Tensor) (tensor:Tensor) = tensor.reversePush(value)
+
+    /// <summary>TBD</summary>
     static member reverse (value:Tensor) (tensor:Tensor) = tensor.reverse(value)
+
+    /// <summary>TBD</summary>
     static member evalForwardDiff f x v = x |> dsharp.forwardDiff (GlobalNestingLevel.Next()) v |> f |> dsharp.primalDerivative
+
+    /// <summary>TBD</summary>
     static member evalReverseDiff f x =
         let x = x |> dsharp.reverseDiff (GlobalNestingLevel.Next())
         let fx = f x
         let r = fun v -> fx |> dsharp.reverse v; x.derivative
         fx.primal, r
+
+    /// <summary>TBD</summary>
     static member evalForwardDiffs (f:Tensor->Tensor) x (v:Tensor[]) =
         let n = v.Length
         if n = 0 then [|f x|]
@@ -297,37 +783,65 @@ type dsharp with
                 fx <- fx.primal
                 d
                 |] |> Array.rev |> Array.append [|fx|]
+
+    /// <summary>TBD</summary>
     static member fjacobianv f (x:Tensor) (v:Tensor) = 
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let fx, d = dsharp.evalForwardDiff f x v
         if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, d
+
+    /// <summary>TBD</summary>
     static member jacobianv f x v = dsharp.fjacobianv f x v |> snd
+
+    /// <summary>TBD</summary>
     static member fgradv f (x:Tensor) (v:Tensor) =
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let fx, d = dsharp.evalForwardDiff f x v
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, d
+
+    /// <summary>TBD</summary>
     static member gradv f x v = dsharp.fgradv f x v |> snd
+
+    /// <summary>TBD</summary>
     static member fdiff f (x:Tensor) =
         let fx, d = dsharp.evalForwardDiff f x (x.onesLike())
         if x.dim <> 0 then failwithf "f must be a function of a scalar, encountered f:%A->%A" x.shape fx.shape
         fx, d
+
+    /// <summary>TBD</summary>
     static member diff f x = dsharp.fdiff f x |> snd
+
+    /// <summary>TBD</summary>
     static member ffdiffn (n:int) (f:Tensor->Tensor) (x:Tensor) =
         if n < 0 then failwith "Differentiation order n must be >= 0"
         if x.dim <> 0 then failwithf "f must be a function of a scalar"
         dsharp.evalForwardDiffs f x (Array.create n (x.onesLike()))
+
+    /// <summary>TBD</summary>
     static member fdiffn n f x = let a = dsharp.ffdiffn n f x in a |> Array.head, a |> Array.last
+
+    /// <summary>TBD</summary>
     static member diffn n f x = dsharp.fdiffn n f x |> snd
+
+    /// <summary>TBD</summary>
     static member fdiff2 f x = dsharp.fdiffn 2 f x
+
+    /// <summary>TBD</summary>
     static member diff2 f x = dsharp.diffn 2 f x
+
+    /// <summary>TBD</summary>
     static member fjacobianTv f x (v:Tensor) =
         let fx, r = dsharp.evalReverseDiff f x
         if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         if fx.nelement <> v.nelement then failwithf "(f x) and v must have the same number of elements"
         fx, r v
+
+    /// <summary>TBD</summary>
     static member jacobianTv f x v = dsharp.fjacobianTv f x v |> snd
+
+    /// <summary>TBD</summary>
     static member fjacobian (f:Tensor->Tensor) x =
         let fx, r = dsharp.evalReverseDiff f x
         if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
@@ -335,7 +849,11 @@ type dsharp with
             fx, dsharp.stack(Array.init fx.nelement (fun i -> r (x.onehotLike(fx.nelement, i))), 0)
         else
             fx, dsharp.stack(Array.init x.nelement (fun j -> dsharp.jacobianv f x (x.onehotLike(x.nelement, j))), 1)
+
+    /// <summary>TBD</summary>
     static member jacobian f x = dsharp.fjacobian f x |> snd
+
+    /// <summary>TBD</summary>
     static member fgrad f (x:Tensor) =
         if x.dim = 0 then 
             dsharp.fdiff f x
@@ -343,16 +861,28 @@ type dsharp with
             let fx, r = dsharp.evalReverseDiff f x
             if x.dim > 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector or scalar, encountered f:%A->%A" x.shape fx.shape
             fx, r (fx.onesLike())
+
+    /// <summary>TBD</summary>
     static member grad f x = dsharp.fgrad f x |> snd
+
+    /// <summary>TBD</summary>
     static member fgradhessianv f (x:Tensor) (v:Tensor) =
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let x = x |> dsharp.reverseDiff (GlobalNestingLevel.Next())
         let fx, gv = dsharp.fgradv f x v
         gv.reverse()
         fx.primal, gv.primal, x.derivative
+
+    /// <summary>TBD</summary>
     static member gradhessianv f x v = let _, gv, hv = dsharp.fgradhessianv f x v in gv, hv
+
+    /// <summary>TBD</summary>
     static member fhessianv f x v = let fx, _, hv = dsharp.fgradhessianv f x v in fx, hv
+
+    /// <summary>TBD</summary>
     static member hessianv f x v = dsharp.fhessianv f x v |> snd
+
+    /// <summary>TBD</summary>
     static member fgradhessian (f:Tensor->Tensor) (x:Tensor) =
         let mutable fx = dsharp.zero()
         let gvs, hvs = Array.init x.nelement (fun j -> let ffxx, gv, hv = dsharp.fgradhessianv f x (x.onehotLike(x.nelement, j)) in fx <- ffxx; gv, hv) |> Array.unzip
@@ -360,88 +890,167 @@ type dsharp with
         let g = dsharp.stack(gvs)
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, g, h
+
+    /// <summary>TBD</summary>
     static member gradhessian f x = let _, g, h = dsharp.fgradhessian f x in g, h
+
+    /// <summary>TBD</summary>
     static member fhessian (f:Tensor->Tensor) (x:Tensor) =
         let mutable fx = dsharp.zero()
         let h = dsharp.stack(Array.init x.nelement (fun j -> let ffxx, hv = dsharp.fhessianv f x (x.onehotLike(x.nelement, j)) in fx <- ffxx; hv), 1)
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, h
+
+    /// <summary>TBD</summary>
     static member hessian f x = dsharp.fhessian f x |> snd
+
+    /// <summary>TBD</summary>
     static member flaplacian f x =
         let fx, h = dsharp.fhessian f x
         fx, h.trace()
+
+    /// <summary>TBD</summary>
     static member laplacian f x = dsharp.flaplacian f x |> snd
+
+    /// <summary>TBD</summary>
     static member fcurl f x =
         let fx, j = dsharp.fjacobian f x
         if j.shape <> [|3; 3|] then failwithf "f must be a function with a three-by-three Jacobian"
         fx, dsharp.stack([j.[2, 1] - j.[1, 2]; j.[0, 2] - j.[2, 0]; j.[1, 0] - j.[0, 1]])
+
+    /// <summary>TBD</summary>
     static member curl f x = dsharp.fcurl f x |> snd
+
+    /// <summary>TBD</summary>
     static member fdivergence f x =
         let fx, j = dsharp.fjacobian f x
         if j.shape.[0] <> j.shape.[1] then failwithf "f must have a square Jacobian"
         fx, j.trace()
+
+    /// <summary>TBD</summary>
     static member divergence f x = dsharp.fdivergence f x |> snd
+
+    /// <summary>TBD</summary>
     static member fcurldivergence f x =
         let fx, j = dsharp.fjacobian f x
         if j.shape <> [|3; 3|] then failwithf "f must be a function with a three-by-three Jacobian"
         fx, dsharp.stack([j.[2, 1] - j.[1, 2]; j.[0, 2] - j.[2, 0]; j.[1, 0] - j.[0, 1]]), j.trace()
+
+    /// <summary>TBD</summary>
     static member curldivergence f x = let _, c, d = dsharp.fcurldivergence f x in c, d
 
 
 // Functional automatic differentiation API shorthand names
 type dsharp with
-    static member gvp f x v = dsharp.gradv f x v
-    static member g f x = dsharp.grad f x
-    static member hvp f x v = dsharp.hessianv f x v
-    static member h f x = dsharp.hessian f x
-    static member gh f x = dsharp.gradhessian f x
-    static member ghvp f x v = dsharp.gradhessianv f x v
-    static member jvp f x v = dsharp.jacobianv f x v
-    static member vjp f x v = dsharp.jacobianTv f x v
-    static member j f x = dsharp.jacobian f x
-    static member fgvp f x v = dsharp.fgradv f x v
-    static member fg f x = dsharp.fgrad f x
-    static member fgh f x = dsharp.fgradhessian f x
-    static member fhvp f x v = dsharp.fhessianv f x v
-    static member fh f x = dsharp.fhessian f x
-    static member fghvp f x v = dsharp.fgradhessianv f x v
-    static member fjvp f x v = dsharp.fjacobianv f x v
-    static member fvjp f x v = dsharp.fjacobianTv f x v
-    static member fj f x = dsharp.fjacobian f x    
 
+    /// <summary>TBD</summary>
+    static member gvp f x v = dsharp.gradv f x v
+
+    /// <summary>TBD</summary>
+    static member g f x = dsharp.grad f x
+
+    /// <summary>TBD</summary>
+    static member hvp f x v = dsharp.hessianv f x v
+
+    /// <summary>TBD</summary>
+    static member h f x = dsharp.hessian f x
+
+    /// <summary>TBD</summary>
+    static member gh f x = dsharp.gradhessian f x
+
+    /// <summary>TBD</summary>
+    static member ghvp f x v = dsharp.gradhessianv f x v
+
+    /// <summary>TBD</summary>
+    static member jvp f x v = dsharp.jacobianv f x v
+
+    /// <summary>TBD</summary>
+    static member vjp f x v = dsharp.jacobianTv f x v
+
+    /// <summary>TBD</summary>
+    static member j f x = dsharp.jacobian f x
+
+    /// <summary>TBD</summary>
+    static member fgvp f x v = dsharp.fgradv f x v
+
+    /// <summary>TBD</summary>
+    static member fg f x = dsharp.fgrad f x
+
+    /// <summary>TBD</summary>
+    static member fgh f x = dsharp.fgradhessian f x
+
+    /// <summary>TBD</summary>
+    static member fhvp f x v = dsharp.fhessianv f x v
+
+    /// <summary>TBD</summary>
+    static member fh f x = dsharp.fhessian f x
+
+    /// <summary>TBD</summary>
+    static member fghvp f x v = dsharp.fgradhessianv f x v
+
+    /// <summary>TBD</summary>
+    static member fjvp f x v = dsharp.fjacobianv f x v
+
+    /// <summary>TBD</summary>
+    static member fvjp f x v = dsharp.fjacobianTv f x v
+
+    /// <summary>TBD</summary>
+    static member fj f x = dsharp.fjacobian f x    
 
 // Functional numerical differentiation API
 type dsharp with
+
+    /// <summary>TBD</summary>
     static member numdiff (epsilon:float) (f:Tensor->Tensor) (x:Tensor) = 
         if x.dim <> 0 then failwithf "f must be a function of a scalar"
         ((f (x + epsilon)) - (f (x - epsilon))) / (2.*epsilon)
+
+    /// <summary>TBD</summary>
     static member numfdiff epsilon f x = f x, dsharp.numdiff epsilon f x
+
+    /// <summary>TBD</summary>
     static member numfdiff2 (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
         if x.dim <> 0 then failwithf "f must be a function of a scalar"
         let fx = f x
         fx, ((f (x + epsilon)) - 2. * fx + (f (x - epsilon))) / (epsilon * epsilon)
+
+    /// <summary>TBD</summary>
     static member numdiff2 epsilon f x = dsharp.numfdiff2 epsilon f x |> snd
+
+    /// <summary>TBD</summary>
     static member numjacobianv (epsilon:float) (f:Tensor->Tensor) (x:Tensor) (v:Tensor) =
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let veps = v * epsilon
         let fxa, fxb = f (x+veps), f (x-veps)
         if x.dim <> 1 || fxa.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fxa.shape
         (fxa - fxb) / (2.*epsilon)
+
+    /// <summary>TBD</summary>
     static member numfjacobianv epsilon f x v = f x, dsharp.numjacobianv epsilon f x v
+
+    /// <summary>TBD</summary>
     static member numfjacobian (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
         let fx = f x
         if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         let j = fx.expand([x.nelement; fx.nelement])
         let jj = dsharp.stack(Array.init x.nelement (fun i -> f (x + dsharp.onehot(x.nelement, i)*epsilon)))
         fx, (jj - j).transpose() / epsilon
+
+    /// <summary>TBD</summary>
     static member numjacobian epsilon f x = dsharp.numfjacobian epsilon f x |> snd
+
+    /// <summary>TBD</summary>
     static member numgradv (epsilon:float) (f:Tensor->Tensor) (x:Tensor) (v:Tensor) =
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let veps = v * epsilon
         let fxa, fxb = f (x + veps), f (x - veps)
         if x.dim <> 1 || fxa.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fxa.shape
         (fxa - fxb) / (2.*epsilon)
+
+    /// <summary>TBD</summary>
     static member numfgradv epsilon f x v = f x, dsharp.numgradv epsilon f x v
+
+    /// <summary>TBD</summary>
     static member numfgrad (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
         if x.dim = 0 then
             dsharp.numfdiff epsilon f x
@@ -450,16 +1059,28 @@ type dsharp with
             if x.dim > 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector or scalar, encountered f:%A->%A" x.shape fx.shape
             let gg = dsharp.stack(Array.init x.nelement (fun i -> let h = dsharp.onehot(x.nelement, i)*epsilon in f (x + h) - f (x - h)))
             fx, gg/(2.*epsilon)
+
+    /// <summary>TBD</summary>
     static member numgrad epsilon f x = dsharp.numfgrad epsilon f x |> snd
+
+    /// <summary>TBD</summary>
     static member numfgradhessian (epsilon:float) (f:Tensor->Tensor) (x:Tensor) =
         let fx, g = dsharp.numfgrad epsilon f x
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         let h = g.expand([x.nelement; x.nelement])
         let hh = dsharp.stack(Array.init x.nelement (fun i -> dsharp.numgrad epsilon f (x + dsharp.onehot(x.nelement, i)*epsilon)))
         fx, g, (hh - h) / epsilon
+
+    /// <summary>TBD</summary>
     static member numgradhessian epsilon f x = let _, g, h = dsharp.numfgradhessian epsilon f x in g, h
+
+    /// <summary>TBD</summary>
     static member numfhessian epsilon f x = let fx, _, h = dsharp.numfgradhessian epsilon f x in fx, h
+
+    /// <summary>TBD</summary>
     static member numhessian epsilon f x = dsharp.numfhessian epsilon f x |> snd
+
+    /// <summary>TBD</summary>
     static member numfhessianv (epsilon:float) (f:Tensor->Tensor) (x:Tensor) (v:Tensor) =
         if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
         let veps = v*epsilon
@@ -467,41 +1088,87 @@ type dsharp with
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         let gg = dsharp.numgrad epsilon f (x + veps)
         fx, (gg-g)/epsilon
+
+    /// <summary>TBD</summary>
     static member numhessianv epsilon f x v = dsharp.numfhessianv epsilon f x v |> snd
+
+    /// <summary>TBD</summary>
     static member numflaplacian epsilon f x =
         let fx, h = dsharp.numfhessian epsilon f x
         fx, h.trace()
+
+    /// <summary>TBD</summary>
     static member numlaplacian epsilon f x = dsharp.numflaplacian epsilon f x |> snd
+
+    /// <summary>TBD</summary>
     static member numfcurl epsilon f x =
         let fx, j = dsharp.numfjacobian epsilon f x
         if j.shape <> [|3; 3|] then failwithf "f must be a function with a three-by-three Jacobian"
         fx, dsharp.stack([j.[2, 1] - j.[1, 2]; j.[0, 2] - j.[2, 0]; j.[1, 0] - j.[0, 1]])
+
+    /// <summary>TBD</summary>
     static member numcurl epsilon f x = dsharp.numfcurl epsilon f x |> snd
+
+    /// <summary>TBD</summary>
     static member numfdivergence epsilon f x =
         let fx, j = dsharp.numfjacobian epsilon f x
         if j.shape.[0] <> j.shape.[1] then failwithf "f must have a square Jacobian"
         fx, j.trace()
+
+    /// <summary>TBD</summary>
     static member numdivergence epsilon f x = dsharp.numfdivergence epsilon f x |> snd
+
+    /// <summary>TBD</summary>
     static member numfcurldivergence epsilon f x =
         let fx, j = dsharp.numfjacobian epsilon f x
         if j.shape <> [|3; 3|] then failwithf "f must be a function with a three-by-three Jacobian"
         fx, dsharp.stack([j.[2, 1] - j.[1, 2]; j.[0, 2] - j.[2, 0]; j.[1, 0] - j.[0, 1]]), j.trace()
+
+    /// <summary>TBD</summary>
     static member numcurldivergence epsilon f x = let _, c, d = dsharp.numfcurldivergence epsilon f x in c, d
 
 
 // Functional numerical differentiation API shorthand names
 type dsharp with
+
+    /// <summary>TBD</summary>
     static member numgvp f x v = dsharp.numgradv f x v
+
+    /// <summary>TBD</summary>
     static member numg f x = dsharp.numgrad f x
+
+    /// <summary>TBD</summary>
     static member numhvp f x v = dsharp.numhessianv f x v
+
+    /// <summary>TBD</summary>
     static member numh f x = dsharp.numhessian f x
+
+    /// <summary>TBD</summary>
     static member numgh f x = dsharp.numgradhessian f x
+
+    /// <summary>TBD</summary>
     static member numjvp f x v = dsharp.numjacobianv f x v
+
+    /// <summary>TBD</summary>
     static member numj f x = dsharp.numjacobian f x
+
+    /// <summary>TBD</summary>
     static member numfgvp f x v = dsharp.numfgradv f x v
+
+    /// <summary>TBD</summary>
     static member numfg f x = dsharp.numfgrad f x
+
+    /// <summary>TBD</summary>
     static member numfhvp f x v = dsharp.numfhessianv f x v
+
+    /// <summary>TBD</summary>
     static member numfh f x = dsharp.numfhessian f x
+
+    /// <summary>TBD</summary>
     static member numfgh f x = dsharp.numfgradhessian f x
+
+    /// <summary>TBD</summary>
     static member numfjvp f x v = dsharp.numfjacobianv f x v
+
+    /// <summary>TBD</summary>
     static member numfj f x = dsharp.numfjacobian f x    

--- a/src/DiffSharp.Core/Distributions.fs
+++ b/src/DiffSharp.Core/Distributions.fs
@@ -17,60 +17,118 @@ module internal Utils =
 
 
 [<AbstractClass>]
+/// <summary>TBD</summary>
 type Distribution<'T>() =
+
+    /// <summary>TBD</summary>
     abstract member sample: unit -> 'T
+
+    /// <summary>TBD</summary>
     abstract member logprob: 'T -> Tensor
 
 
 [<AbstractClass>]
+/// <summary>TBD</summary>
 type TensorDistribution() =
     inherit Distribution<Tensor>()
+
+    /// <summary>TBD</summary>
     member d.sample(numSamples:int) = Array.init numSamples (fun _ -> d.sample()) |> dsharp.stack
+
+    /// <summary>TBD</summary>
     abstract member batchShape: int[]
+
+    /// <summary>TBD</summary>
     abstract member eventShape: int[]
+
+    /// <summary>TBD</summary>
     abstract member mean: Tensor
+
+    /// <summary>TBD</summary>
     abstract member stddev: Tensor
+
+    /// <summary>TBD</summary>
     abstract member variance: Tensor
+
     default d.stddev = d.variance.sqrt()
     default d.variance = d.stddev * d.stddev
+
+    /// <summary>TBD</summary>
     member d.prob(value) = d.logprob(value).exp()
 
 
+/// <summary>TBD</summary>
 type Normal(mean:Tensor, stddev:Tensor) =
     inherit TensorDistribution()
     do if mean.shape <> stddev.shape then failwithf "Expecting mean and standard deviation with same shape, received %A, %A" mean.shape stddev.shape
     do if mean.dim > 1 then failwithf "Expecting scalar parameters (0-dimensional mean and stddev) or a batch of scalar parameters (1-dimensional mean and stddev)"
+
+    /// <summary>TBD</summary>
     override d.batchShape = d.mean.shape
+
+    /// <summary>TBD</summary>
     override d.eventShape = [||]
+
+    /// <summary>TBD</summary>
     override d.mean = mean
+
+    /// <summary>TBD</summary>
     override d.stddev = stddev
+
+    /// <summary>TBD</summary>
     override d.sample() = d.mean + dsharp.randnLike(d.mean) * d.stddev
+
+    /// <summary>TBD</summary>
     override d.logprob(value) = 
         if value.shape <> d.batchShape then failwithf "Expecting a value with shape %A, received %A" d.batchShape value.shape
         let v = value - d.mean in -(v * v) / (2. * d.variance) - (log d.stddev) - logSqrt2Pi
+
+    /// <summary>TBD</summary>
     override d.ToString() = sprintf "Normal(mean:%A, stddev:%A)" d.mean d.stddev
 
 
+/// <summary>TBD</summary>
 type Uniform(low:Tensor, high:Tensor) =
     inherit TensorDistribution()
     do if low.shape <> high.shape then failwithf "Expecting low and high with same shape, received %A, %A" low.shape high.shape
     do if low.dim > 1 then failwithf "Expecting scalar parameters (0-dimensional low and high) or a batch of scalar parameters (1-dimensional low and high)"
+
+    /// <summary>TBD</summary>
     member d.low = low
+
+    /// <summary>TBD</summary>
     member d.high = high
+
+    /// <summary>TBD</summary>
     member d.range = high - low
+
+    /// <summary>TBD</summary>
     override d.batchShape = low.shape
+
+    /// <summary>TBD</summary>
     override d.eventShape = [||]
+
+    /// <summary>TBD</summary>
     override d.mean = (low + high) / 2.
+
+    /// <summary>TBD</summary>
     override d.variance = d.range * d.range / 12.
+
+    /// <summary>TBD</summary>
     override d.sample() = d.low + dsharp.randLike(d.low) * d.range
+
+    /// <summary>TBD</summary>
     override d.logprob(value) = 
         if value.shape <> d.batchShape then failwithf "Expecting a value with shape %A, received %A" d.batchShape value.shape
         let lb = low.le(value).cast(low.dtype)
         let ub = high.gt(value).cast(high.dtype)
         log (lb * ub) - log d.range
+
+    /// <summary>TBD</summary>
     override d.ToString() = sprintf "Uniform(low:%A, high:%A)" d.low d.high
 
 
+/// <summary>TBD</summary>
 type Bernoulli(?probs:Tensor, ?logits:Tensor) =
     inherit TensorDistribution()
     let _probs, _logits, _dtype =
@@ -79,20 +137,39 @@ type Bernoulli(?probs:Tensor, ?logits:Tensor) =
         | Some p, None -> let pp = p.float() in clampProbs pp, probsToLogits pp true, p.dtype  // Do not normalize probs
         | None, Some lp -> let lpp = lp.float() in logitsToProbs lpp true, lpp, lp.dtype  // Do not normalize logits
         | None, None -> failwithf "Expecting either probs or logits"
+
+    /// <summary>TBD</summary>
     member d.probs = _probs.cast(_dtype)
+
+    /// <summary>TBD</summary>
     member d.logits = _logits.cast(_dtype)
+
+    /// <summary>TBD</summary>
     override d.batchShape = d.probs.shape
+
+    /// <summary>TBD</summary>
     override d.eventShape = [||]
+
+    /// <summary>TBD</summary>
     override d.mean = d.probs
+
+    /// <summary>TBD</summary>
     override d.variance = (_probs * (1. - _probs)).cast(_dtype)
+
+    /// <summary>TBD</summary>
     override d.sample() = dsharp.bernoulli(_probs).cast(_dtype)
+
+    /// <summary>TBD</summary>
     override d.logprob(value) =
         if value.shape <> d.batchShape then failwithf "Expecting a value with shape %A, received %A" d.batchShape value.shape
         let lp = (_probs ** value) * ((1. - _probs) ** (1. - value))  // Correct but numerical stability can be improved
         lp.log().cast(_dtype)
+
+    /// <summary>TBD</summary>
     override d.ToString() = sprintf "Bernoulli(probs:%A)" d.probs
 
 
+/// <summary>TBD</summary>
 type Categorical(?probs:Tensor, ?logits:Tensor) =
     inherit TensorDistribution()
     let _probs, _logits, _dtype =
@@ -102,13 +179,29 @@ type Categorical(?probs:Tensor, ?logits:Tensor) =
         | None, Some lp -> let lpp = (lp - lp.logsumexp(-1, keepDim=true)).float() in logitsToProbs lpp false, lpp, lp.dtype  // Normalize logits
         | None, None -> failwithf "Expecting either probs or logits"    
     do if _probs.dim < 1 || _probs.dim > 2 then failwithf "Expecting vector parameters (1-dimensional probs or logits) or batch of vector parameters (2-dimensional probs or logits), received shape %A" _probs.shape
+
+    /// <summary>TBD</summary>
     member d.probs = _probs.cast(_dtype)
+
+    /// <summary>TBD</summary>
     member d.logits = _logits.cast(_dtype)
+
+    /// <summary>TBD</summary>
     override d.batchShape = if d.probs.dim = 1 then [||] else [|d.probs.shape.[0]|]
+
+    /// <summary>TBD</summary>
     override d.eventShape = [||]
+
+    /// <summary>TBD</summary>
     override d.mean = dsharp.onesLike(d.probs) * System.Double.NaN
+
+    /// <summary>TBD</summary>
     override d.stddev = dsharp.onesLike(d.probs) * System.Double.NaN
+
+    /// <summary>TBD</summary>
     override d.sample() = dsharp.multinomial(_probs, 1).cast(_dtype).squeeze()
+
+    /// <summary>TBD</summary>
     override d.logprob(value) =
         if value.shape <> d.batchShape then failwithf "Expecting a value with shape %A, received %A" d.batchShape value.shape
         if d.batchShape.Length = 0 then
@@ -118,9 +211,12 @@ type Categorical(?probs:Tensor, ?logits:Tensor) =
             let is = value.int().toArray() :?> int[]
             let lp = Array.init d.batchShape.[0] (fun i -> _logits.[i, is.[i]]) |> dsharp.stack
             lp.cast(_dtype)
+
+    /// <summary>TBD</summary>
     override d.ToString() = sprintf "Categorical(probs:%A)" d.probs
 
 
+/// <summary>TBD</summary>
 type Empirical<'T when 'T:equality>(values:seq<'T>, ?weights:Tensor, ?logWeights:Tensor, ?combineDuplicates:bool) =
     inherit Distribution<'T>()
     let _categorical, _weighted =
@@ -156,25 +252,49 @@ type Empirical<'T when 'T:equality>(values:seq<'T>, ?weights:Tensor, ?logWeights
             _values <- newValues
             _categorical <- Categorical(logits=newLogWeights)
         _weighted <- not (Seq.allEqual (_categorical.probs.unstack()))
+
+    /// <summary>TBD</summary>
     member d.values = _values
+
+    /// <summary>TBD</summary>
     member d.valuesTensor = _valuesTensor.Force()
+
+    /// <summary>TBD</summary>
     member d.length = d.values.Length
+
+    /// <summary>TBD</summary>
     member d.weights = _categorical.probs
+
+    /// <summary>TBD</summary>
     member d.logWeights = _categorical.logits
+
+    /// <summary>TBD</summary>
     member d.isWeighted = _weighted
+
+    /// <summary>TBD</summary>
     member d.Item
         with get(i) = d.values.[i], d.weights.[i]
+
+    /// <summary>TBD</summary>
     member d.GetSlice(start, finish) =
         let start = defaultArg start 0
         let finish = defaultArg finish d.length - 1
         Empirical(d.values.[start..finish], logWeights=d.logWeights.[start..finish])
+
+    /// <summary>TBD</summary>
     member d.unweighted() = Empirical(d.values)
+
+    /// <summary>TBD</summary>
     member d.map (f:'T->'a) = Empirical(Array.map f d.values, logWeights=d.logWeights)
+
+    /// <summary>TBD</summary>
     member d.filter (predicate:'T->bool) =
         let results = ResizeArray<'T*Tensor>()
         Array.iteri (fun i v -> if predicate v then results.Add(v, d.logWeights.[i])) d.values
         let v, lw = results.ToArray() |> Array.unzip
         Empirical(v, logWeights=dsharp.stack(lw))
+
+    /// <summary>TBD</summary>
     member d.sample(?minIndex:int, ?maxIndex:int) = // minIndex is inclusive, maxIndex is exclusive
         let minIndex = defaultArg minIndex 0
         let maxIndex = defaultArg maxIndex d.length
@@ -185,7 +305,11 @@ type Empirical<'T when 'T:equality>(values:seq<'T>, ?weights:Tensor, ?logWeights
             d.[minIndex..maxIndex].sample()
         else
             let i = _categorical.sample() |> int in d.values.[i]
+
+    /// <summary>TBD</summary>
     member d.resample(numSamples, ?minIndex:int, ?maxIndex:int) = Array.init numSamples (fun _ -> d.sample(?minIndex=minIndex, ?maxIndex=maxIndex)) |> Empirical
+
+    /// <summary>TBD</summary>
     member d.thin(numSamples, ?minIndex:int, ?maxIndex:int) = 
         if d.isWeighted then failwithf "Cannot thin weighted distribution. Consider transforming Empirical to an unweigted Empirical by resampling."
         let minIndex = defaultArg minIndex 0
@@ -196,13 +320,25 @@ type Empirical<'T when 'T:equality>(values:seq<'T>, ?weights:Tensor, ?logWeights
             let v = d.values.[i]
             results.Add(v)
         Empirical(results.ToArray())
+
+    /// <summary>TBD</summary>
     member d.combineDuplicates() = Empirical(d.values, logWeights=d.logWeights, combineDuplicates=true)
+
+    /// <summary>TBD</summary>
     member d.expectation (f:Tensor->Tensor) =
         if d.isWeighted then d.valuesTensor.unstack() |> Seq.mapi (fun i v -> d.weights.[i]*(f v)) |> dsharp.stack |> dsharp.sum(0)
         else d.valuesTensor.unstack() |> Seq.map f |> dsharp.stack |> dsharp.mean(0)
+
+    /// <summary>TBD</summary>
     member d.mean = d.expectation(id)
+
+    /// <summary>TBD</summary>
     member d.variance = let mean = d.mean in d.expectation(fun x -> (x-mean)**2)
+
+    /// <summary>TBD</summary>
     member d.stddev = dsharp.sqrt(d.variance)
+
+    /// <summary>TBD</summary>
     member d.mode =
         if d.isWeighted then 
             let dCombined = d.combineDuplicates()
@@ -210,9 +346,24 @@ type Empirical<'T when 'T:equality>(values:seq<'T>, ?weights:Tensor, ?logWeights
         else
             let vals, _ = d.values |> Array.getUniqueCounts true
             vals.[0]
+
+    /// <summary>TBD</summary>
     member d.min = d.valuesTensor.min()
+
+    /// <summary>TBD</summary>
     member d.max = d.valuesTensor.max()
+
+    /// <summary>TBD</summary>
     member d.effectiveSampleSize = 1. / d.weights.pow(2).sum()
+
+    /// <summary>TBD</summary>
     override d.sample() = d.sample(minIndex=0, maxIndex=d.length)
+
+    /// <summary>TBD</summary>
     override d.logprob(_) = failwith "Not supported"  // TODO: can be implemented using density estimation
+
+    /// <summary>TBD</summary>
+
+    /// <summary>TBD</summary>
     override d.ToString() = sprintf "Empirical(length:%A)" d.length
+

--- a/src/DiffSharp.Core/Optim.fs
+++ b/src/DiffSharp.Core/Optim.fs
@@ -6,12 +6,20 @@ open DiffSharp.Util
 
 
 [<AbstractClass>]
+/// <summary>TBD</summary>
 type Optimizer(model:Model) =
+
+    /// <summary>TBD</summary>
     member val model = model
+
+    /// <summary>TBD</summary>
     member o.step() = model.parametersDict.iter(fun (n, p) -> let t = o.updateRule n p.value in p.value <- t)
+
+    /// <summary>TBD</summary>
     abstract member updateRule: string -> Tensor -> Tensor
 
 
+/// <summary>TBD</summary>
 type SGD(model, ?lr:Tensor, ?momentum:Tensor, ?nesterov:bool, ?weightDecay:Tensor, ?reversible:bool) =
     inherit Optimizer(model)
     let lr = defaultArg lr (dsharp.tensor(1e-3))
@@ -19,6 +27,8 @@ type SGD(model, ?lr:Tensor, ?momentum:Tensor, ?nesterov:bool, ?weightDecay:Tenso
     let reversible = defaultArg reversible false
     let mutable momInit = false
     let mutable momBuffer = ParameterDict()
+
+    /// <summary>TBD</summary>
     override o.updateRule name t = 
         let mutable d = t.derivative
         let t = if reversible then t else t.primal
@@ -39,6 +49,7 @@ type SGD(model, ?lr:Tensor, ?momentum:Tensor, ?nesterov:bool, ?weightDecay:Tenso
         t - lr * d
 
 
+/// <summary>TBD</summary>
 type Adam(model, ?lr:Tensor, ?beta1:Tensor, ?beta2:Tensor, ?eps:Tensor, ?weightDecay:Tensor, ?reversible:bool) =
     inherit Optimizer(model)
     let lr = defaultArg lr (dsharp.tensor(1e-3))
@@ -49,6 +60,8 @@ type Adam(model, ?lr:Tensor, ?beta1:Tensor, ?beta2:Tensor, ?eps:Tensor, ?weightD
     let mutable stateStep = 0
     let mutable stateExpAvg = ParameterDict()
     let mutable stateExpAvgSq = ParameterDict()
+
+    /// <summary>TBD</summary>
     override o.updateRule name t =
         let mutable d = t.derivative
         let t = if reversible then t else t.primal
@@ -70,7 +83,9 @@ type Adam(model, ?lr:Tensor, ?beta1:Tensor, ?beta2:Tensor, ?eps:Tensor, ?weightD
         t - stepSize * (expAvg/denom)
 
 
+/// <summary>TBD</summary>
 type optim =
+
     static member internal optimizeFun(update:Tensor->Tensor*Tensor, x0:Tensor, ?iters:int, ?threshold:double, ?print:bool, ?printEvery:int, ?printPrefix:string, ?printPostfix:string) =
         let iters = defaultArg iters -1
         let threshold, thresholdGiven = 
@@ -129,6 +144,7 @@ type optim =
             if not stop then x <- nx
         fx, x
 
+    /// <summary>TBD</summary>
     static member internal optimizeModel(model:Model, optimizer:Optimizer, dataloader:DataLoader, loss:Tensor->Tensor->Tensor, ?iters:int, ?epochs:int, ?threshold:double, ?print:bool, ?printEvery:int, ?printPrefix:string, ?printPostfix:string) =
         let iters, epochs =
             match iters, epochs with
@@ -199,6 +215,7 @@ type optim =
                 not stop
             ) |> Seq.iter ignore
 
+    /// <summary>TBD</summary>
     static member sgd(f, x0:Tensor, ?lr:Tensor, ?momentum:Tensor, ?nesterov:bool, ?iters:int, ?threshold:double, ?print:bool, ?printEvery:int, ?printPrefix:string, ?printPostfix:string) =
         let lr = defaultArg lr (dsharp.tensor(0.001))
         let mutable momBuffer = dsharp.zero()
@@ -218,6 +235,7 @@ type optim =
             f, x - lr * p
         optim.optimizeFun(update, x0, ?iters=iters, ?threshold=threshold, ?print=print, ?printEvery=printEvery, ?printPrefix=printPrefix, ?printPostfix=printPostfix)
 
+    /// <summary>TBD</summary>
     static member adam(f, x0:Tensor, ?lr:Tensor, ?beta1:Tensor, ?beta2:Tensor, ?eps:Tensor, ?iters:int, ?threshold:double, ?print:bool, ?printEvery:int, ?printPrefix:string, ?printPostfix:string) =
         let lr = defaultArg lr (dsharp.tensor(1e-3))
         let beta1 = defaultArg beta1 (dsharp.tensor(0.9))
@@ -239,10 +257,12 @@ type optim =
             f, x - stepSize * p
         optim.optimizeFun(update, x0, ?iters=iters, ?threshold=threshold, ?print=print, ?printEvery=printEvery, ?printPrefix=printPrefix, ?printPostfix=printPostfix)
 
+    /// <summary>TBD</summary>
     static member sgd(model, dataloader, loss, ?lr:Tensor, ?momentum:Tensor, ?nesterov:bool, ?weightDecay:Tensor, ?reversible:bool, ?iters:int, ?epochs:int, ?threshold:double, ?print:bool, ?printEvery:int, ?printPrefix:string, ?printPostfix:string) =
         let optimizer = SGD(model, ?lr=lr, ?momentum=momentum, ?nesterov=nesterov, ?weightDecay=weightDecay, ?reversible=reversible)
         optim.optimizeModel(model, optimizer, dataloader, loss, ?iters=iters, ?epochs=epochs, ?threshold=threshold, ?print=print, ?printEvery=printEvery, ?printPrefix=printPrefix, ?printPostfix=printPostfix)
 
+    /// <summary>TBD</summary>
     static member adam(model, dataloader, loss, ?lr:Tensor, ?beta1:Tensor, ?beta2:Tensor, ?eps:Tensor, ?weightDecay:Tensor, ?reversible:bool, ?iters:int, ?epochs:int, ?threshold:double, ?print:bool, ?printEvery:int, ?printPrefix:string, ?printPostfix:string) =
         let optimizer = Adam(model, ?lr=lr, ?beta1=beta1, ?beta2=beta2, ?eps=eps, ?weightDecay=weightDecay, ?reversible=reversible)
         optim.optimizeModel(model, optimizer, dataloader, loss, ?iters=iters, ?epochs=epochs, ?threshold=threshold, ?print=print, ?printEvery=printEvery, ?printPrefix=printPrefix, ?printPostfix=printPostfix)

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -389,7 +389,6 @@ type Tensor =
         t.primalRaw.AllClose(tensor.primalRaw, relativeTolerance, absoluteTolerance)
 
     /// Returns a new tensor filled with '0' values for the given shape, element type and configuration, defaulting to the 
-
     /// shape and configuration of the input tensor.
     member a.zerosLike(?shape:seq<int>, ?dtype, ?device, ?backend) = 
         let shape = defaultArg shape (a.shape |> Array.toSeq)
@@ -554,8 +553,10 @@ type Tensor =
         if d |> List.isEmpty then failwithf "Empty diagonal"
         Tensor.stack(d)
 
+    /// <summary>TBD</summary>
     member a.trace() = let d:Tensor = a.diagonal() in d.sum()
 
+    /// <summary>TBD</summary>
     member a.expand(newShape:seq<int>) =
         let newShape = newShape|>Seq.toArray
         if a.shape = newShape then a else
@@ -569,6 +570,7 @@ type Tensor =
             let cp = ap.expand(newShape)
             TensorR(cp, ref (a.zeroLike()), ExpandT(a), ref 0u, at)
 
+    /// <summary>TBD</summary>
     member internal t.GetSlice(bounds:int[,]) =
         // printfn "t.GetSlice bounds\n %A" bounds
         if t.dim = 0 then failwith "Cannot slice a scalar Tensor"
@@ -582,6 +584,7 @@ type Tensor =
         | TensorF(ap,ad,at) -> TensorF(ap.GetSlice(fullBounds), ad.GetSlice(fullBounds), at)
         | TensorR(ap,_,_,_,at) -> TensorR(ap.GetSlice(fullBounds), ref (ap.zeroLike()), SliceT(t, fullBounds), ref 0u, at)
 
+    /// <summary>TBD</summary>
     member t.Item
         with get([<System.ParamArray>] index:int[]) =
             if t.dim = 0 then failwith "Cannot index a scalar Tensor"
@@ -589,6 +592,7 @@ type Tensor =
             let bounds = Array2D.init index.Length 3 (fun i j -> if j=2 then 1 else index.[i])
             t.GetSlice(bounds)
 
+    /// <summary>TBD</summary>
     static member create(value:obj, ?dtype:Dtype, ?device:Device, ?backend:Backend) =
         let res = value |> DataConverter.tryFlatArrayAndShape<Tensor> // support creation of new Tensor from a structure holding scalar Tensors
         match res with
@@ -599,6 +603,7 @@ type Tensor =
         | None ->
             Tensor(RawTensor.Create(value, ?dtype=dtype, ?device=device, ?backend=backend))        
 
+    /// <summary>TBD</summary>
     static member stack(tensors:seq<Tensor>, ?dim:int) = 
         let dim = defaultArg dim 0 
         let tensors = tensors |> Seq.toArray
@@ -616,6 +621,7 @@ type Tensor =
             let cp = Tensor.stack(ap,dim=dim)
             TensorR(cp, ref (cp.zeroLike()), StackTs(tensors, dim), ref 0u, at)
 
+    /// <summary>TBD</summary>
     member a.unstack (?dim:int) =
         let dim = defaultArg dim 0 
         Shape.checkCanUnstack a.shape |> ignore
@@ -624,6 +630,7 @@ type Tensor =
         | TensorF(ap,ad,at) -> Array.map2 (fun p d -> TensorF(p,d,at)) (ap.unstack(dim)) (ad.unstack(dim))
         | TensorR(ap,_,_,_,at) -> Array.mapi (fun i p -> TensorR(p, ref (p.zeroLike()), UnstackT(a, dim, i), ref 0u, at)) (ap.unstack(dim))
 
+    /// <summary>TBD</summary>
     static member cat(tensors:seq<Tensor>, ?dim: int) = 
         let dim = defaultArg dim 0 
         let tensors = tensors |> Seq.toArray
@@ -639,6 +646,7 @@ type Tensor =
             let cp = Tensor.cat(ap, dim=dim)
             TensorR(cp, ref (cp.zeroLike()), CatTs(tensors, dim), ref 0u, at)
 
+    /// <summary>TBD</summary>
     member a.split (sizes: seq<int>, ?dim: int) =
         let dim = defaultArg dim 0
         let sizes = sizes |> Seq.toArray
@@ -647,14 +655,17 @@ type Tensor =
         | TensorF(ap,ad,at) -> Array.map2 (fun p d -> TensorF(p,d,at)) (ap.split(sizes)) (ad.split(sizes, dim=dim))
         | TensorR(ap,_,_,_,at) -> Array.mapi (fun i p -> TensorR(p, ref (p.zeroLike()), SplitT(a, sizes, dim, i), ref 0u, at)) (ap.split(sizes, dim=dim))
 
+    /// <summary>TBD</summary>
     static member inline (-->) (t:Tensor, f:Tensor -> ^a) = f t
 
+    /// <summary>TBD</summary>
     static member inline OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev) =
         match a with
         | Tensor(ap)           -> Tensor(fRaw(ap))
         | TensorF(ap,ad,at)    -> let cp = fTensor(ap) in TensorF(cp, dfTensorFwd(cp,ap,ad), at)
         | TensorR(ap,_,_,_,at) -> let cp = fTensor(ap) in TensorR(cp, ref (a.zeroLike()), dfTensorRev(a), ref 0u, at)
 
+    /// <summary>TBD</summary>
     static member inline OpBinary(a, b, fRaw, fTensor, dfTensorFwdTT, dfTensorFwdTC, dfTensorFwdCT, dfTensorRevTT, dfTensorRevTC, dfTensorRevCT) =
         match a, b with
         | Tensor(ap),           Tensor(bp)                      -> Tensor(fRaw(ap, bp))
@@ -676,6 +687,7 @@ type Tensor =
         | TensorR(_,_,_,_,at),  TensorR(bp,_,_,_,bt) when at<bt -> let cp = fTensor(a,bp)  in TensorR(cp, ref (a.zeroLike()), dfTensorRevCT(a,b), ref 0u, bt)
         | _ -> failwith "Unexpected combination of Tensors" // Won't happen, added for suppressing "incomplete matches" warning
 
+    /// <summary>TBD</summary>
     static member (+) (a:Tensor, b:Tensor) =
         if a.dtype <> b.dtype then
             match Dtype.widen a.dtype b.dtype with
@@ -739,11 +751,20 @@ type Tensor =
             let aExpanded = a.expand(newShape)
             let bExpanded = b.expand(newShape)
             aExpanded + bExpanded
+
+    /// <summary>TBD</summary>
     static member (+) (a:Tensor, b) = a + a.scalarLike(b)
+
+    /// <summary>TBD</summary>
     static member (+) (a, b:Tensor) = b.scalarLike(a) + b
+
+    /// <summary>TBD</summary>
     member a.add(b:Tensor) = a + b
+
+    /// <summary>TBD</summary>
     member a.add(b) = a + a.scalarLike(b)
 
+    /// <summary>TBD</summary>
     static member (-) (a:Tensor, b:Tensor) =
         if a.dtype <> b.dtype then
             match Dtype.widen a.dtype b.dtype with
@@ -787,11 +808,20 @@ type Tensor =
             let aExpanded = a.expand(newShape)
             let bExpanded = b.expand(newShape)
             aExpanded - bExpanded
+
+    /// <summary>TBD</summary>
     static member (-) (a:Tensor, b) = a - a.scalarLike(b)
+
+    /// <summary>TBD</summary>
     static member (-) (a, b:Tensor) = b.scalarLike(a) - b
+
+    /// <summary>TBD</summary>
     member a.sub(b:Tensor) = a - b
+
+    /// <summary>TBD</summary>
     member a.sub(b) = a - a.scalarLike(b)
 
+    /// <summary>TBD</summary>
     static member (*) (a:Tensor, b:Tensor) =
         if a.dtype <> b.dtype then
             match Dtype.widen a.dtype b.dtype with
@@ -835,11 +865,20 @@ type Tensor =
             let aExpanded = a.expand(newShape)
             let bExpanded = b.expand(newShape)
             aExpanded * bExpanded
+
+    /// <summary>TBD</summary>
     static member (*) (a:Tensor, b) = a * a.scalarLike(b)
+
+    /// <summary>TBD</summary>
     static member (*) (a, b:Tensor) = b.scalarLike(a) * b
+
+    /// <summary>TBD</summary>
     member a.mul(b:Tensor) = a * b
+
+    /// <summary>TBD</summary>
     member a.mul(b) = a * a.scalarLike(b)
 
+    /// <summary>TBD</summary>
     static member (/) (a:Tensor, b:Tensor) =
         if a.dtype <> b.dtype then
             match Dtype.widen a.dtype b.dtype with
@@ -883,11 +922,20 @@ type Tensor =
             let aExpanded = a.expand(newShape)
             let bExpanded = b.expand(newShape)
             aExpanded / bExpanded
+
+    /// <summary>TBD</summary>
     static member (/) (a:Tensor, b) = a / a.scalarLike(b)
+
+    /// <summary>TBD</summary>
     static member (/) (a, b:Tensor) = b.scalarLike(a) / b
+
+    /// <summary>TBD</summary>
     member a.div(b:Tensor) = a / b
+
+    /// <summary>TBD</summary>
     member a.div(b) = a / a.scalarLike(b)
 
+    /// <summary>TBD</summary>
     static member Pow (a:Tensor, b:Tensor) =
         if a.dtype <> b.dtype then
             match Dtype.widen a.dtype b.dtype with
@@ -932,15 +980,31 @@ type Tensor =
             let bExpanded = b.expand(newShape)
             Tensor.Pow(aExpanded, bExpanded)
 
+    /// <summary>TBD</summary>
     static member Pow (a:Tensor, b:float) = a ** a.scalarLike(b)
+
+    /// <summary>TBD</summary>
     static member Pow (a:Tensor, b:int) = a ** a.scalarLike(b)
+
+    /// <summary>TBD</summary>
     static member Pow (a:Tensor, b) = a ** a.scalarLike(b)
+
+    /// <summary>TBD</summary>
     static member Pow (a:float, b:Tensor) = b.scalarLike(a) ** b
+
+    /// <summary>TBD</summary>
     static member Pow (a:int, b:Tensor) = b.scalarLike(a) ** b
+
+    /// <summary>TBD</summary>
     static member Pow (a, b:Tensor) = b.scalarLike(a) ** b
+
+    /// <summary>TBD</summary>
     member a.pow(b:Tensor) = a ** b
+
+    /// <summary>TBD</summary>
     member a.pow(b) = a ** a.scalarLike(b)
 
+    /// <summary>TBD</summary>
     member a.matmul (b:Tensor) =
         Shape.checkCanMatmul a.shape b.shape
         let fRaw(a:RawTensor,b) = a.MatMulT2T2(b)
@@ -953,20 +1017,25 @@ type Tensor =
         let dfTensorRevCT(a,b) = MatMulT2ConstT2(a,b)
         Tensor.OpBinary(a, b, fRaw, fTensor, dfTensorFwdTT, dfTensorFwdTC, dfTensorFwdCT, dfTensorRevTT, dfTensorRevTC, dfTensorRevCT)
 
+    /// <summary>TBD</summary>
     member a.dot(b:Tensor) =
         Shape.checkCanDot a.shape b.shape
         let a:Tensor = a.view([1;a.nelement])
         let b:Tensor = b.view([b.nelement;1])
         a.matmul(b).view([])
 
+    /// <summary>TBD</summary>
     static member (~-) (a:Tensor) =
         let fRaw(a:RawTensor) = a.NegT()
         let fTensor(a) = -a
         let dfTensorFwd(cp,ap,ad) = -ad
         let dfTensorRev(a) = NegT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     member a.neg() = -a
 
+    /// <summary>TBD</summary>
     member a.sum(?dtype: Dtype) =
         let fRaw(a:RawTensor) = a.SumT(?resultType=dtype)
         let fTensor(a:Tensor) = a.sum(?dtype=dtype)
@@ -975,6 +1044,7 @@ type Tensor =
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
     // TODO: this can be implemented in a more memory efficient way by pushing the sum operation to the RawTensor level and implementing the derivatives using general broadcasting when it's available
+    /// <summary>TBD</summary>
     member a.sum(dim:int, ?keepDim:bool, ?dtype: Dtype) =
        let keepDim = defaultArg keepDim false
        let dim = Shape.completeDim a.dim dim  // Handles -1 semantics
@@ -1016,8 +1086,10 @@ type Tensor =
                     result <- result.sum(dim, keepDim=true)
             result.castAfterSummation(?dtype=dtype)
 
+    /// <summary>TBD</summary>
     member a.mean() = a.sum() / a.nelement
 
+    /// <summary>TBD</summary>
     member a.mean(dim:int, ?keepDim:bool) = 
         let dim = Shape.completeDim a.dim dim  // Handles -1 semantics
         if dim = 0 && a.dim = 0 then a
@@ -1026,12 +1098,14 @@ type Tensor =
            let dv = sm / a.shape.[dim]
            dv
 
+    /// <summary>TBD</summary>
     // This is the two-pass algorithm better than the naive algorithm
     member a.variance(?unbiased:bool) = 
         let unbiased = defaultArg unbiased true  // Use Bessel's correction if unbiased=true
         let n = if unbiased then a.nelement - 1 else a.nelement
         let a' = a - a.mean() in (a' * a').sum() / n
 
+    /// <summary>TBD</summary>
     // TODO: this is the naive algorithm, can be improved for better numerical stability
     member a.variance(dim:int, ?keepDim:bool, ?unbiased:bool) =
         let keepDim = defaultArg keepDim false
@@ -1054,10 +1128,13 @@ type Tensor =
         let res = (sSquare - (s * s) / n) / nn
         if keepDim then res.unsqueeze(dim) else res
 
+    /// <summary>TBD</summary>
     member a.stddev(dim, ?keepDim, ?unbiased) = a.variance(dim, ?keepDim=keepDim, ?unbiased=unbiased) |> Tensor.Sqrt
 
+    /// <summary>TBD</summary>
     member a.stddev(?unbiased) = a.variance(?unbiased=unbiased) |> Tensor.Sqrt
 
+    /// <summary>TBD</summary>
     member probs.multinomial(numSamples:int, ?dtype:Dtype, ?device:Device, ?backend:Backend, ?normalize:bool) =
         // TODO: the following may be implemented by RawTensor at a later point
         if probs.dim < 1 || probs.dim > 2 then failwithf "Expecting 1d or 2d probs, received shape %A" probs.shape
@@ -1082,6 +1159,7 @@ type Tensor =
                 | _ -> failwithf "Expecting probs to have dtype Float32 or Float64, received %A" probs.dtype
             Tensor.create(Random.Multinomial(p, numSamples), dtype=dtype, device=device, backend=backend)
 
+    /// <summary>TBD</summary>
     member probs.bernoulli(?dtype:Dtype, ?device:Device, ?backend:Backend) =
         // TODO: the following may be implemented by RawTensor at a later point
         if not (probs.dtype = Dtype.Float32 || probs.dtype = Dtype.Float64) then failwithf "Expecting probs to have dtype Float32 or Float64, received %A" probs.dtype
@@ -1096,6 +1174,7 @@ type Tensor =
             let b = p.toArray() :?> float[] |> Array.map Random.Bernoulli
             Tensor.create(b, dtype=dtype, device=device, backend=backend).view(probs.shape)
 
+    /// <summary>TBD</summary>
     member a.dropout(?p:double) =
         let p = defaultArg p 0.5
         Shape.checkCanDropout p
@@ -1107,6 +1186,7 @@ type Tensor =
             let mask = a.fullLike(1.-p).bernoulli()
             a * mask
 
+    /// <summary>TBD</summary>
     member a.dropout2d(?p:double) =
         let p = defaultArg p 0.5
         Shape.checkCanDropout2d a.shape p
@@ -1118,6 +1198,7 @@ type Tensor =
             let mask = a.fullLike(1.-p, Array.append a.shape.[0..1] [|1;1|]).bernoulli()
             a * mask
 
+    /// <summary>TBD</summary>
     member a.dropout3d(?p:double) =
         let p = defaultArg p 0.5
         Shape.checkCanDropout3d a.shape p
@@ -1129,6 +1210,7 @@ type Tensor =
             let mask = a.fullLike(1.-p, Array.append a.shape.[0..1] [|1;1;1|]).bernoulli()
             a * mask
 
+    /// <summary>TBD</summary>
     // This is useful to keep as a special case of sum for performance reasons because it's involved in reverse mode of broadcasting addition of bias in NN linear layers
     member internal a.sumT2Dim0() =
         let fRaw(a:RawTensor) = a.SumT2Dim0()
@@ -1137,6 +1219,7 @@ type Tensor =
         let dfTensorRev(a) = SumT2Dim0(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
     
+    /// <summary>TBD</summary>
     member a.transpose(dim0:int, dim1:int) =
         let dim0 = Shape.completeDim a.dim dim0  // Handles -1 semantics
         let dim1 = Shape.completeDim a.dim dim1  // Handles -1 semantics
@@ -1150,6 +1233,7 @@ type Tensor =
             let dfTensorRev(a) = TransposeT(a, dim0, dim1)
             Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.transpose() =
         Shape.checkCanTranspose2d a.dim
         let fRaw(a:RawTensor) = a.TransposeT2()
@@ -1158,6 +1242,7 @@ type Tensor =
         let dfTensorRev(a) = TransposeT2(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.squeeze(?dim:int) =
         let dim = defaultArg dim -1
         let fRaw(a:RawTensor) = a.SqueezeT(dim)
@@ -1166,6 +1251,7 @@ type Tensor =
         let dfTensorRev(a) = SqueezeT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.unsqueeze(dim:int) =
         let fRaw(a:RawTensor) = a.UnsqueezeT(dim)
         let fTensor(a:Tensor) = a.unsqueeze(dim)
@@ -1173,6 +1259,7 @@ type Tensor =
         let dfTensorRev(a) = UnsqueezeT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.flip(dims:seq<int>) =
         let dims = dims |> Array.ofSeq
         Shape.checkCanFlip a.dim dims
@@ -1182,6 +1269,7 @@ type Tensor =
         let dfTensorRev(a) = FlipT(a, dims)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.dilate(dilations:seq<int>) =
         let dilations = dilations |> Array.ofSeq
         Shape.checkCanDilate a.dim dilations
@@ -1191,6 +1279,7 @@ type Tensor =
         let dfTensorRev(a) = DilateT(a, dilations)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.undilate(dilations:seq<int>) =
         let dilations = dilations |> Array.ofSeq
         let fRaw(a:RawTensor) = a.UndilateT(dilations)
@@ -1199,6 +1288,7 @@ type Tensor =
         let dfTensorRev(a) = UndilateT(a, dilations)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.repeat(dim:int, times:int) =
         Shape.checkCanRepeat a.shape dim
         let newShape = a.shape |> Array.copy
@@ -1210,6 +1300,7 @@ type Tensor =
             ret <- ret.addSlice(location, a)
         ret
 
+    /// <summary>TBD</summary>
     member a.gather(dim:int, indices:Tensor) =
         Shape.checkCanGather a.shape dim indices.shape indices.dtype
         let fRaw(a:RawTensor) = a.GatherT(dim, indices.primalRaw)
@@ -1218,6 +1309,7 @@ type Tensor =
         let dfTensorRev(a) = GatherT(a, dim, indices)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.view(shape:seq<int>) =
         let shape = shape |> Seq.toArray |> Shape.complete a.nelement  // Handles -1 semantics
         Shape.checkCanView a.shape shape
@@ -1226,10 +1318,14 @@ type Tensor =
         let dfTensorFwd(cp,ap,ad:Tensor) = ad.view(shape)
         let dfTensorRev(a) = ViewT(a, a.shape)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     member t.view(shape:int) = t.view([|shape|])
 
+    /// <summary>TBD</summary>
     member a.viewAs(b:Tensor) = a.view(b.shape)
 
+    /// <summary>TBD</summary>
     member a.flatten(?startDim:int, ?endDim:int) =
         if a.dim < 2 then 
             a
@@ -1255,8 +1351,10 @@ type Tensor =
         | TensorF(ap,ad,at)    -> let result, mask = ap.clampWithMask(?low=low, ?high=high) in TensorF(result, ad * mask, at), mask
         | TensorR(ap,_,_,_,at) -> let result, mask = ap.clampWithMask(?low=low, ?high=high) in TensorR(result, ref (a.zeroLike()), ClampT(a, mask), ref 0u, at), mask
 
+    /// <summary>TBD</summary>
     member a.clamp(?low:scalar, ?high:scalar) = a.clampWithMask(?low=low, ?high=high) |> fst
 
+    /// <summary>TBD</summary>
     member a.sign() =
         let fRaw(a:RawTensor) = a.SignT()
         let fTensor(a:Tensor) = a.sign()
@@ -1265,38 +1363,51 @@ type Tensor =
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
     // static member Sign(a:Tensor) = a.sign() // not supported becaose FSharp.Core sign operator returns int
 
+    /// <summary>TBD</summary>
     member a.floor() =
         let fRaw(a:RawTensor) = a.FloorT()
         let fTensor(a:Tensor) = a.floor()
         let dfTensorFwd(cp:Tensor,ap,ad) = cp.zerosLike()
         let dfTensorRev(a) = FloorT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Floor(a:Tensor) = a.floor() // needed for FSharp.Core floor operator overload
 
+    /// <summary>TBD</summary>
     member a.ceil() =
         let fRaw(a:RawTensor) = a.CeilT()
         let fTensor(a:Tensor) = a.ceil()
         let dfTensorFwd(cp:Tensor,ap,ad) = cp.zerosLike()
         let dfTensorRev(a) = CeilT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Ceiling(a:Tensor) = a.ceil() // needed for FSharp.Core ceil operator overload
 
+    /// <summary>TBD</summary>
     member a.round() =
         let fRaw(a:RawTensor) = a.RoundT()
         let fTensor(a:Tensor) = a.round()
         let dfTensorFwd(cp:Tensor,ap,ad) = cp.zerosLike()
         let dfTensorRev(a) = RoundT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Round(a:Tensor) = a.round() // needed for FSharp.Core round operator overload
 
+    /// <summary>TBD</summary>
     member a.abs() =
         let fRaw(a:RawTensor) = a.AbsT()
         let fTensor(a:Tensor) = a.abs()
         let dfTensorFwd(cp,ap:Tensor,ad) = ad * ap.sign()
         let dfTensorRev(a) = AbsT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Abs(a:Tensor) = a.abs() // needed for FSharp.Core abs operator overload
 
+    /// <summary>TBD</summary>
     member a.relu() =
         let fRaw(a:RawTensor) = a.ReluT()
         let fTensor(a:Tensor) = a.relu()
@@ -1304,10 +1415,12 @@ type Tensor =
         let dfTensorRev(a) = ReluT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.leakyRelu(?negativeSlope:float) =
         let negativeSlope = defaultArg negativeSlope 0.01
         let zeros = a.zerosLike() in zeros.max(a) + negativeSlope * zeros.min(a)
 
+    /// <summary>TBD</summary>
     member a.sigmoid() =
         let fRaw(a:RawTensor) = a.SigmoidT()
         let fTensor(a:Tensor) = a.sigmoid()
@@ -1315,22 +1428,29 @@ type Tensor =
         let dfTensorRev(a) = SigmoidT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.exp() =
         let fRaw(a:RawTensor) = a.ExpT()
         let fTensor(a:Tensor) = a.exp()
         let dfTensorFwd(cp,ap,ad) = ad * cp
         let dfTensorRev(a) = ExpT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Exp(a:Tensor) = a.exp() // needed for FSharp.Core exp operator overload
 
+    /// <summary>TBD</summary>
     member a.log() =
         let fRaw(a:RawTensor) = a.LogT()
         let fTensor(a:Tensor) = a.log()
         let dfTensorFwd(cp,ap,ad) = ad / ap
         let dfTensorRev(a) = LogT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Log(a:Tensor) = a.log() // needed for FSharp.Core log operator overload
 
+    /// <summary>TBD</summary>
     member a.softplus() =
         let fRaw(a:RawTensor) = a.SoftplusT()
         let fTensor(a:Tensor) = a.softplus()
@@ -1338,94 +1458,128 @@ type Tensor =
         let dfTensorRev(a) = SoftplusT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.log10() =
         let fRaw(a:RawTensor) = a.Log10T()
         let fTensor(a:Tensor) = a.log10()
         let dfTensorFwd(cp,ap:Tensor,ad) = ad / (ap * log10Val)
         let dfTensorRev(a) = Log10T(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Log10(a:Tensor) = a.log10() // needed for FSharp.Core log10 operator overload
 
+    /// <summary>TBD</summary>
     member a.sqrt() =
         let fRaw(a:RawTensor) = a.SqrtT()
         let fTensor(a:Tensor) = a.sqrt()
         let dfTensorFwd(cp:Tensor,ap,ad) = ad / (2. * cp)
         let dfTensorRev(a) = SqrtT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Sqrt(a:Tensor) = a.sqrt() // needed for FSharp.Core sqrt operator overload
 
+    /// <summary>TBD</summary>
     member a.sin() =
         let fRaw(a:RawTensor) = a.SinT()
         let fTensor(a:Tensor) = a.sin()
         let dfTensorFwd(cp:Tensor,ap:Tensor,ad) = ad * ap.cos()
         let dfTensorRev(a) = SinT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Sin(a:Tensor) = a.sin() // needed for FSharp.Core sin operator overload
 
+    /// <summary>TBD</summary>
     member a.cos() =
         let fRaw(a:RawTensor) = a.CosT()
         let fTensor(a:Tensor) = a.cos()
         let dfTensorFwd(cp:Tensor,ap:Tensor,ad) = -ad * ap.sin()
         let dfTensorRev(a) = CosT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Cos(a:Tensor) = a.cos() // needed for FSharp.Core cos operator overload
 
+    /// <summary>TBD</summary>
     member a.tan() =
         let fRaw(a:RawTensor) = a.TanT()
         let fTensor(a:Tensor) = a.tan()
         let dfTensorFwd(cp:Tensor,ap:Tensor,ad) = let cosap = ap.cos() in ad / (cosap * cosap)
         let dfTensorRev(a) = TanT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Tan(a:Tensor) = a.tan() // needed for FSharp.Core tan operator overload
 
+    /// <summary>TBD</summary>
     member a.sinh() =
         let fRaw(a:RawTensor) = a.SinhT()
         let fTensor(a:Tensor) = a.sinh()
         let dfTensorFwd(cp:Tensor,ap:Tensor,ad) = ad * ap.cosh()
         let dfTensorRev(a) = SinhT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Sinh(a:Tensor) = a.sinh() // needed for FSharp.Core sinh operator overload
 
+    /// <summary>TBD</summary>
     member a.cosh() =
         let fRaw(a:RawTensor) = a.CoshT()
         let fTensor(a:Tensor) = a.cosh()
         let dfTensorFwd(cp:Tensor,ap:Tensor,ad) = ad * ap.sinh()
         let dfTensorRev(a) = CoshT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Cosh(a:Tensor) = a.cosh() // needed for FSharp.Core cosh operator overload
 
+    /// <summary>TBD</summary>
     member a.tanh() =
         let fRaw(a:RawTensor) = a.TanhT()
         let fTensor(a:Tensor) = a.tanh()
         let dfTensorFwd(cp:Tensor,ap:Tensor,ad) = let coshap = ap.cosh() in ad / (coshap * coshap)
         let dfTensorRev(a) = TanhT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Tanh(a:Tensor) = a.tanh() // needed for FSharp.Core tanh operator overload
 
+    /// <summary>TBD</summary>
     member a.asin() =
         let fRaw(a:RawTensor) = a.AsinT()
         let fTensor(a:Tensor) = a.asin()
         let dfTensorFwd(cp:Tensor,ap:Tensor,ad) = ad / (1. - ap*ap).sqrt()
         let dfTensorRev(a) = AsinT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Asin(a:Tensor) = a.asin() // needed for FSharp.Core asin operator overload
 
+    /// <summary>TBD</summary>
     member a.acos() =
         let fRaw(a:RawTensor) = a.AcosT()
         let fTensor(a:Tensor) = a.acos()
         let dfTensorFwd(cp:Tensor,ap:Tensor,ad) = -ad / (1. - ap*ap).sqrt()
         let dfTensorRev(a) = AcosT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Acos(a:Tensor) = a.acos() // needed for FSharp.Core acos operator overload
 
+    /// <summary>TBD</summary>
     member a.atan() =
         let fRaw(a:RawTensor) = a.AtanT()
         let fTensor(a:Tensor) = a.atan()
         let dfTensorFwd(cp:Tensor,ap:Tensor,ad) = ad / (1. + ap*ap)
         let dfTensorRev(a) = AtanT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
+
+    /// <summary>TBD</summary>
     static member Atan(a:Tensor) = a.atan() // needed for FSharp.Core atan operator overload
 
+    /// <summary>TBD</summary>
     member a.addSlice(location:seq<int>, b:Tensor) =
         let location = location |> Seq.toArray
         Shape.checkCanAddSlice a.shape location b.shape
@@ -1439,16 +1593,19 @@ type Tensor =
         let dfTensorRevCT(a,b) = AddTConstTSlice(location,b)
         Tensor.OpBinary(a, b, fRaw, fTensor, dfTensorFwdTT, dfTensorFwdTC, dfTensorFwdCT, dfTensorRevTT, dfTensorRevTC, dfTensorRevCT)
 
+    /// <summary>TBD</summary>
     member a.softmax(dim:int) =
         let dim = Shape.completeDim a.dim dim  // Handles -1 semantics
         let e = (a - a.max().noDiff()).exp()
         let esum = e.sum(dim, keepDim=true).repeat(dim, a.shape.[dim])
         e / esum
 
+    /// <summary>TBD</summary>
     member a.logsoftmax(dim:int) =
         let dim = Shape.completeDim a.dim dim  // Handles -1 semantics
         a - a.logsumexp(dim, keepDim=true)
 
+    /// <summary>TBD</summary>
     member a.logsumexp(dim:int, ?keepDim:bool) =
         let dim = Shape.completeDim a.dim dim  // Handles -1 semantics
         let keepDim = defaultArg keepDim false
@@ -1457,6 +1614,7 @@ type Tensor =
         let res = amax + e.sum(dim).add(System.Single.Epsilon).log()
         if keepDim then res.unsqueeze(dim) else res
 
+    /// <summary>TBD</summary>
     member input.mseLoss(target:Tensor, ?reduction:string) = 
         if input.shape <> target.shape then failwithf "Expecting input.shape (%A) and target.shape (%A) to be the same" input.shape target.shape
         let reduction = defaultArg reduction "mean"
@@ -1470,6 +1628,7 @@ type Tensor =
         else // reduction = "sum"
             l.sum()
 
+    /// <summary>TBD</summary>
     member input.bceLoss(target:Tensor, ?weight:Tensor, ?reduction:string) =
         if input.shape <> target.shape then failwithf "Expecting input shape (%A) and target shape (%A) to be the same" input.shape target.shape
         if target.max() > target.oneLike() || target.min() < target.zeroLike() then failwith "Expecting target values to be between 0 and 1."
@@ -1489,9 +1648,11 @@ type Tensor =
         else // reduction = "sum"
             l.sum()
 
+    /// <summary>TBD</summary>
     member input.crossEntropyLoss(target:Tensor, ?weight:Tensor, ?reduction:string) =
         input.logsoftmax(dim=1).nllLoss(target, ?weight=weight, ?reduction=reduction)
 
+    /// <summary>TBD</summary>
     member input.nllLoss(target:Tensor, ?weight:Tensor, ?reduction:string) =
         let n, classes, d = 
             if input.dim < 2 
@@ -1544,6 +1705,7 @@ type Tensor =
             else // reduction = "sum"
                 l.sum()
 
+    /// <summary>TBD</summary>
     member a.pad(paddings:seq<int>) =
         let paddings = paddings |> Array.ofSeq
         Shape.checkCanPad a.shape paddings
@@ -1556,6 +1718,7 @@ type Tensor =
             let ret = a.zerosLike(shape)
             ret.addSlice(paddings, a)
 
+    /// <summary>TBD</summary>
     member a.maxpool1di(kernelSize:int, ?stride:int, ?padding:int) =
         let stride = defaultArg stride kernelSize
         let padding = defaultArg padding 0
@@ -1565,8 +1728,10 @@ type Tensor =
         | TensorF(ap,ad,at)    -> let result, indices = ap.maxpool1di(kernelSize, stride, padding) in TensorF(result, ad.gather(dim=2, indices=indices), at), indices
         | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool1di(kernelSize, stride, padding) in TensorR(result, ref (a.zeroLike()), MaxPool1DT(a, indices, kernelSize), ref 0u, at), indices
 
+    /// <summary>TBD</summary>
     member a.maxpool1d(kernelSize:int, ?stride:int, ?padding:int) = a.maxpool1di(kernelSize, ?stride=stride, ?padding=padding) |> fst
 
+    /// <summary>TBD</summary>
     member a.maxunpool1d(indices:Tensor, kernelSize:int, ?stride:int, ?padding:int, ?outputSize:seq<int>) =
         let stride = defaultArg stride kernelSize
         let padding = defaultArg padding 0
@@ -1583,6 +1748,7 @@ type Tensor =
         let dfTensorRev(a) = MaxUnpool1DT(a, indices)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.maxpool2di(?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) =
         let kernelSizes =
             match kernelSize, kernelSizes with
@@ -1608,8 +1774,10 @@ type Tensor =
         | TensorF(ap,ad,at)    -> let result, indices = ap.maxpool2di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorF(result, ad.flatten(startDim=2).gather(dim=2, indices=indices.flatten(startDim=2)).viewAs(indices), at), indices
         | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool2di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorR(result, ref (a.zeroLike()), MaxPool2DT(a, indices, kernelSizes), ref 0u, at), indices
 
+    /// <summary>TBD</summary>
     member a.maxpool2d(?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) = a.maxpool2di(?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings) |> fst
 
+    /// <summary>TBD</summary>
     member a.maxunpool2d(indices:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?outputSize:seq<int>) =
         let kernelSizes =
             match kernelSize, kernelSizes with
@@ -1643,6 +1811,7 @@ type Tensor =
         let dfTensorRev(a) = MaxUnpool2DT(a, indices)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.maxpool3di(?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) =
         let kernelSizes =
             match kernelSize, kernelSizes with
@@ -1668,8 +1837,10 @@ type Tensor =
         | TensorF(ap,ad,at)    -> let result, indices = ap.maxpool3di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorF(result, ad.flatten(startDim=2).gather(dim=2, indices=indices.flatten(startDim=2)).viewAs(indices), at), indices
         | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool3di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorR(result, ref (a.zeroLike()), MaxPool3DT(a, indices, kernelSizes), ref 0u, at), indices
 
+    /// <summary>TBD</summary>
     member a.maxpool3d(?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) = a.maxpool3di(?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings) |> fst
 
+    /// <summary>TBD</summary>
     member a.maxunpool3d(indices:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?outputSize:seq<int>) =
         let kernelSizes =
             match kernelSize, kernelSizes with
@@ -1704,6 +1875,7 @@ type Tensor =
         let dfTensorRev(a) = MaxUnpool3DT(a, indices)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
+    /// <summary>TBD</summary>
     member a.conv1d(b:Tensor, ?stride:int, ?padding:int, ?dilation:int) =
         // a: input, b: filter
         let stride = defaultArg stride 1
@@ -1770,6 +1942,7 @@ type Tensor =
                     bderivative <- bderivative.addSlice([|k; 0; 0|], c)
         aderivative, bderivative
 
+    /// <summary>TBD</summary>
     member a.conv2d(b:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>) =
         let strides = 
             match stride, strides with
@@ -1803,6 +1976,7 @@ type Tensor =
         let dfTensorRevCT(a,b) = Conv2DTConstT(a,b, strides, paddings)
         Tensor.OpBinary(a, b, fRaw, fTensor, dfTensorFwdTT, dfTensorFwdTC, dfTensorFwdCT, dfTensorRevTT, dfTensorRevTC, dfTensorRevCT)
 
+    /// <summary>TBD</summary>
     // a: input, NxCxHxW (batchSize x inputChannels x inputHeight x inputWidth)
     // b: filters, KxCxFxG (outputChannels x inputChannels x kernelHeight x kernelWidth)
     // t: output, NxKxLxM (batchSize x outputChannels x outputHeight x outputWidth)
@@ -1857,6 +2031,7 @@ type Tensor =
                     bderivative <- bderivative.addSlice([|k; 0; 0; 0|], c)
         aderivative, bderivative
 
+    /// <summary>TBD</summary>
     member a.conv3d(b:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>) =
         let strides = 
             match stride, strides with
@@ -1890,6 +2065,7 @@ type Tensor =
         let dfTensorRevCT(a,b) = Conv3DTConstT(a,b, strides, paddings)
         Tensor.OpBinary(a, b, fRaw, fTensor, dfTensorFwdTT, dfTensorFwdTC, dfTensorFwdCT, dfTensorRevTT, dfTensorRevTC, dfTensorRevCT)
 
+    /// <summary>TBD</summary>
     // a: input, NxCxDxHxW (batchSize x inputChannels x inputDepth x inputHeight x inputWidth)
     // b: filters, KxCxExFxG (outputChannels x inputChannels x kernelDepth x kernelHeight x kernelWidth)
     // t: output, NxKxLxMxN (batchSize x outputChannels x outputDepth x outputHeight x outputWidth)
@@ -1948,6 +2124,7 @@ type Tensor =
                     bderivative <- bderivative.addSlice([|k; 0; 0; 0; 0|], c)
         aderivative, bderivative
 
+    /// <summary>TBD</summary>
     member t.reverse(?value:Tensor, ?zeroDerivatives:bool) =
         let value = defaultArg value (t.onesLike())
         let zeroDerivatives = defaultArg zeroDerivatives true
@@ -1955,8 +2132,10 @@ type Tensor =
         t.reverseReset(zeroDerivatives)
         t.reversePush(value)
 
+    /// <summary>TBD</summary>
     member inline t.backward(value) = t.reverse(value)
 
+    /// <summary>TBD</summary>
     member t.reverseReset(zeroDerivatives:bool) =
         let rec reset (ts: Tensor list) =
             match ts with
@@ -2074,6 +2253,7 @@ type Tensor =
                 | _ -> reset tt
         reset [t]
 
+    /// <summary>TBD</summary>
     member t.reversePush(value:Tensor) =
         let rec push (ts:(Tensor*Tensor) list) =
             match ts with

--- a/tests/DiffSharp.Backends.TestDuplicate/DiffSharp.Backends.TestDuplicate.fsproj
+++ b/tests/DiffSharp.Backends.TestDuplicate/DiffSharp.Backends.TestDuplicate.fsproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DiffSharp.Core\DiffSharp.Core.fsproj" />
+	<PackageReference Update="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/tests/DiffSharp.Benchmarks/DiffSharp.Benchmarks.fsproj
+++ b/tests/DiffSharp.Benchmarks/DiffSharp.Benchmarks.fsproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <!-- <ProjectReference Include="..\..\bundles\DiffSharp-cpu\DiffSharp-cpu.fsproj" /> -->
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Reference\DiffSharp.Backends.Reference.fsproj" />
+	<PackageReference Update="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
+++ b/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Reference\DiffSharp.Backends.Reference.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Torch\DiffSharp.Backends.Torch.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Core\DiffSharp.Core.fsproj" />
+	<PackageReference Update="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 
   <!-- Choose the appropriate version of libtorch for our current OS and environment -->


### PR DESCRIPTION
@gbaydin This adds about 500 placeholders for documentation. Not pretty but necesssary.  Seems best to add them first and then fill things in as it makes the codebase still look consistent 

I add `<summary>...</summary>` tags everywhere.  This is because I'd eventually expect most docs in this repo to use math `\(...\)` and `\[...\]` 

Let me know what you think

BTW 

* I worked on tooling to make F# IDE tools check docs as you type - it makes it so much easier to reliably write the docs https://github.com/dotnet/fsharp/pull/10118.  That will appear in upcoming editions of Visual Studio and F# support in VS Code

* I worked on making sure we can add examples too e.g. https://github.com/DiffSharp/DiffSharp/pull/184/files#diff-4db1087bc965bcae8b149b068e5b186cR14
