### PR TITLE
update torchsharp version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
 
      <LibTorchNugetVersion>1.5.6</LibTorchNugetVersion>
-     <TorchSharpVersion>0.3.52267</TorchSharpVersion>
+     <TorchSharpVersion>0.3.52276</TorchSharpVersion>
 	 <FSharpCoreVersion>4.7.2</FSharpCoreVersion>
       <!-- Standard nuget.org location -->
     <RestoreSources>https://api.nuget.org/v3/index.json</RestoreSources>


### PR DESCRIPTION
This version of TorchSharp has getter/setters up to dimension 6, plus `t.RegisterAsMemoryPressure()` which we can use to help make memory management better when creating large stable tensors