### PR TITLE
tidy up shape abbreviation

### DIFF
--- a/src/DiffSharp.Core/Distributions.fs
+++ b/src/DiffSharp.Core/Distributions.fs
@@ -37,10 +37,10 @@ type TensorDistribution() =
     member d.sample(numSamples:int) = Array.init numSamples (fun _ -> d.sample()) |> dsharp.stack
 
     /// <summary>TBD</summary>
-    abstract member batchShape: int[]
+    abstract member batchShape: Shape
 
     /// <summary>TBD</summary>
-    abstract member eventShape: int[]
+    abstract member eventShape: Shape
 
     /// <summary>TBD</summary>
     abstract member mean: Tensor

--- a/src/DiffSharp.Core/Extensions.fs
+++ b/src/DiffSharp.Core/Extensions.fs
@@ -187,7 +187,7 @@ module ExtensionAutoOpens =
         Array4D.init r1 r2 r3 r4 (fun i j k m -> data.[i,j].[k,m])
 
     /// Initializes an array with a given shape and initializer function.
-    let arrayND (shape: Shape) f =
+    let arrayND (shape: int[]) f =
         match shape with 
         | [| |] -> f [| |] |> box
         | [| d0 |] -> Array.init d0 (fun i -> f [| i |]) |> box

--- a/src/DiffSharp.Core/Model.fs
+++ b/src/DiffSharp.Core/Model.fs
@@ -274,7 +274,7 @@ type Weight() =
         w * s
 
     /// <summary>TBD</summary>
-    static member uniform(shape:int[], k:float) =
+    static member uniform(shape:Shape, k:float) =
         -k + dsharp.rand(shape) * 2*k
 
 

--- a/src/DiffSharp.Core/RawTensor.fs
+++ b/src/DiffSharp.Core/RawTensor.fs
@@ -24,28 +24,28 @@ type BackendStatics() =
     abstract Zero: device: Device -> RawTensor
 
     /// Gets a tensor filled with arbitrary values for the given shape and device
-    abstract Empty: shape:int[] * device: Device -> RawTensor
+    abstract Empty: shape:Shape * device: Device -> RawTensor
 
     /// Gets a tensor filled with zeros for the given shape and device
-    abstract Zeros: shape:int[] * device: Device -> RawTensor
+    abstract Zeros: shape:Shape * device: Device -> RawTensor
 
     /// Gets the scalar 1 tensor for the given device
     abstract One: device: Device -> RawTensor
 
     /// Gets a tensor filled with ones for the given shape and device
-    abstract Ones: shape:int[] * device: Device -> RawTensor
+    abstract Ones: shape:Shape * device: Device -> RawTensor
 
     /// Gets a tensor filled with the given value for the given shape and device
-    abstract Full: shape:int[] * value: obj * device: Device -> RawTensor
+    abstract Full: shape:Shape * value: obj * device: Device -> RawTensor
 
     /// Gets a tensor filled with random values for the given shape and device
-    abstract Random: shape:int[] * device: Device -> RawTensor
+    abstract Random: shape:Shape * device: Device -> RawTensor
 
     /// Gets a tensor filled with random values from the normal distribution for the given shape and device
-    abstract RandomNormal: shape:int[] * device: Device -> RawTensor
+    abstract RandomNormal: shape:Shape * device: Device -> RawTensor
 
     /// Gets a tensor filled with random integers from the given range for the given shape and device
-    abstract RandomInt: shape:int[] * low:int * high:int * device: Device -> RawTensor
+    abstract RandomInt: shape:Shape * low:int * high:int * device: Device -> RawTensor
 
     /// Gets the devices supported by this backend
     abstract GetDevices: ?deviceType: DeviceType -> Device list
@@ -63,7 +63,7 @@ type BackendStatics() =
 
     /// Create a tensor of appropriate dtype from a scalar or array of appropriate values.
     /// A backend type is delivered consistent with in-memory data - a type for dtype Int32 gets int32 data etc.
