### PR TITLE
Make underlying tensor handles available where necesssary

### DIFF
--- a/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
+++ b/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
@@ -28,6 +28,7 @@ type RawTensorCPU<'T when 'T : equality>(values: 'T[], shape: int[], dtype: Dtyp
     override _.Dtype = dtype
     override _.Device = device
     override _.DeviceType = device.DeviceType
+    override _.Handle = box values
     override _.Backend =
 #if TEST_DUPLICATE_BACKEND
         Backend.Register "TestDuplicate"

--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -89,6 +89,7 @@ type TorchRawTensor(tt: TorchTensor, shape: int[], dtype: Dtype, device: Device)
     override _.DeviceType : DiffSharp.DeviceType = enum (int tt.DeviceType)
     override t.Device = Device(t.DeviceType, tt.DeviceIndex)
     override _.Backend = Backend.Torch
+    override _.Handle = box tt
 
     member t.MakeLike(tt, ?shape, ?dtype, ?device) : RawTensor =
         upcast TorchRawTensor(tt, defaultArg shape t.Shape, defaultArg dtype t.Dtype, defaultArg device t.Device)

--- a/src/DiffSharp.Core/RawTensor.fs
+++ b/src/DiffSharp.Core/RawTensor.fs
@@ -125,6 +125,10 @@ type RawTensor() =
     /// Gets the backend for the tensor
     abstract member Backend : Backend
 
+    /// Gets a handle to the underlying representation of the the tensor. For example, if the Torch
+    /// backend is used this will be the corresponding TorchSharp TorchTensor.
+    abstract member Handle : obj
+
     override t.ToString() = t.GetString()
     
     /// Gets the scalar zero tensor for the given configuration

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -94,6 +94,11 @@ type TestTensor () =
         Assert.AreEqual(Dtype.Float32, t4.dtype)
 
     [<Test>]
+    member _.TestTensorHandle () =
+        let t1 = dsharp.tensor([1.0f ; 1.0f ])
+        Assert.AreEqual([| 1.0f ; 1.0f |], (t1.primalRaw.Handle :?> float32[]))
+
+    [<Test>]
     member _.TestTensorCreate0 () =
       for combo in Combos.AllDevicesAndBackends do
         let t0 = combo.tensor(1.)


### PR DESCRIPTION
This makes available a handle to the underlying tensor objects where necessary, accessed via

        let t1 = dsharp.tensor([1.0f ; 1.0f ])
        t1.primalRaw.Handle 

etc.  For Torch backend the object is TorchTensor, for Reference backend it is the underlying .NET array

There are lots of reasons we may need this in practical debugging, performance investigations etc.

