### PR TITLE
Rename BackendStatics to BackendTensorStatics and minor cleanup

### DIFF
--- a/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
+++ b/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
@@ -117,13 +117,14 @@ type RawTensorCPU<'T when 'T : equality>(values: 'T[], shape: Shape, dtype: Dtyp
         t.MakeLike(result, newShape)
 
     override t.ToValues() =
+        let shape = t.Shape
         match t.Dim with
         | 0 -> box values.[0]
-        | 1 -> upcast Array.init t.Shape.[0] (fun i -> t.[i])
-        | 2 -> upcast Array2D.init t.Shape.[0] t.Shape.[1] (fun i j -> t.[i, j])
-        | 3 -> upcast Array3D.init t.Shape.[0] t.Shape.[1] t.Shape.[2] (fun i j k -> t.[i, j, k])
-        | 4 -> upcast Array4D.init t.Shape.[0] t.Shape.[1] t.Shape.[2] t.Shape.[3] (fun i j k l -> t.[i, j, k, l])
-        | _ -> arrayND t.Shape (fun idxs -> t.[idxs])
+        | 1 -> upcast Array.init shape.[0] (fun i -> t.[i])
+        | 2 -> upcast Array2D.init shape.[0] shape.[1] (fun i j -> t.[i, j])
+        | 3 -> upcast Array3D.init shape.[0] shape.[1] shape.[2] (fun i j k -> t.[i, j, k])
+        | 4 -> upcast Array4D.init shape.[0] shape.[1] shape.[2] shape.[3] (fun i j k l -> t.[i, j, k, l])
+        | _ -> arrayND shape (fun idxs -> t.[idxs])
 
     override _.StackTs(tensors, dim) =
         let values, shapes = tensors |> Array.map (fun t -> t.GetTypedValues(), t.Shape) |> Array.unzip
@@ -334,12 +335,12 @@ module internal RawTensorCPU =
     /// Get the scalar "0" tensor for a CPU tensor type
     let inline Zero () : (^T[] * Shape) =
         let values = [|zero< ^T > |]
-        (values, [| |])
+        (values, Shape.scalar)
 
     /// Get the scalar "1" tensor for a CPU tensor type
     let inline One() : (^T[] * Shape) =
         let values = [| one< ^T > |]
-        (values, [| |])
+        (values, Shape.scalar)
     
     /// Get the "0" tensor for a CPU tensor type of the given shape
     let inline Zeros(shape:Shape)  : (^T[] * Shape) =
@@ -753,7 +754,7 @@ module internal RawTensorCPU =
         (result, t.Shape)
 
     let inline SumT(t: RawTensorCPU< ^T >) : (^T[] * Shape) =
-        if Array.isEmpty t.Values then ([|zero< ^T >|], [||]) else // Return a zero-valued scalar tensor if summing a zero-sized tensor (not holding any value). This is mirroring the behavior in PyTorch 1.5.1.
+        if Array.isEmpty t.Values then ([|zero< ^T >|], Shape.scalar) else // Return a zero-valued scalar tensor if summing a zero-sized tensor (not holding any value). This is mirroring the behavior in PyTorch 1.5.1.
         let result = Array.reduce (+) t.Values
         ([|result|], [||])
     
@@ -1513,8 +1514,8 @@ type RawTensorBool(values: bool[], shape:Shape, device) =
     override t.AtanT() = opNotSupported "AtanT" t.Dtype
 
     static member Seed(seed) = Random.Seed(seed)
-    static member Zero(device) = ([| false |], [||]) |> createOn device
-    static member One(device) = ([| true |], [||]) |> createOn device
+    static member Zero(device) = ([| false |], Shape.scalar) |> createOn device
+    static member One(device) = ([| true |], Shape.scalar) |> createOn device
     static member Zeros(shape:Shape, device) = (Array.zeroCreate (shapeLength shape), shape) |> createOn device
     static member Empty(shape:Shape, device) = (Array.zeroCreate (shapeLength shape), shape) |> createOn device
     static member Ones(shape:Shape, device) = (Array.create (shapeLength shape) true, shape) |> createOn device

--- a/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
+++ b/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
@@ -1525,12 +1525,12 @@ type RawTensorBool(values: bool[], shape:Shape, device) =
     static member CreateFromFlatArray(values:Array, shape, device) = RawTensorCPU.CreateFromFlatArray (values, shape) |> createOn device
 
 #if TEST_DUPLICATE_BACKEND
-type TestDuplicateBackendStatics() = 
+type TestDuplicateBackendTensorStatics() = 
 #else
-type ReferenceBackendStatics() = 
+type ReferenceBackendTensorStatics() = 
 #endif
 
-    inherit BackendStatics()
+    inherit BackendTensorStatics()
 
     override _.GetDevices(deviceType) =
         match deviceType with 

--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -972,8 +972,8 @@ type TorchByteTensorOps() =
         System.Convert.ToByte, 
         TorchScalar.op_Implicit)
 
