### PR TITLE
Zero size tensors (2)

### DIFF
--- a/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
+++ b/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
@@ -84,6 +84,7 @@ type RawTensorCPU<'T when 'T : equality>(values: 'T[], shape: int[], dtype: Dtyp
     override x.ComputeHash() = hash shape + hash values
     
     override t.Expand(newShape) =
+        if newShape.Length = 1 && newShape.[0] = 0 then t.MakeLike([||], newShape) else  // Return zero-sized tensor if expanding to zero-sized tensor
         if shape = newShape then t :> _ else
         Shape.checkCanExpand shape newShape
         let trim = newShape.Length - shape.Length

--- a/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
+++ b/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
@@ -753,6 +753,7 @@ module internal RawTensorCPU =
         (result, t.Shape)
 
     let inline SumT(t: RawTensorCPU< ^T >) : (^T[] * int[]) =
+        if Array.isEmpty t.Values then ([|zero< ^T >|], [||]) else // Return a zero-valued scalar tensor if summing a zero-sized tensor (not holding any value). This is mirroring the behavior in PyTorch 1.5.1.
         let result = Array.reduce (+) t.Values
         ([|result|], [||])
     

--- a/tests/DiffSharp.Tests/TestModel.fs
+++ b/tests/DiffSharp.Tests/TestModel.fs
@@ -877,4 +877,4 @@ type TestModel () =
                                               [[  0.5402,   9.7216],
                                                [  0.0364,  -8.8851]]]]).unsqueeze(0)
 
-        Assert.True(zEvalCorrect.allclose(zEval, 0.1, 0.1))        
+        Assert.True(zEvalCorrect.allclose(zEval, 0.1, 0.1))

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -595,6 +595,9 @@ type TestTensor () =
             Assert.AreEqual(tshapeCorrect, tshape)
             Assert.AreEqual(tdtypeCorrect, tdtype)
 
+        for combo in Combos.All do
+            let t = combo.tensor([])
+
             let tAdd = t + 2
             let tAddCorrect = t
             Assert.AreEqual(tAddCorrect, tAdd)
@@ -607,14 +610,40 @@ type TestTensor () =
             let tSumCorrect = tSum.zeroLike()
             Assert.AreEqual(tSumCorrect, tSum)
 
-            if combo.dtype <> Dtype.Bool then
-                let tSub = t - 2
-                let tSubCorrect = t
-                Assert.AreEqual(tSubCorrect, tSub)
+            let tClone = t.clone()
+            let tCloneCorrect = t
+            Assert.AreEqual(tCloneCorrect, tClone)
 
-                let tDiv = t / 2
-                let tDivCorrect = t
-                Assert.AreEqual(tDivCorrect, tDiv)
+
+        for combo in Combos.IntegralAndFloatingPoint do
+            let t = combo.tensor([])
+
+            let tSub = t - 2
+            let tSubCorrect = t
+            Assert.AreEqual(tSubCorrect, tSub)
+
+            let tDiv = t / 2
+            let tDivCorrect = t
+            Assert.AreEqual(tDivCorrect, tDiv)
+
+            let tNeg = -t
+            let tNegCorrect = t
+            Assert.AreEqual(tNegCorrect, tNeg)
+
+            let tAbs = dsharp.abs(t)
+            let tAbsCorrect = t
+            Assert.AreEqual(tAbsCorrect, tAbs)
+
+            let tSign = dsharp.sign(t)
+            let tSignCorrect = t
+            Assert.AreEqual(tSignCorrect, tSign)
+
+        for combo in Combos.FloatingPoint do
+            let t = combo.tensor([])
+
+            let tPow = t ** 2
+            let tPowCorrect = t
+            Assert.AreEqual(tPowCorrect, tPow)
 
     [<Test>]
     member _.TestTensorMultinomial () =

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -603,6 +603,10 @@ type TestTensor () =
             let tMulCorrect = t
             Assert.AreEqual(tMulCorrect, tMul)
 
+            let tSum = t.sum()
+            let tSumCorrect = tSum.zeroLike()
+            Assert.AreEqual(tSumCorrect, tSum)
+
             if combo.dtype <> Dtype.Bool then
                 let tSub = t - 2
                 let tSubCorrect = t

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -579,21 +579,38 @@ type TestTensor () =
     [<Test>]
     member _.TestTensorZeroSize () =
         for combo in Combos.All do
-          let t = combo.tensor([])
-          let tshape = t.shape
-          let tshapeCorrect = [|0|]
-          let tdtype = t.dtype
-          let tdtypeCorrect = combo.dtype
-          Assert.AreEqual(tshapeCorrect, tshape)
-          Assert.AreEqual(tdtypeCorrect, tdtype)
+            let t = combo.tensor([])
+            let tshape = t.shape
+            let tshapeCorrect = [|0|]
+            let tdtype = t.dtype
+            let tdtypeCorrect = combo.dtype
+            Assert.AreEqual(tshapeCorrect, tshape)
+            Assert.AreEqual(tdtypeCorrect, tdtype)
 
-          let t = combo.tensor([||])
-          let tshape = t.shape
-          let tshapeCorrect = [|0|]
-          let tdtype = t.dtype
-          let tdtypeCorrect = combo.dtype
-          Assert.AreEqual(tshapeCorrect, tshape)
-          Assert.AreEqual(tdtypeCorrect, tdtype)
+            let t = combo.tensor([||])
+            let tshape = t.shape
+            let tshapeCorrect = [|0|]
+            let tdtype = t.dtype
+            let tdtypeCorrect = combo.dtype
+            Assert.AreEqual(tshapeCorrect, tshape)
+            Assert.AreEqual(tdtypeCorrect, tdtype)
+
+            let tAdd = t + 2
+            let tAddCorrect = t
+            Assert.AreEqual(tAddCorrect, tAdd)
+
+            let tMul = t * 2
+            let tMulCorrect = t
+            Assert.AreEqual(tMulCorrect, tMul)
+
+            if combo.dtype <> Dtype.Bool then
+                let tSub = t - 2
+                let tSubCorrect = t
+                Assert.AreEqual(tSubCorrect, tSub)
+
+                let tDiv = t / 2
+                let tDivCorrect = t
+                Assert.AreEqual(tDivCorrect, tDiv)
 
     [<Test>]
     member _.TestTensorMultinomial () =


### PR DESCRIPTION
This is following from #196 and it adds more tests to ensure behavior of zero-size tensors is correct in a range of operations.