-    abstract CreateFromFlatArray: data: System.Array * shape: int[] * device: Device -> RawTensor
+    abstract CreateFromFlatArray: data: System.Array * shape: Shape * device: Device -> RawTensor
 
     /// Get the backend implementation for the given tensor element type and backend.
     static member Get(?dtype: Dtype, ?backend: Backend) =
@@ -135,7 +135,7 @@ type RawTensor() =
     override t.ToString() = t.GetString()
     
     /// Gets a tensor containing arbitrary values for the given shape and configuration
-    static member Empty(shape:int[], ?dtype, ?device, ?backend) = 
+    static member Empty(shape:Shape, ?dtype, ?device, ?backend) = 
         let statics = BackendStatics.Get(?dtype=dtype, ?backend=backend)
         let device = defaultArg device Device.Default
         statics.Empty(shape, device)
@@ -147,7 +147,7 @@ type RawTensor() =
         statics.Zero(device)
 
     /// Gets the zero tensor for the given shape and configuration
-    static member Zeros(shape:int[], ?dtype, ?device, ?backend) = 
+    static member Zeros(shape:Shape, ?dtype, ?device, ?backend) = 
         let statics = BackendStatics.Get(?dtype=dtype, ?backend=backend)
         let device = defaultArg device Device.Default
         statics.Zeros(shape, device)
@@ -159,31 +159,31 @@ type RawTensor() =
         statics.One(device)
 
     /// Gets a tensor filled with 1 values for the given shape and configuration
-    static member Ones(shape:int[], ?dtype, ?device, ?backend) =
+    static member Ones(shape:Shape, ?dtype, ?device, ?backend) =
         let statics = BackendStatics.Get(?dtype=dtype, ?backend=backend)
         let device = defaultArg device Device.Default
         statics.Ones(shape, device)
 
     /// Gets a tensor filled with the given value for the given shape and configuration
-    static member Full(shape:int[], value, ?dtype, ?device, ?backend) =
+    static member Full(shape:Shape, value, ?dtype, ?device, ?backend) =
         let statics = BackendStatics.Get(?dtype=dtype, ?backend=backend)
         let device = defaultArg device Device.Default
         statics.Full(shape, value, device)
 
     /// Gets a tensor filled with random values for the given shape and configuration
-    static member Random(shape:int[], ?dtype, ?device, ?backend) =
+    static member Random(shape:Shape, ?dtype, ?device, ?backend) =
         let statics = BackendStatics.Get(?dtype=dtype, ?backend=backend)
         let device = defaultArg device Device.Default
         statics.Random(shape, device)
 
     /// Gets a tensor filled with random values from the normal distribution for the given shape and configuration
-    static member RandomNormal(shape:int[], ?dtype, ?device, ?backend) =
+    static member RandomNormal(shape:Shape, ?dtype, ?device, ?backend) =
         let statics = BackendStatics.Get(?dtype=dtype, ?backend=backend)
         let device = defaultArg device Device.Default
         statics.RandomNormal(shape, device)
 
     /// Gets a tensor filled with random integer values from the given range for the given shape and configuration
-    static member RandomInt(shape:int[], low, high, ?dtype, ?device, ?backend) =
+    static member RandomInt(shape:Shape, low, high, ?dtype, ?device, ?backend) =
         let statics = BackendStatics.Get(?dtype=dtype, ?backend=backend)
         let device = defaultArg device Device.Default
         statics.RandomInt(shape, low, high, device)
@@ -245,7 +245,7 @@ type RawTensor() =
 
     /// Gets a tensor filled with arbitrary values for the given shape and configuration settings,
     /// defaulting to the configuration settings of the object tensor
-    member t.EmptyLike(shape: int[], ?dtype: Dtype, ?device: Device, ?backend: Backend) =
+    member t.EmptyLike(shape: Shape, ?dtype: Dtype, ?device: Device, ?backend: Backend) =
         RawTensor.Empty(shape=shape, dtype=defaultArg dtype t.Dtype, device=defaultArg device t.Device, backend=defaultArg backend t.Backend)
 
     /// Gets a zero tensor for the given configuration settings, defaulting to the configuration settings of the object tensor