-type TorchBackendStatics() =
-    inherit BackendStatics()
+type TorchBackendTensorStatics() =
+    inherit BackendTensorStatics()
 
     let torchFloat32 = TorchFloat32TensorOps()
     let torchFloat64 = TorchFloat64TensorOps()

--- a/src/DiffSharp.Core/Backend.fs
+++ b/src/DiffSharp.Core/Backend.fs
@@ -34,3 +34,36 @@ module Backend =
     /// Get or set the default backend used when creating tensors. Note, use <c>dsharp.config(...)</c> instead.
     let mutable Default = Backend.Reference
 
+type BackendFunctionality<'T>() =
+    let mutable last = None
+    let backends = System.Collections.Concurrent.ConcurrentDictionary<int, 'T>()
+
+    member _.Get(?backend: Backend) =
+        let backend = defaultArg backend Backend.Default
+        let code = backend.Code
+        match last with 
+        | Some (code2, v) when code = code2 -> v
+        | _ ->
+        match backends.TryGetValue(code) with 
+        | true, v -> v
+        | false, _ -> 
+            let res =
+                backends.GetOrAdd(code, fun _ -> 
+                    let name = "DiffSharp.Backends." + backend.Name
+                    let fullName = System.Reflection.Assembly.GetExecutingAssembly().FullName.Replace("DiffSharp.Core", name)
+                    let asm = 
+                        try System.Reflection.Assembly.Load(fullName)
+                        with e ->  failwithf "Couldn't find assembly '%s', error = %s" fullName (e.ToString())
+                    let typeName = sprintf "DiffSharp.Backends.%s.%s%s" backend.Name backend.Name typeof<'T>.Name
+                    let theType = asm.GetType(typeName)
+                    if isNull theType then failwithf "Couldn't find type '%s' in assembly '%s'" typeName fullName
+                    let b = 
+                        match System.Activator.CreateInstance(theType) with
+                        | :? 'T as b -> b
+                        | _ -> failwith "activation failed to return correct type"
+                    b
+                    ) 
+            last <- Some (code, res)
+            res
+
+    member _.Backends = backends

--- a/src/DiffSharp.Core/DiffSharp.fs
+++ b/src/DiffSharp.Core/DiffSharp.fs
@@ -3,11 +3,7 @@ namespace DiffSharp
 open DiffSharp.Backends
 open DiffSharp.Util
 
-
-
-
 /// Tensor operations
-
 type dsharp =
 
     /// <summary>
@@ -26,7 +22,7 @@ type dsharp =
     static member tensor(value:obj, ?dtype:Dtype, ?device:Device, ?backend:Backend) = Tensor.create(value=value, ?dtype=dtype, ?device=device, ?backend=backend)
 
     /// <summary>Seeds all backends with the given random seed, or a new seed based on the current time if no seed is specified.</summary>
