### PR TITLE
Fix save/load so it loads into a configuration, and doesn't store the device

### DIFF
--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -58,7 +58,7 @@ type TorchRawTensor(tt: TorchTensor, shape: int[], dtype: Dtype, device: Device)
 
     inherit RawTensor()
 
-    // Note, shape and dtype are stored as fields.  These dupicate information in TorchTensor, but
+    // Note, shape and dtype are stored as fields. These dupicate information in TorchTensor, but
     // it is a little too costly to repeatedly re-extract this information.
     //
     // 'device' is not stored as a field, it is rarely accessed and can be fetched from TorchTensor

--- a/src/DiffSharp.Core/DiffSharp.fs
+++ b/src/DiffSharp.Core/DiffSharp.fs
@@ -9,8 +9,23 @@ type dsharp =
     static member tensor(value:obj, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor.create(value=value, ?dtype=dtype, ?device=device, ?backend=backend)
     static member seed(?seed:int) = BackendStatics.Seed(?seed=seed)
     static member isTensor(value:obj) = value :? Tensor
+
+    /// <summary>Saves the tensor to the given file using a bespoke binary format.</summary>
+    /// <remarks>
+    ///   The binary format records the elements, backend, element type and shape. It does not record the device.
+    ///   The format used may change from version to version of DiffSharp.
+    /// </remarks>
     static member save(tensor:Tensor, fileName) = tensor.save(fileName)
+
+    /// <summary>Loads the tensor from the given file using the given configuration. If no configuration is specified the default configuration is used.</summary>
+    ///
+    /// <remarks>
+    ///   The backend used at the time of saving the tensor must be available when the tensor is reloaded.
+    ///   The tensor is first loaded into that backend and then moved. As a result, intermediate tensors may be created
+    ///   in the process of reloading.
+    /// </remarks>
     static member load(fileName) = Tensor.load(fileName)
+
     static member zero(?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Zero(?dtype=dtype, ?device=device, ?backend=backend))
     static member zeros(shape:seq<int>, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Zeros(shape|>Seq.toArray, ?dtype=dtype, ?device=device, ?backend=backend))
     static member zeros(length:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor(RawTensor.Zeros([|length|], ?dtype=dtype, ?device=device, ?backend=backend))

--- a/src/DiffSharp.Core/DiffSharp.fs
+++ b/src/DiffSharp.Core/DiffSharp.fs
@@ -35,12 +35,17 @@ type dsharp =
     /// </remarks>
     static member save(tensor:Tensor, fileName) = tensor.save(fileName)
 
-    /// <summary>Loads the tensor from the given file using the given configuration. If no configuration is specified the default configuration is used.</summary>
+    /// <summary>Loads the tensor from the given file using the given element type and configuration.</summary>
+    ///
+    /// <param name="fileName">The file from which to load the tensor.</param>
+    /// <param name="dtype">The element type of the resulting tensor. Defaults to the element type of the saved tensor.</param>
+    /// <param name="device">The device of the resulting tensor. Defaults to the current default device.</param>
+    /// <param name="backend">The device of the resulting tensor. Defaults to the current default backend.</param>
     ///
     /// <remarks>
-    ///   The backend used at the time of saving the tensor must be available when the tensor is reloaded.
-    ///   The tensor is first loaded into that backend and then moved. As a result, intermediate tensors may be created
-    ///   in the process of reloading.
+    ///    The backend at the time of saving the tensor must be available when the tensor is reloaded.
+    ///    The tensor is first loaded into that backend and then moved. As a result, intermediate tensors may be created
+    ///    in the process of reloading.
     /// </remarks>
     static member load(fileName, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor.load(fileName, ?dtype=dtype, ?device=device, ?backend=backend)
 

--- a/src/DiffSharp.Core/Dtype.fs
+++ b/src/DiffSharp.Core/Dtype.fs
@@ -52,7 +52,7 @@ type Device =
 /// Contains functions and settings related to device specifications.
 module Device = 
 
-    /// Get or set the default device used when creating tensors.  Note, use <c>dsharp.config(...)</c> instead.
+    /// Get or set the default device used when creating tensors. Note, use <c>dsharp.config(...)</c> instead.
     let mutable Default : Device = Device.CPU
 
 /// Represents a backend for DiffSharp tensors
@@ -86,7 +86,7 @@ module Backend =
     /// Register a new backend
     let Register name = codes.GetOrAdd(name, (fun _ -> incr count; Backend.Other(name, count.Value)))
 
-    /// Get or set the default backend used when creating tensors.  Note, use <c>dsharp.config(...)</c> instead.
+    /// Get or set the default backend used when creating tensors. Note, use <c>dsharp.config(...)</c> instead.
     let mutable Default = Backend.Reference
 
 /// Represents a storage type for elements of a tensor
@@ -202,7 +202,7 @@ module Dtype =
         elif ty.Equals(typeof<bool>) then Dtype.Bool
         else failwithf "unknown type '%A' used as tensor type" ty
 
-    /// Get or set the default element type used when creating tensors.  Note, use <c>dsharp.config(...)</c> instead.
+    /// Get or set the default element type used when creating tensors. Note, use <c>dsharp.config(...)</c> instead.
     let mutable Default = Dtype.Float32
 
 /// Contains global functions and settings related to tensor element types, used when writing backends.

--- a/src/DiffSharp.Core/RawTensor.fs
+++ b/src/DiffSharp.Core/RawTensor.fs
@@ -180,7 +180,7 @@ type RawTensor() =
     /// </summary>
     ///
     /// <remarks>
-    ///  The value may be a scalar, an array, or an array of tupled objects.  If the <c>dtype</c> is not specified
+    ///  The value may be a scalar, an array, or an array of tupled objects. If the <c>dtype</c> is not specified
     ///  then it is inferred from the .NET type of the object.
     /// </remarks>
     static member Create(values: obj, ?dtype, ?device, ?backend) =
@@ -292,7 +292,7 @@ type RawTensor() =
     /// <summary> Get a slice of the given tensor.</summary>
     ///
     /// <param name="fullBounds">
-    ///  The indexes are an Nx3 array.   The first row is the start bounds, the second row is
+    ///  The indexes are an Nx3 array.  The first row is the start bounds, the second row is
     ///  the end bounds, the third is 1/0 indicating dimension removal.
     /// </param>
     abstract member GetSlice: fullBounds: int[,] -> RawTensor
@@ -309,7 +309,7 @@ type RawTensor() =
     /// Returns a tensor moved to the given device.
     abstract member MoveTo: device: Device -> RawTensor
 
-    /// Returns a hash of the contents of the tensor.  This operation may cause the
+    /// Returns a hash of the contents of the tensor. This operation may cause the
     /// tensor to be moved to the CPU, and its entire contents iterated.
     abstract member ComputeHash: unit -> int
 

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -82,10 +82,10 @@ type Tensor =
 
     /// Returns a new tensor with the same contents moved to the given configuration
     member t.move(?dtype:Dtype, ?device:Device, ?backend:Backend) =
-        let dtype = defaultArg dtype Dtype.Default
-        let device = defaultArg device Device.Default
-        let backend = defaultArg backend Backend.Default
-        t.move(backend).cast(dtype).move(device)
+        let t = match backend with None -> t | Some backend -> t.move(backend)
+        let t = match dtype with None -> t | Some dtype -> t.cast(dtype)
+        let t = match device with None -> t | Some device -> t.move(device)
+        t
 
     member internal t.castAfterSummation(?dtype:Dtype) =
         match dtype with
@@ -290,7 +290,9 @@ type Tensor =
     static member load(fileName:string, ?dtype: Dtype, ?device: Device, ?backend: Backend):Tensor =
         let t : Tensor = loadBinary fileName
         let dtype = defaultArg dtype t.dtype
-        t.move(dtype=dtype, ?device=device, ?backend=backend)
+        let device = defaultArg device Device.Default
+        let backend = defaultArg backend Backend.Default
+        t.move(dtype=dtype, device=device, backend=backend)
 
     /// Returns a string summarising the tensor
     member t.summary() =

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -268,11 +268,23 @@ type Tensor =
         | TensorR(_), TensorF(_) -> false
         | TensorR(_), TensorR(_) -> true
 
-    /// Saves the tensor to the given file using a bespoke binary format
+    /// <summary>Saves the tensor to the given file using a bespoke binary format.</summary>
+    /// <remarks>
+    ///   The binary format records the elements, backend, element type and shape. It does not record the device.
+    ///   The format used may change from version to version of DiffSharp.
+    /// </remarks>
     member t.save(fileName:string) = saveBinary t fileName
 
-    /// Loads the tensor from the given file
-    static member load(fileName:string):Tensor = loadBinary fileName
+    /// <summary>Loads the tensor from the given file using the given configuration. If no configuration is specified the default configuration is used.</summary>
+    ///
+    /// <remarks>
+    ///   The backend used at the time of saving the tensor must be available when the tensor is reloaded.
+    ///   The tensor is first loaded into that backend and then moved. As a result, intermediate tensors may be created
+    ///   in the process of reloading.
+    /// </remarks>
+    static member load(fileName:string, ?dtype: Dtype, ?device: Device, ?backend: Backend):Tensor =
+        let t : Tensor = loadBinary fileName
+        t.move(?dtype=dtype, ?device=device, ?backend=backend)
 
     /// Returns a string summarising the tensor
     member t.summary() =

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -275,16 +275,22 @@ type Tensor =
     /// </remarks>
     member t.save(fileName:string) = saveBinary t fileName
 
-    /// <summary>Loads the tensor from the given file using the given configuration. If no configuration is specified the default configuration is used.</summary>
+    /// <summary>Loads the tensor from the given file using the given element type and configuration.</summary>
+    ///
+    /// <param name="fileName">The file from which to load the tensor.</param>
+    /// <param name="dtype">The element type of the resulting tensor. Defaults to the element type of the saved tensor.</param>
+    /// <param name="device">The device of the resulting tensor. Defaults to the current default device.</param>
+    /// <param name="backend">The device of the resulting tensor. Defaults to the current default backend.</param>
     ///
     /// <remarks>
-    ///   The backend used at the time of saving the tensor must be available when the tensor is reloaded.
-    ///   The tensor is first loaded into that backend and then moved. As a result, intermediate tensors may be created
-    ///   in the process of reloading.
+    ///    The backend at the time of saving the tensor must be available when the tensor is reloaded.
+    ///    The tensor is first loaded into that backend and then moved. As a result, intermediate tensors may be created
+    ///    in the process of reloading.
     /// </remarks>
     static member load(fileName:string, ?dtype: Dtype, ?device: Device, ?backend: Backend):Tensor =
         let t : Tensor = loadBinary fileName
-        t.move(?dtype=dtype, ?device=device, ?backend=backend)
+        let dtype = defaultArg dtype t.dtype
+        t.move(dtype=dtype, ?device=device, ?backend=backend)
 
     /// Returns a string summarising the tensor
     member t.summary() =
@@ -1077,7 +1083,7 @@ type Tensor =
        let res2 = if keepDim then res.unsqueeze(dim) else res
        res2.castAfterSummation(?dtype=dtype)
 
-    /// Reduce the dimensionality via summation until we reach `newShape`.  An expansion
+    /// Reduce the dimensionality via summation until we reach `newShape`. An expansion
     /// from newShape to shape must be possible.
     member a.sumToSize(newShape:int[], ?dtype: Dtype) =
         let oldShape = a.shape

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -274,7 +274,7 @@ type TestTensor () =
             let a = combo.tensor([[1,2],[3,4]])
             a.save(fileName)
             let aInDefault = a.move(device=Device.Default, backend=Backend.Default)
-            let b = Tensor.load(fileName)
+            let b = Tensor.load(fileName, dtype = combo.dtype)
             Assert.AreEqual(aInDefault, b)
 
     [<Test>]
@@ -783,12 +783,21 @@ type TestTensor () =
                 // printfn "%A %A" (combo1.dtype, combo1.device, combo1.backend) (combo2.dtype, combo2.device, combo2.backend)
                 let t1 = combo1.tensor([0, 1, 2, 3])
                 let t2 = t1.move(combo2.dtype, combo2.device, combo2.backend)
-                let t1b = t2.move(combo1.dtype, combo1.device, combo1.backend)
+                let t2b = t2.move(combo1.dtype, combo1.device, combo1.backend)
                 Assert.AreEqual(combo2.dtype, t2.dtype)
                 Assert.AreEqual(combo2.device, t2.device)
                 Assert.AreEqual(combo2.backend, t2.backend)
                 if combo2.dtype <> Dtype.Bool then // Conversion to bool is irreversible for tensor([0, 1, 2, 3])
-                    Assert.AreEqual(t1, t1b)
+                    Assert.AreEqual(t1, t2b)
+
+    [<Test>]
+    member _.TestTensorMoveDefaultBackend () =
+        // Check that device and backend are not changed if not specified in move
+        for combo1 in Combos.All do
+            let t1 = combo1.tensor([0, 1, 2, 3])
+            let t1b = t1.move(combo1.dtype, ?backend=None, ?device=None)
+            Assert.AreEqual(combo1.backend, t1b.backend)
+            Assert.AreEqual(combo1.device, t1b.device)
 
     [<Test>]
     member _.TestTensorCast () =

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -258,6 +258,16 @@ type TestTensor () =
             Assert.AreEqual(a, b)
 
     [<Test>]
+    member _.TestTensorSaveLoadConfiguarion () =
+        let fileName = System.IO.Path.GetTempFileName()
+        let a = dsharp.tensor([[1,2],[3,4]])
+        a.save(fileName)
+        let b = Tensor.load(fileName)
+        Assert.AreEqual(a, b)
+        let b2 = Tensor.load(fileName, dtype=Dtype.Float32)
+        Assert.AreEqual(a.move(dtype=Dtype.Float32), b2)
+
+    [<Test>]
     member _.TestTensorClone () =
         for combo in Combos.All do 
             let a = combo.randint(0,100,[10;10])

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -258,7 +258,7 @@ type TestTensor () =
             Assert.AreEqual(a, b)
 
     [<Test>]
-    member _.TestTensorSaveLoadBackToDefaultConfiguarion () =
+    member _.TestTensorSaveLoadBackToDefaultConfiguarionThenMoveToCombo () =
         let fileName = System.IO.Path.GetTempFileName()
         for combo in Combos.All do 
             let a = combo.tensor([[1,2],[3,4]])
@@ -266,6 +266,16 @@ type TestTensor () =
             let b = Tensor.load(fileName)
             let bInCombo = combo.move(b)
             Assert.AreEqual(a, bInCombo)
+
+    [<Test>]
+    member _.TestTensorSaveLoadBackToDefaultConfiguarion () =
+        let fileName = System.IO.Path.GetTempFileName()
+        for combo in Combos.All do 
+            let a = combo.tensor([[1,2],[3,4]])
+            a.save(fileName)
+            let aInDefault = a.move(device=Device.Default, backend=Backend.Default)
+            let b = Tensor.load(fileName)
+            Assert.AreEqual(aInDefault, b)
 
     [<Test>]
     member _.TestTensorSaveLoadConfiguarion () =


### PR DESCRIPTION
Fixes #123 

`dsharp.load` now takes parameters for dtype, device, backend etc.

The default dtype is the one in the tensor file

The default backend and device are the current ones