@@ -254,7 +254,7 @@ type RawTensor() =
 
     /// Gets a tensor filled with zero values for the given shape and configuration settings,
     /// defaulting to the configuration settings of the object tensor
-    member t.ZerosLike(shape: int[], ?dtype: Dtype, ?device: Device, ?backend: Backend) =
+    member t.ZerosLike(shape: Shape, ?dtype: Dtype, ?device: Device, ?backend: Backend) =
         RawTensor.Zeros(shape=shape, dtype=defaultArg dtype t.Dtype, device=defaultArg device t.Device, backend=defaultArg backend t.Backend)
 
     /// Gets a scalar one tensor for the given configuration settings, defaulting to the configuration settings of the object tensor
@@ -263,27 +263,27 @@ type RawTensor() =
 
     /// Gets a tensor filled with one values for the given shape and configuration settings,
     /// defaulting to the configuration settings of the object tensor
-    member t.OnesLike(shape: int[], ?dtype: Dtype, ?device: Device, ?backend: Backend) =
+    member t.OnesLike(shape: Shape, ?dtype: Dtype, ?device: Device, ?backend: Backend) =
         RawTensor.Ones(shape=shape, dtype=defaultArg dtype t.Dtype, device=defaultArg device t.Device, backend=defaultArg backend t.Backend)
 
     /// Gets a tensor filled with the given scalar value for the given shape and configuration settings,
     /// defaulting to the configuration settings of the object tensor
-    member t.FullLike(shape: int[], value: obj, ?dtype: Dtype, ?device: Device, ?backend: Backend) =
+    member t.FullLike(shape: Shape, value: obj, ?dtype: Dtype, ?device: Device, ?backend: Backend) =
         RawTensor.Full(shape, value, dtype=defaultArg dtype t.Dtype, device=defaultArg device t.Device, backend=defaultArg backend t.Backend)
 
     /// Gets a tensor filled with random values for the given shape and configuration settings,
     /// defaulting to the configuration settings of the object tensor
-    member t.RandomLike(shape: int[], ?dtype: Dtype, ?device: Device, ?backend: Backend) =
+    member t.RandomLike(shape: Shape, ?dtype: Dtype, ?device: Device, ?backend: Backend) =
         RawTensor.Random(shape=shape, dtype=defaultArg dtype t.Dtype, device=defaultArg device t.Device, backend=defaultArg backend t.Backend)
 
     /// Gets a tensor filled with random values from a normal distribution for the given shape and configuration settings,
     /// defaulting to the configuration settings of the object tensor
-    member t.RandomNormalLike(shape: int[], ?dtype: Dtype, ?device: Device, ?backend: Backend) =
+    member t.RandomNormalLike(shape: Shape, ?dtype: Dtype, ?device: Device, ?backend: Backend) =
         RawTensor.RandomNormal(shape=shape, dtype=defaultArg dtype t.Dtype, device=defaultArg device t.Device, backend=defaultArg backend t.Backend)
 
     /// Gets a tensor filled with random integer values from the given range for the given shape and configuration settings,
     /// defaulting to the configuration settings of the object tensor
-    member t.RandomIntLike(shape: int[], low:int, high:int, ?dtype: Dtype, ?device: Device, ?backend: Backend) =
+    member t.RandomIntLike(shape: Shape, low:int, high:int, ?dtype: Dtype, ?device: Device, ?backend: Backend) =
         RawTensor.RandomInt(shape=shape, low=low, high=high, dtype=defaultArg dtype t.Dtype, device=defaultArg device t.Device, backend=defaultArg backend t.Backend)
 
     /// Clone the underlying storage of the tensor.