-    static member seed(?seed:int) = BackendStatics.Seed(?seed=seed)
+    static member seed(?seed:int) = BackendTensorStatics.Seed(?seed=seed)
 
     /// <summary>Indicates if an object is a tensor</summary>
     static member isTensor(value:obj) = value :? Tensor
@@ -507,13 +503,13 @@ type dsharp =
     static member config((dtype,device,backend)) = dsharp.config(dtype, device, backend)
 
     /// <summary>TBD</summary>
-    static member devices(?deviceType, ?backend) = BackendStatics.Get(?backend=backend).GetDevices(?deviceType=deviceType)
+    static member devices(?deviceType, ?backend) = BackendTensorStatics.Get(?backend=backend).GetDevices(?deviceType=deviceType)
 
     /// <summary>TBD</summary>
-    static member isDeviceTypeSupported(deviceType, ?backend) = BackendStatics.Get(?backend=backend).IsDeviceTypeSupported(deviceType)
+    static member isDeviceTypeSupported(deviceType, ?backend) = BackendTensorStatics.Get(?backend=backend).IsDeviceTypeSupported(deviceType)
 
     /// <summary>TBD</summary>
-    static member isCudaSupported(?backend) = BackendStatics.Get(?backend=backend).IsDeviceTypeSupported(DeviceType.CUDA)
+    static member isCudaSupported(?backend) = BackendTensorStatics.Get(?backend=backend).IsDeviceTypeSupported(DeviceType.CUDA)
 
 
 // Differentiable methods mirroring F# collection modules

--- a/src/DiffSharp.Core/Distributions.fs
+++ b/src/DiffSharp.Core/Distributions.fs
@@ -68,7 +68,7 @@ type Normal(mean:Tensor, stddev:Tensor) =
     override d.batchShape = d.mean.shape
 
     /// <summary>TBD</summary>
-    override d.eventShape = [||]
+    override d.eventShape = Shape.scalar
 
     /// <summary>TBD</summary>
     override d.mean = mean
@@ -107,7 +107,7 @@ type Uniform(low:Tensor, high:Tensor) =
     override d.batchShape = low.shape
 
     /// <summary>TBD</summary>
-    override d.eventShape = [||]
+    override d.eventShape = Shape.scalar
 
     /// <summary>TBD</summary>
     override d.mean = (low + high) / 2.
@@ -149,7 +149,7 @@ type Bernoulli(?probs:Tensor, ?logits:Tensor) =
     override d.batchShape = d.probs.shape
 
     /// <summary>TBD</summary>
-    override d.eventShape = [||]
+    override d.eventShape = Shape.scalar
 
     /// <summary>TBD</summary>
     override d.mean = d.probs
@@ -188,10 +188,10 @@ type Categorical(?probs:Tensor, ?logits:Tensor) =
     member d.logits = _logits.cast(_dtype)
 
     /// <summary>TBD</summary>
-    override d.batchShape = if d.probs.dim = 1 then [||] else [|d.probs.shape.[0]|]
+    override d.batchShape = if d.probs.dim = 1 then Shape.scalar else [|d.probs.shape.[0]|]
 
     /// <summary>TBD</summary>
-    override d.eventShape = [||]
+    override d.eventShape = Shape.scalar
 
     /// <summary>TBD</summary>
     override d.mean = dsharp.onesLike(d.probs) * System.Double.NaN

--- a/src/DiffSharp.Core/Dtype.fs
+++ b/src/DiffSharp.Core/Dtype.fs
@@ -33,19 +33,6 @@ type Dtype =
         | Int64 -> "Int64"
         | Bool -> "Bool"
 
-    /// Get the .NET type that corresponds to this type when data is transferred to .NET
-    member x.AsType () =
-        match x with
-        //| Float16 -> typeof<single>
-        | Float32 -> typeof<single>
-        | Float64 -> typeof<double>
-        | Int8 -> typeof<int8>
-        | Byte -> typeof<byte>
-        | Int16 -> typeof<int16>
-        | Int32 -> typeof<int32>
-        | Int64 -> typeof<int64>
-        | Bool -> typeof<bool>
-
     /// Gets the natural result of the Sum(), SumToSize() and Sum(dim) operation on this dtype
     member t.SummationType =
         match t with

--- a/src/DiffSharp.Core/Extensions.fs
+++ b/src/DiffSharp.Core/Extensions.fs
@@ -199,3 +199,5 @@ module ExtensionAutoOpens =
     /// Print the given value to the console using the '%A' printf format specifier
     let print x = printfn "%A" x 
 
+[<assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DiffSharp.Tests")>]
+do()

--- a/src/DiffSharp.Core/RawTensor.fs
+++ b/src/DiffSharp.Core/RawTensor.fs
@@ -12,10 +12,10 @@ open DiffSharp.Util
 ///   <summary>Contains types and functionality related to backend implementations for DiffSharp.</summary>
 /// </namespacedoc>
 [<AbstractClass>]
-type BackendStatics() = 
+type BackendTensorStatics() = 
     // cache for most recently accessed backend
     static let mutable last = None
-    static let backends = System.Collections.Concurrent.ConcurrentDictionary<int, BackendStatics>()
+    static let backends = System.Collections.Concurrent.ConcurrentDictionary<int, BackendTensorStatics>()
 
     /// Sets the seed for the default random number generator of the backend
     abstract Seed: seed:int -> unit
@@ -83,13 +83,13 @@ type BackendStatics() =
                     let asm = 
                         try System.Reflection.Assembly.Load(fullName)
                         with e ->  failwithf "Couldn't find assembly '%s', error = %s" fullName (e.ToString())
-                    let typeName = sprintf "DiffSharp.Backends.%s.%sBackendStatics" backend.Name backend.Name
+                    let typeName = sprintf "DiffSharp.Backends.%s.%sBackendTensorStatics" backend.Name backend.Name
                     let theType = asm.GetType(typeName)
                     if isNull theType then failwithf "Couldn't find type '%s' in assembly '%s'" typeName fullName
                     let obj = 
                         match System.Activator.CreateInstance(theType) with
-                        | :? BackendStatics as obj -> obj
-                        | _ -> failwithf "Found the type '%s' in assembly '%s' but it didn't implement BackendStatics" typeName fullName
+                        | :? BackendTensorStatics as obj -> obj
+                        | _ -> failwithf "Found the type '%s' in assembly '%s' but it didn't implement BackendTensorStatics" typeName fullName
                     obj
                     ) 
             last <- Some (code, res)
@@ -135,63 +135,63 @@ type RawTensor() =
     
     /// Gets a tensor containing arbitrary values for the given shape and configuration
     static member Empty(shape:Shape, ?dtype, ?device, ?backend) = 
-        let statics = BackendStatics.Get(?backend=backend)
+        let statics = BackendTensorStatics.Get(?backend=backend)
         let dtype = defaultArg dtype Dtype.Default
         let device = defaultArg device Device.Default
         statics.Empty(shape, dtype, device)
 
     /// Gets the scalar zero tensor for the given configuration
     static member Zero(?dtype, ?device, ?backend) = 
-        let statics = BackendStatics.Get(?backend=backend)
+        let statics = BackendTensorStatics.Get(?backend=backend)
         let dtype = defaultArg dtype Dtype.Default
         let device = defaultArg device Device.Default
         statics.Zero(dtype, device)
 
     /// Gets the zero tensor for the given shape and configuration
     static member Zeros(shape:Shape, ?dtype, ?device, ?backend) = 
-        let statics = BackendStatics.Get(?backend=backend)
+        let statics = BackendTensorStatics.Get(?backend=backend)
         let dtype = defaultArg dtype Dtype.Default
         let device = defaultArg device Device.Default
         statics.Zeros(shape, dtype, device)
 
     /// Gets the scalar 1 tensor for the given configuration
     static member One(?dtype, ?device, ?backend) = 