@@ -487,7 +487,7 @@ type RawTensor() =
     abstract member UndilateT: dilations: int[] -> RawTensor
 
     /// Returns the tensor with the same values viewed as a different shape
-    abstract member ViewT: shape: int[] -> RawTensor
+    abstract member ViewT: shape: Shape -> RawTensor
 
     /// Returns the element-wise sign of the tensor
     abstract member SignT: unit -> RawTensor
@@ -580,7 +580,7 @@ type RawTensor() =
         | 0 -> printVal (t.ToScalar())
         | _ ->
             let sb = System.Text.StringBuilder()
-            let rec print (shape:int[]) externalCoords = 
+            let rec print (shape:Shape) externalCoords = 
                 if shape.Length = 1 then
                     sb.Append("[") |> ignore
                     let mutable prefix = ""

--- a/src/DiffSharp.Core/Shape.fs
+++ b/src/DiffSharp.Core/Shape.fs
@@ -46,6 +46,10 @@ module rec Shape =
                     yield len|]
         outputShape
 
+    /// Computes the shape that results from a dilation operation.
+    let dilated (shape: Shape) (dilations: int[]) =
+        Array.map2 (fun n d -> n + (n - 1) * (d - 1)) shape dilations
+
     /// Checks if the given shapes are appropriate for a concatenation operation and returns information related to the resulting shape.
     let checkCanCat (shapes: Shape[]) (dim: int) =
         let n = shapes.Length
@@ -203,7 +207,7 @@ module rec Shape =
         let filtersChannels = shape2.[0]
         let kernelLength = shape2.[2]
         let kernelShape = [|kernelLength|]
-        let kernelShapeAfterDilation:int[] = dilated kernelShape [|dilation|]
+        let kernelShapeAfterDilation = dilated kernelShape [|dilation|]
         let kernelLength = kernelShapeAfterDilation.[0]
         if filtersChannels <> inputChannels then failwithf "Input and filters have different number of channels: %A, %A" inputChannels filtersChannels
         let outputSize = stride * (inputLength - 1) + kernelLength - 2 * padding + outputPadding
@@ -233,7 +237,7 @@ module rec Shape =
         let kernelHeight = shape2.[2]
         let kernelWidth = shape2.[3]
         let kernelShape = [|kernelHeight; kernelWidth|]
-        let kernelShapeAfterDilation:int[] = dilated kernelShape dilations
+        let kernelShapeAfterDilation = dilated kernelShape dilations
         let kernelHeight = kernelShapeAfterDilation.[0]
         let kernelWidth = kernelShapeAfterDilation.[1]
         if filtersChannels <> inputChannels then failwithf "Input and filters have different number of channels: %A, %A" inputChannels filtersChannels
@@ -267,7 +271,7 @@ module rec Shape =
         let kernelHeight = shape2.[3]
         let kernelWidth = shape2.[4]
         let kernelShape = [|kernelDepth; kernelHeight; kernelWidth|]
-        let kernelShapeAfterDilation:int[] = dilated kernelShape dilations
+        let kernelShapeAfterDilation = dilated kernelShape dilations
         let kernelDepth = kernelShapeAfterDilation.[0]
         let kernelHeight = kernelShapeAfterDilation.[1]
         let kernelWidth = kernelShapeAfterDilation.[2]
@@ -534,10 +538,6 @@ module rec Shape =
 
     /// Finds the shape into which all the shapes can be expanded.
     let broadcastShapes (shapes: Shape[]) = Array.reduce broadcast2 shapes
-
-    /// Computes the shape that results from a dilation operation.
-    let dilated (shape: Shape) (dilations: int[]) =
-        Array.map2 (fun n d -> n + (n - 1) * (d - 1)) shape dilations
 
     // /// Computes the shape that results from a pairwise dilation operation.
     // let dilated2 (shape: Shape) (dilations: int[]) =


### PR DESCRIPTION
Use `Shape` instead of `int[]`

Among other things this helps me minimise the diff while working on symbolic shape checking