-        let statics = BackendStatics.Get(?backend=backend)
+        let statics = BackendTensorStatics.Get(?backend=backend)
         let dtype = defaultArg dtype Dtype.Default
         let device = defaultArg device Device.Default
         statics.One(dtype, device)
 
     /// Gets a tensor filled with 1 values for the given shape and configuration
     static member Ones(shape:Shape, ?dtype, ?device, ?backend) =
-        let statics = BackendStatics.Get(?backend=backend)
+        let statics = BackendTensorStatics.Get(?backend=backend)
         let dtype = defaultArg dtype Dtype.Default
         let device = defaultArg device Device.Default
         statics.Ones(shape, dtype, device)
 
     /// Gets a tensor filled with the given value for the given shape and configuration
     static member Full(shape:Shape, value, ?dtype, ?device, ?backend) =
-        let statics = BackendStatics.Get(?backend=backend)
+        let statics = BackendTensorStatics.Get(?backend=backend)
         let dtype = defaultArg dtype Dtype.Default
         let device = defaultArg device Device.Default
         statics.Full(shape, value, dtype, device)
 
     /// Gets a tensor filled with random values for the given shape and configuration
     static member Random(shape:Shape, ?dtype, ?device, ?backend) =
-        let statics = BackendStatics.Get(?backend=backend)
+        let statics = BackendTensorStatics.Get(?backend=backend)
         let dtype = defaultArg dtype Dtype.Default
         let device = defaultArg device Device.Default
         statics.Random(shape, dtype, device)
 
     /// Gets a tensor filled with random values from the normal distribution for the given shape and configuration
     static member RandomNormal(shape:Shape, ?dtype, ?device, ?backend) =
-        let statics = BackendStatics.Get(?backend=backend)
+        let statics = BackendTensorStatics.Get(?backend=backend)
         let dtype = defaultArg dtype Dtype.Default
         let device = defaultArg device Device.Default
         statics.RandomNormal(shape, dtype, device)
 
     /// Gets a tensor filled with random integer values from the given range for the given shape and configuration
     static member RandomInt(shape:Shape, low, high, ?dtype, ?device, ?backend) =
-        let statics = BackendStatics.Get(?backend=backend)
+        let statics = BackendTensorStatics.Get(?backend=backend)
         let dtype = defaultArg dtype Dtype.Default
         let device = defaultArg device Device.Default
         statics.RandomInt(shape, low, high, dtype, device)
@@ -241,7 +241,7 @@ type RawTensor() =
                 let a,s = DataConverter.dataOfValuesForFloat32 values 
                 (a :> Array), s, Dtype.Float32
 
-        let statics = BackendStatics.Get(?backend=backend)
+        let statics = BackendTensorStatics.Get(?backend=backend)
         let device = defaultArg device Device.Default
 
         statics.CreateFromFlatArray(data, shape, dtype, device)

--- a/src/DiffSharp.Core/Shape.fs
+++ b/src/DiffSharp.Core/Shape.fs
@@ -446,7 +446,7 @@ module rec Shape =
 
     /// Checks if the given shape is appropriate for a view operation.
     let checkCanView (shape1: Shape) (shape2: Shape) =
-        if length shape1 <> length shape2 then failwithf "Cannot view Tensor of shape %A as shape %A" shape1 shape2
+        if nelement shape1 <> nelement shape2 then failwithf "Cannot view Tensor of shape %A as shape %A" shape1 shape2
 
     /// Checks if the given shape is appropriate for a flatten operation.
     let checkCanFlatten (shape: Shape) (startDim: int) (endDim: int) =
@@ -556,7 +556,7 @@ module rec Shape =
         elif numUnspecified = 0 then
             shape
         else
-            let divisor = shape |> Array.filter ((<>) -1) |> length
+            let divisor = shape |> Array.filter ((<>) -1) |> Shape.nelement
             if nelement % divisor <> 0 then failwithf "Cannot complete shape %A to have %A elements" shape nelement
             let missing = nelement / divisor
             [|for d in shape do if d = -1 then yield missing else yield d|]

--- a/src/DiffSharp.Core/Shape.fs
+++ b/src/DiffSharp.Core/Shape.fs
@@ -9,7 +9,7 @@ type Shape = int[]
 module rec Shape =
 
     /// Gets the total number of elements in the shape.
-    let length (shape: Shape) =
+    let nelement (shape: Shape) =
         if shape.Length = 0 then 1
         else Array.reduce (*) shape
 
@@ -297,7 +297,7 @@ module rec Shape =
         let inputSize = shape.[2]
         let inputLengthAfterPadding = inputSize + 2*padding
         if kernelSize > inputLengthAfterPadding then failwithf "Expecting kernelSize (%A) <= inputLengthAfterPadding (%A)" kernelSize inputLengthAfterPadding
-        let outputSize = int (floor (float (inputSize + 2*padding - kernelSize)/(float stride))) + 1
+        let outputSize = int (floor (float (inputLengthAfterPadding - kernelSize)/(float stride))) + 1
         let outputShape = [|batchSize; channels; outputSize|]
         batchSize, channels, inputSize, outputSize, outputShape
 
@@ -321,8 +321,8 @@ module rec Shape =
         let inputWidthAfterPadding = inputWidth + 2*paddings.[1]
         if kernelSize.[0] > inputHeightAfterPadding then failwithf "Expecting kernelSize.[0] (%A) <= inputHeightAfterPadding (%A)" kernelSize.[0] inputHeightAfterPadding
         if kernelSize.[1] > inputWidthAfterPadding then failwithf "Expecting kernelSize.[1] (%A) <= inputWidthAfterPadding (%A)" kernelSize.[1] inputWidthAfterPadding
-        let outputHeight = int (floor (float (inputHeight + 2*paddings.[0] - kernelHeight)/(float strides.[0]))) + 1
-        let outputWidth = int (floor (float (inputWidth + 2*paddings.[1] - kernelWidth)/(float strides.[1]))) + 1
+        let outputHeight = int (floor (float (inputHeightAfterPadding - kernelHeight)/(float strides.[0]))) + 1
+        let outputWidth = int (floor (float (inputWidthAfterPadding - kernelWidth)/(float strides.[1]))) + 1
         let outputShape = [|batchSize; channels; outputHeight; outputWidth|]
         (batchSize, channels, (inputHeight, inputWidth), (kernelHeight, kernelWidth), (outputHeight, outputWidth), outputShape)
 
@@ -350,9 +350,9 @@ module rec Shape =
         if kernelSize.[0] > inputDepthAfterPadding then failwithf "Expecting kernelSize.[0] (%A) <= inputDepthAfterPadding (%A)" kernelSize.[0] inputDepthAfterPadding
         if kernelSize.[1] > inputHeightAfterPadding then failwithf "Expecting kernelSize.[1] (%A) <= inputHeightAfterPadding (%A)" kernelSize.[1] inputHeightAfterPadding
         if kernelSize.[2] > inputWidthAfterPadding then failwithf "Expecting kernelSize.[1] (%A) <= inputWidthAfterPadding (%A)" kernelSize.[1] inputWidthAfterPadding
-        let outputDepth = int (floor (float (inputDepth + 2*paddings.[0] - kernelDepth)/(float strides.[0]))) + 1
-        let outputHeight = int (floor (float (inputHeight + 2*paddings.[1] - kernelHeight)/(float strides.[1]))) + 1
-        let outputWidth = int (floor (float (inputWidth + 2*paddings.[2] - kernelWidth)/(float strides.[2]))) + 1
+        let outputDepth = int (floor (float (inputDepthAfterPadding - kernelDepth)/(float strides.[0]))) + 1
+        let outputHeight = int (floor (float (inputHeightAfterPadding - kernelHeight)/(float strides.[1]))) + 1
+        let outputWidth = int (floor (float (inputWidthAfterPadding - kernelWidth)/(float strides.[2]))) + 1
         let outputShape = [|batchSize; channels; outputDepth; outputHeight; outputWidth|]
         (batchSize, channels, (inputDepth, inputHeight, inputWidth), (kernelDepth, kernelHeight, kernelWidth), (outputDepth, outputHeight, outputWidth), outputShape)
 
@@ -578,7 +578,7 @@ module rec Shape =
 module ShapeAutoOpens =
 
     /// Gets the total number of elements in a shape.
-    let shapeLength (shape: Shape) = Shape.length shape
+    let shapeLength (shape: Shape) = Shape.nelement shape
 
     /// Converts the array of three-position bounds specifications to a location.
     let boundsToLocation (bounds: int[,]) =
@@ -589,7 +589,7 @@ module ShapeAutoOpens =
         [|for i=0 to bounds.GetLength(0) - 1 do yield bounds.[i, 1] - bounds.[i, 0] + 1|]
 
     /// Mirrors the coordinates in the given dimensions in the context of the given shape.
-    let mirrorCoordinates (coordinates: int[]) (shape: Shape) (mirrorDims: int[]) =
+    let mirrorCoordinates (coordinates: int[]) (shape: int[]) (mirrorDims: int[]) =
         if coordinates.Length <> shape.Length then failwithf "Expecting coordinates and shape of the same dimension, received %A, %A" coordinates.Length shape.Length
         let result = Array.copy coordinates
         for d=0 to coordinates.Length-1 do
@@ -602,13 +602,13 @@ module ShapeAutoOpens =
         Array.map2 (*) coordinates dilations
 
     /// Checks if the given index is valid in the context of the given shape.
-    let checkValidIndex (shape: Shape) (index: int[]) =
+    let checkValidIndex (shape: int[]) (index: int[]) =
         if shape.Length <> index.Length then failwithf "Expecting shape (%A) and index (%A) to have the same length" shape index
         let valid = Array.forall2 (fun s i -> i < s) shape index
         if not valid then failwithf "index (%A) is not valid for shape (%A)" index shape
 
     /// Converts the given index to a flat index in the context of the given shape.
-    let indexToFlatIndex (shape: Shape) (index: int[]) =
+    let indexToFlatIndex (shape: int[]) (index: int[]) =
         checkValidIndex shape index
         let mutable flatIndex = 0
         for i=0 to index.Length - 1 do
@@ -617,7 +617,7 @@ module ShapeAutoOpens =
         flatIndex
 
     /// Converts the given flat index to an index in the context of the given shape.
-    let flatIndexToIndex (shape: Shape) (flatIndex: int) =
+    let flatIndexToIndex (shape: int[]) (flatIndex: int) =
         let dim = shape.Length
         let nelement = shapeLength shape
         let index = Array.create dim 0

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -5540,6 +5540,3 @@ type Tensor with
         let i5max   = i5
         let bounds = array2D [[i0min; i0max; i0given]; [i1min; i1max; i1given]; [i2min; i2max; i2given]; [i3min; i3max; i3given]; [i4min; i4max; i4given]; [i5min; i5max; i5given]]
         t.GetSlice(bounds)
-
-[<assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DiffSharp.Tests")>]
-do()


### PR DESCRIPTION

This is factoring out some small cleanup from feature/sym

1. Rename BackendStatics to BackendTensorStatics (the shape symbol processing is also part of the tensor backend)

2. Refactor the code to acquire backend functionality into a separate routine in Backend.fs

3. Other minor cleanup , e.g. remove unused Dtype.AsType.
