### PR TITLE
apply docs to Tensor.fs and make some fixes to docs

### DIFF
--- a/src/DiffSharp.Core/DiffSharp.Compose.fs
+++ b/src/DiffSharp.Core/DiffSharp.Compose.fs
@@ -10,6 +10,7 @@ module DiffSharp.Compose
 type dsharp with
     /// <summary>Returns a tensor where each row contains <paramref name="numSamples"/> indices sampled from the multinomial probability distribution located in the corresponding row of tensor input.</summary>
     /// <param name="numSamples">Number of samples to draw</param>
+    /// <param name="dtype">The desired element type of returned tensor. Default: if None, uses Dtype.Default.</param>
     /// <param name="device">The desired device of returned tensor. Default: if None, uses Device.Default.</param>
     /// <param name="backend">The desired backend of returned tensor. Default: if None, uses Backend.Default.</param>
     /// <remarks>

--- a/src/DiffSharp.Core/DiffSharp.fs
+++ b/src/DiffSharp.Core/DiffSharp.fs
@@ -238,11 +238,12 @@ type dsharp =
     /// <summary>Returns a tensor where each row contains numSamples indices sampled from the multinomial probability distribution located in the corresponding row of tensor input.</summary>
     /// <param name="probs">The input tensor containing probabilities.</param>
     /// <param name="numSamples">The number of samples to draw.</param>
+    /// <param name="normalize">Indicates where the probabilities should first be normalized by their sum.</param>
     /// <param name="dtype">The desired element type of returned tensor. Default: if None, uses Dtype.Default.</param>
     /// <param name="device">The desired device of returned tensor. Default: if None, uses Device.Default.</param>
     /// <param name="backend">The desired backend of returned tensor. Default: if None, uses Backend.Default.</param>
-    static member multinomial(probs:Tensor, numSamples:int, ?dtype:Dtype, ?device:Device, ?backend:Backend) =
-        probs.multinomial(numSamples, ?dtype=dtype, ?device=device, ?backend=backend)
+    static member multinomial(probs:Tensor, numSamples:int, ?normalize:bool, ?dtype:Dtype, ?device:Device, ?backend:Backend) =
+        probs.multinomial(numSamples, ?normalize=normalize, ?dtype=dtype, ?device=device, ?backend=backend)
 
     /// <summary>Draws binary random numbers (0 or 1) from a Bernoulli distribution</summary>
     /// <param name="probs">The input tensor of probability values for the Bernoulli distribution.</param>
@@ -257,12 +258,12 @@ type dsharp =
     /// <param name="p">The probability of an element to be zeroed. Default: 0.5.</param>
     static member dropout(input:Tensor, ?p:double) = input.dropout(?p=p)
 
-    /// <summary>Randomly zeroes some of the elements of the input tensor with probability p using samples from a Bernoulli distribution</summary>
+    /// <summary>Randomly zero out entire channels (a channel is a 2D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 2D tensor \text{input}[i, j]input[i,j] ). Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution</summary>
     /// <param name="input">The input tensor.</param>
     /// <param name="p">The probability of an element to be zeroed. Default: 0.5.</param>
     static member dropout2d(input:Tensor, ?p:double) = input.dropout2d(?p=p)
 
-    /// <summary>Randomly zeroes some of the elements of the input tensor with probability p using samples from a Bernoulli distribution</summary>
+    /// <summary>Randomly zero out entire channels (a channel is a 3D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 3D tensor \text{input}[i, j]input[i,j] ). Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.</summary>
     /// <param name="input">The input tensor.</param>
     /// <param name="p">The probability of an element to be zeroed. Default: 0.5.</param>
     static member dropout3d(input:Tensor, ?p:double) = input.dropout3d(?p=p)
@@ -677,18 +678,34 @@ type dsharp =
     static member repeat(input:Tensor, dim:int, times:int) = input.repeat(dim, times)
 
     /// <summary>Returns a new tensor with the same data as the self tensor but of a different shape.</summary>
-    /// <remarks>The returned tensor shares the same data and must have the same number of elements, but may have a different size. For a tensor to be viewed, the new view size must be compatible with its original size.</remarks>
-    /// <param name="input">The shape and characteristics of input will determine those of the output tensor.</param>
+    /// <remarks>The returned tensor shares the same data and must have the same number of elements, but may have a different size. For a tensor to be viewed, the new view size must be compatible with its original size.
+    ///   The returned tensor shares the same data and must have the same number of elements, but may have a different size. 
+    ///   For a tensor to be viewed, the new view size must be compatible with its original size and stride, i.e., each new view dimension must either be a subspace of an original dimension,
+    ///   or only span across original dimensions \(d, d+1, \dots, d+kd,d+1,…,d+k\) that satisfy the following contiguity-like condition that
+    ///   \(\forall i = d, \dots, d+k-1∀i=d,…,d+k−1 ,\) \[\text{stride}[i] = \text{stride}[i+1] \times \text{size}[i+1]\]
+    /// </remarks>
+    /// <param name="input">The input tensor.</param>
     /// <param name="shape">The desired shape of returned tensor.</param>
     static member view(input:Tensor, shape:seq<int>) = input.view(shape)
 
     /// <summary>Returns a new tensor with the same data as the self tensor but of a different shape.</summary>
-    /// <remarks>The returned tensor shares the same data and must have the same number of elements, but may have a different size. For a tensor to be viewed, the new view size must be compatible with its original size.</remarks>
-    /// <param name="input">The shape and characteristics of input will determine those of the output tensor.</param>
+    /// <remarks>The returned tensor shares the same data and must have the same number of elements, but may have a different size. For a tensor to be viewed, the new view size must be compatible with its original size.
+    ///   The returned tensor shares the same data and must have the same number of elements, but may have a different size. 
+    ///   For a tensor to be viewed, the new view size must be compatible with its original size and stride, i.e., each new view dimension must either be a subspace of an original dimension,
+    ///   or only span across original dimensions \(d, d+1, \dots, d+kd,d+1,…,d+k\) that satisfy the following contiguity-like condition that
+    ///   \(\forall i = d, \dots, d+k-1∀i=d,…,d+k−1 ,\) \[\text{stride}[i] = \text{stride}[i+1] \times \text{size}[i+1]\]
+    /// </remarks>
+    /// <param name="input">The input tensor.</param>
     /// <param name="shape">The desired shape of returned tensor.</param>
     static member view(input:Tensor, shape:int) = input.view(shape)
 
     /// <summary>View this tensor as the same size as other.</summary>
+    /// <remarks>The returned tensor shares the same data and must have the same number of elements, but may have a different size. For a tensor to be viewed, the new view size must be compatible with its original size.
+    ///   The returned tensor shares the same data and must have the same number of elements, but may have a different size. 
+    ///   For a tensor to be viewed, the new view size must be compatible with its original size and stride, i.e., each new view dimension must either be a subspace of an original dimension,
+    ///   or only span across original dimensions \(d, d+1, \dots, d+kd,d+1,…,d+k\) that satisfy the following contiguity-like condition that
+    ///   \(\forall i = d, \dots, d+k-1∀i=d,…,d+k−1 ,\) \[\text{stride}[i] = \text{stride}[i+1] \times \text{size}[i+1]\]
+    /// </remarks>
     /// <param name="input">The input tensor.</param>
     /// <param name="other">The result tensor has the same size as other.</param>
     static member viewAs(input:Tensor, other:Tensor) = input.viewAs(other)
@@ -700,23 +717,27 @@ type dsharp =
     static member flatten(input:Tensor, ?startDim:int, ?endDim:int) = input.flatten(?startDim=startDim, ?endDim=endDim)
 
     /// <summary>Returns a new tensor with the signs of the elements of input.</summary>
+    /// <remarks>The tensor will have the same element type as the input tensor.</remarks>
     /// <param name="input">The input tensor.</param>
     static member sign(input:Tensor) = input.sign()
 
     /// <summary>Returns a new tensor with the floor of the elements of input, the largest integer less than or equal to each element.</summary>
+    /// <remarks>The tensor will have the same element type as the input tensor.</remarks>
     /// <param name="input">The input tensor.</param>
     static member floor(input:Tensor) = input.floor()
 
     /// <summary>Returns a new tensor with the ceil of the elements of input, the smallest integer greater than or equal to each element.</summary>
+    /// <remarks>The tensor will have the same element type as the input tensor.</remarks>
     /// <param name="input">The input tensor.</param>
     static member ceil(input:Tensor) = input.ceil()
 
     /// <summary>Returns a new tensor with each of the elements of input rounded to the closest integer.</summary>
+    /// <remarks>The tensor will have the same element type as the input tensor.</remarks>
     /// <param name="input">The input tensor.</param>
     static member round(input:Tensor) = input.round()
 
     /// <summary>Computes the element-wise absolute value of the given input tensor.</summary>
-    /// <param name="input">The input tensor.</param>
+    /// <remarks>The tensor will have the same element type as the input tensor.</remarks>
     static member abs(input:Tensor) = input.abs()
 
     /// <summary>Applies the rectified linear unit function element-wise.</summary>
@@ -937,50 +958,50 @@ type dsharp =
 
     /// <summary>Applies a 1D convolution over an input signal composed of several input planes</summary>
     /// <param name="input">The input tensor.</param>
-    /// <param name="weight">The filters.</param>
+    /// <param name="filters">The filters.</param>
     /// <param name="stride">The stride of the convolving kernel.</param>
     /// <param name="padding">The implicit paddings on both sides of the input.</param>
     /// <param name="dilation">The spacing between kernel elements.</param>
-    static member conv1d(input:Tensor, weight:Tensor, ?stride:int, ?padding:int, ?dilation:int) =
-        input.conv1d(weight, ?stride=stride, ?padding=padding, ?dilation=dilation)
+    static member conv1d(input:Tensor, filters:Tensor, ?stride:int, ?padding:int, ?dilation:int) =
+        input.conv1d(filters, ?stride=stride, ?padding=padding, ?dilation=dilation)
 
     /// <summary>Applies a 2D convolution over an input signal composed of several input planes</summary>
     /// <param name="input">The input tensor.</param>
-    /// <param name="weight">The filters.</param>
+    /// <param name="filters">The filters.</param>
     /// <param name="stride">The stride of the convolving kernel.</param>
     /// <param name="padding">The implicit padding on corresponding sides of the input.</param>
     /// <param name="dilation">The spacing between kernel elements.</param>
     /// <param name="strides">The strides of the convolving kernel.</param>
     /// <param name="paddings">The implicit paddings on corresponding sides of the input.</param>
     /// <param name="dilations">The spacings between kernel elements.</param>
-    static member conv2d(input:Tensor, weight:Tensor, ?stride:int, ?strides:seq<int>, ?padding:int, ?paddings:seq<int>, ?dilation:int, ?dilations:seq<int>) =
-        input.conv2d(weight, ?stride=stride, ?strides=strides, ?padding=padding, ?paddings=paddings, ?dilation=dilation, ?dilations=dilations)
+    static member conv2d(input:Tensor, filters:Tensor, ?stride:int, ?strides:seq<int>, ?padding:int, ?paddings:seq<int>, ?dilation:int, ?dilations:seq<int>) =
+        input.conv2d(filters, ?stride=stride, ?strides=strides, ?padding=padding, ?paddings=paddings, ?dilation=dilation, ?dilations=dilations)
 
     /// <summary>Applies a 3D convolution over an input signal composed of several input planes</summary>
     /// <param name="input">The input tensor.</param>
-    /// <param name="weight">The filters.</param>
+    /// <param name="filters">The filters.</param>
     /// <param name="stride">The stride of the convolving kernel.</param>
     /// <param name="padding">The implicit padding on corresponding sides of the input.</param>
     /// <param name="dilation">The spacing between kernel elements.</param>
     /// <param name="strides">The strides of the convolving kernel.</param>
     /// <param name="paddings">The implicit paddings on corresponding sides of the input.</param>
     /// <param name="dilations">The spacings between kernel elements.</param>
-    static member conv3d(input:Tensor, weight:Tensor, ?stride:int, ?strides:seq<int>, ?padding:int, ?paddings:seq<int>, ?dilation:int, ?dilations:seq<int>) =
-        input.conv3d(weight, ?stride=stride, ?strides=strides, ?padding=padding, ?paddings=paddings, ?dilation=dilation, ?dilations=dilations)
+    static member conv3d(input:Tensor, filters:Tensor, ?stride:int, ?strides:seq<int>, ?padding:int, ?paddings:seq<int>, ?dilation:int, ?dilations:seq<int>) =
+        input.conv3d(filters, ?stride=stride, ?strides=strides, ?padding=padding, ?paddings=paddings, ?dilation=dilation, ?dilations=dilations)
 
     /// <summary>Applies a 1D transposed convolution operator over an input signal composed of several input planes, sometimes also called 'deconvolution'.</summary>
     /// <param name="input">The input tensor.</param>
-    /// <param name="weight">The filters.</param>
+    /// <param name="filters">The filters.</param>
     /// <param name="stride">The stride of the convolving kernel.</param>
     /// <param name="padding">The implicit padding on both sides of the input.</param>
     /// <param name="dilation">The spacing between kernel elements.</param>
     /// <param name="outputPadding">The additional size added to one side of each dimension in the output shape.</param>
-    static member convTranspose1d(input:Tensor, weight:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int) =
-        input.convTranspose1d(weight, ?stride=stride, ?padding=padding, ?dilation=dilation, ?outputPadding=outputPadding)
+    static member convTranspose1d(input:Tensor, filters:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int) =
+        input.convTranspose1d(filters, ?stride=stride, ?padding=padding, ?dilation=dilation, ?outputPadding=outputPadding)
 
     /// <summary>Applies a 2D transposed convolution operator over an input signal composed of several input planes, sometimes also called 'deconvolution'.</summary>
     /// <param name="input">The input tensor.</param>
-    /// <param name="weight">The filters.</param>
+    /// <param name="filters">The filters.</param>
     /// <param name="stride">The stride of the convolving kernel.</param>
     /// <param name="padding">The implicit padding on both sides of the input.</param>
     /// <param name="dilation">The spacing between kernel elements.</param>
@@ -989,12 +1010,12 @@ type dsharp =
     /// <param name="dilations">The spacings between kernel elements.</param>
     /// <param name="outputPadding">The additional size added to one side of each dimension in the output shape.</param>
     /// <param name="outputPaddings">The additional sizes added to one side of each dimension in the output shape.</param>
-    static member convTranspose2d(input:Tensor, weight:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?outputPaddings:seq<int>) =
-        input.convTranspose2d(weight, ?stride=stride, ?padding=padding, ?dilation=dilation, ?outputPadding=outputPadding, ?strides=strides, ?paddings=paddings, ?dilations=dilations, ?outputPaddings=outputPaddings)
+    static member convTranspose2d(input:Tensor, filters:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?outputPaddings:seq<int>) =
+        input.convTranspose2d(filters, ?stride=stride, ?padding=padding, ?dilation=dilation, ?outputPadding=outputPadding, ?strides=strides, ?paddings=paddings, ?dilations=dilations, ?outputPaddings=outputPaddings)
 
     /// <summary>Applies a 3D transposed convolution operator over an input signal composed of several input planes, sometimes also called 'deconvolution'.</summary>
     /// <param name="input">The input tensor.</param>
-    /// <param name="weight">The filters.</param>
+    /// <param name="filters">The filters.</param>
     /// <param name="stride">The stride of the convolving kernel.</param>
     /// <param name="padding">The implicit padding on both sides of the input.</param>
     /// <param name="dilation">The spacing between kernel elements.</param>
@@ -1003,8 +1024,8 @@ type dsharp =
     /// <param name="dilations">The spacings between kernel elements.</param>
     /// <param name="outputPadding">The additional size added to one side of each dimension in the output shape.</param>
     /// <param name="outputPaddings">The additional sizes added to one side of each dimension in the output shape.</param>
-    static member convTranspose3d(input:Tensor, weight:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?outputPaddings:seq<int>) =
-        input.convTranspose3d(weight, ?stride=stride, ?padding=padding, ?dilation=dilation, ?outputPadding=outputPadding, ?strides=strides, ?paddings=paddings, ?dilations=dilations, ?outputPaddings=outputPaddings)
+    static member convTranspose3d(input:Tensor, filters:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?outputPaddings:seq<int>) =
+        input.convTranspose3d(filters, ?stride=stride, ?padding=padding, ?dilation=dilation, ?outputPadding=outputPadding, ?strides=strides, ?paddings=paddings, ?dilations=dilations, ?outputPaddings=outputPaddings)
 
     /// <summary>Add zero padding to each side of a tensor</summary>
     /// <param name="input">The input tensor.</param>

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -731,7 +731,6 @@ type Tensor =
         if normalize then pixels <- pixels.normalize()
         pixels
 
-    /// <summary>TBD</summary>
     member internal t.GetSlice(bounds:int[,]) =
         // printfn "t.GetSlice bounds\n %A" bounds
         if t.dim = 0 then failwith "Cannot slice a scalar Tensor"
@@ -1350,8 +1349,13 @@ type Tensor =
     /// <param name="unbiased">Whether to use the unbiased estimation or not.</param>
     member a.stddev(?unbiased) = a.variance(?unbiased=unbiased) |> Tensor.Sqrt
 
-    /// <summary>TBD</summary>
-    member probs.multinomial(numSamples:int, ?dtype:Dtype, ?device:Device, ?backend:Backend, ?normalize:bool) =
+    /// <summary>Returns a tensor where each row contains numSamples indices sampled from the multinomial probability distribution located in the corresponding row of tensor input.</summary>
+    /// <param name="numSamples">The number of samples to draw.</param>
+    /// <param name="dtype">The desired element type of returned tensor. Default: if None, uses Dtype.Default.</param>
+    /// <param name="device">The desired device of returned tensor. Default: if None, uses Device.Default.</param>
+    /// <param name="backend">The desired backend of returned tensor. Default: if None, uses Backend.Default.</param>
+    /// <param name="normalize">Indicates where the probabilities should first be normalized by their sum.</param>
+    member probs.multinomial(numSamples:int, ?normalize:bool, ?dtype:Dtype, ?device:Device, ?backend:Backend) =
         // TODO: the following may be implemented by RawTensor at a later point
         if probs.dim < 1 || probs.dim > 2 then failwithf "Expecting 1d or 2d probs, received shape %A" probs.shape
         let dtype = defaultArg dtype Dtype.Int32
@@ -1375,7 +1379,10 @@ type Tensor =
                 | _ -> failwithf "Expecting probs to have dtype Float32 or Float64, received %A" probs.dtype
             Tensor.create(Random.Multinomial(p, numSamples), dtype=dtype, device=device, backend=backend)
 
-    /// <summary>TBD</summary>
+    /// <summary>Draws binary random numbers (0 or 1) from a Bernoulli distribution</summary>
+    /// <param name="dtype">The desired element type of returned tensor. Default: if None, uses Dtype.Default.</param>
+    /// <param name="device">The desired device of returned tensor. Default: if None, uses Device.Default.</param>
+    /// <param name="backend">The desired backend of returned tensor. Default: if None, uses Backend.Default.</param>
     member probs.bernoulli(?dtype:Dtype, ?device:Device, ?backend:Backend) =
         // TODO: the following may be implemented by RawTensor at a later point
         if not (probs.dtype = Dtype.Float32 || probs.dtype = Dtype.Float64) then failwithf "Expecting probs to have dtype Float32 or Float64, received %A" probs.dtype
@@ -1390,7 +1397,8 @@ type Tensor =
             let b = p.toArray() :?> float[] |> Array.map Random.Bernoulli
             Tensor.create(b, dtype=dtype, device=device, backend=backend).view(probs.shape)
 
-    /// <summary>TBD</summary>
+    /// <summary>Randomly zeroes some of the elements of the input tensor with probability p using samples from a Bernoulli distribution</summary>
+    /// <param name="p">The probability of an element to be zeroed. Default: 0.5.</param>
     member a.dropout(?p:double) =
         let p = defaultArg p 0.5
         Shape.checkCanDropout p
@@ -1402,7 +1410,8 @@ type Tensor =
             let mask = a.fullLike(1.-p).bernoulli()
             a * mask
 
-    /// <summary>TBD</summary>
+    /// <summary>Randomly zero out entire channels (a channel is a 2D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 2D tensor \text{input}[i, j]input[i,j] ). Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution</summary>
+    /// <param name="p">The probability of an element to be zeroed. Default: 0.5.</param>
     member a.dropout2d(?p:double) =
         let p = defaultArg p 0.5
         Shape.checkCanDropout2d a.shape p
@@ -1414,7 +1423,8 @@ type Tensor =
             let mask = a.fullLike(1.-p, Array.append a.shape.[0..1] [|1;1|]).bernoulli()
             a * mask
 
-    /// <summary>TBD</summary>
+    /// <summary>Randomly zero out entire channels (a channel is a 3D feature map, e.g., the jj -th channel of the ii -th sample in the batched input is a 3D tensor \text{input}[i, j]input[i,j] ). Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.</summary>
+    /// <param name="p">The probability of an element to be zeroed. Default: 0.5.</param>
     member a.dropout3d(?p:double) =
         let p = defaultArg p 0.5
         Shape.checkCanDropout3d a.shape p
@@ -1426,7 +1436,6 @@ type Tensor =
             let mask = a.fullLike(1.-p, Array.append a.shape.[0..1] [|1;1;1|]).bernoulli()
             a * mask
 
-    /// <summary>TBD</summary>
     // This is useful to keep as a special case of sum for performance reasons because it's involved in reverse mode of broadcasting addition of bias in NN linear layers
     member internal a.sumT2Dim0() =
         let fRaw(a:RawTensor) = a.SumT2Dim0()
@@ -1435,7 +1444,9 @@ type Tensor =
         let dfTensorRev(a) = SumT2Dim0(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
     
-    /// <summary>TBD</summary>
+    /// <summary>Returns a tensor that is a transposed version of input. The given dimensions dim0 and dim1 are swapped.</summary>
+    /// <param name="dim0">The first dimension to be transposed.</param>
+    /// <param name="dim1">The second dimension to be transposed.</param>
     member a.transpose(dim0:int, dim1:int) =
         let dim0 = Shape.completeDim a.dim dim0  // Handles -1 semantics
         let dim1 = Shape.completeDim a.dim dim1  // Handles -1 semantics
@@ -1449,7 +1460,7 @@ type Tensor =
             let dfTensorRev(a) = TransposeT(a, dim0, dim1)
             Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a tensor that is a transposed version of input with dimensions 0 and 1 swapped.</summary>
     member a.transpose() =
         Shape.checkCanTranspose2d a.dim
         let fRaw(a:RawTensor) = a.TransposeT2()
@@ -1458,7 +1469,9 @@ type Tensor =
         let dfTensorRev(a) = TransposeT2(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a tensor with all the dimensions of input of size 1 removed.</summary>
+    /// <remarks>If the tensor has a batch dimension of size 1, then squeeze(input) will also remove the batch dimension, which can lead to unexpected errors.</remarks>
+    /// <param name="dim">If given, the input will be squeezed only in this dimension.</param>
     member a.squeeze(?dim:int) =
         let dim = defaultArg dim -1
         let fRaw(a:RawTensor) = a.SqueezeT(dim)
@@ -1467,7 +1480,8 @@ type Tensor =
         let dfTensorRev(a) = SqueezeT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with a dimension of size one inserted at the specified position</summary>
+    /// <param name="dim">The index at which to insert the singleton dimension.</param>
     member a.unsqueeze(dim:int) =
         let fRaw(a:RawTensor) = a.UnsqueezeT(dim)
         let fTensor(a:Tensor) = a.unsqueeze(dim)
@@ -1475,7 +1489,8 @@ type Tensor =
         let dfTensorRev(a) = UnsqueezeT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Reverse the order of a n-D tensor along given axis in dims</summary>
+    /// <param name="dims">The axis to flip on.</param>
     member a.flip(dims:seq<int>) =
         let dims = dims |> Array.ofSeq
         Shape.checkCanFlip a.dim dims
@@ -1485,7 +1500,8 @@ type Tensor =
         let dfTensorRev(a) = FlipT(a, dims)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Dilate the tensor in using the given dilations in each corresponding dimension.</summary>
+    /// <param name="dilations">The dilations to use.</param>
     member a.dilate(dilations:seq<int>) =
         let dilations = dilations |> Array.ofSeq
         Shape.checkCanDilate a.dim dilations
@@ -1495,7 +1511,8 @@ type Tensor =
         let dfTensorRev(a) = DilateT(a, dilations)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Reverse the dilation of the tensor in using the given dilations in each corresponding dimension.</summary>
+    /// <param name="dilations">The dilations to use.</param>
     member a.undilate(dilations:seq<int>) =
         let dilations = dilations |> Array.ofSeq
         let fRaw(a:RawTensor) = a.UndilateT(dilations)
@@ -1504,7 +1521,9 @@ type Tensor =
         let dfTensorRev(a) = UndilateT(a, dilations)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Repeat elements of a tensor</summary>
+    /// <param name="dim">The dimension along which to repeat values.</param>
+    /// <param name="times">The number of repetitions for each element.</param>
     member a.repeat(dim:int, times:int) =
         Shape.checkCanRepeat a.shape dim
         let newShape = a.shape |> Array.copy
@@ -1516,7 +1535,9 @@ type Tensor =
             ret <- ret.addSlice(location, a)
         ret
 
-    /// <summary>TBD</summary>
+    /// <summary>Gathers values along an axis specified by dim.</summary>
+    /// <param name="dim">The axis along which to index.</param>
+    /// <param name="indices">The the indices of elements to gather.</param>
     member a.gather(dim:int, indices:Tensor) =
         Shape.checkCanGather a.shape dim indices.shape indices.dtype
         let fRaw(a:RawTensor) = a.GatherT(dim, indices.primalRaw)
@@ -1525,7 +1546,14 @@ type Tensor =
         let dfTensorRev(a) = GatherT(a, dim, indices)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the same data as the self tensor but of a different shape.</summary>
+    /// <remarks>
+    ///   The returned tensor shares the same data and must have the same number of elements, but may have a different size. 
+    ///   For a tensor to be viewed, the new view size must be compatible with its original size and stride, i.e., each new view dimension must either be a subspace of an original dimension,
+    ///   or only span across original dimensions \(d, d+1, \dots, d+kd,d+1,…,d+k\) that satisfy the following contiguity-like condition that
+    ///   \(\forall i = d, \dots, d+k-1∀i=d,…,d+k−1 ,\) \[\text{stride}[i] = \text{stride}[i+1] \times \text{size}[i+1]\]
+    /// </remarks>
+    /// <param name="shape">The desired shape of returned tensor.</param>
     member a.view(shape:seq<int>) =
         let shape = shape |> Shape.create |> Shape.complete a.nelement  // Handles -1 semantics
         Shape.checkCanView a.shape shape
@@ -1545,10 +1573,19 @@ type Tensor =
     /// <param name="shape">the desired shape</param>
     member t.view(shape:int) = t.view([|shape|])
 
-    /// <summary>TBD</summary>
-    member a.viewAs(b:Tensor) = a.view(b.shape)
+    /// <summary>View this tensor as the same size as other.</summary>
+    /// <remarks>The returned tensor shares the same data and must have the same number of elements, but may have a different size. For a tensor to be viewed, the new view size must be compatible with its original size.
+    ///   The returned tensor shares the same data and must have the same number of elements, but may have a different size. 
+    ///   For a tensor to be viewed, the new view size must be compatible with its original size and stride, i.e., each new view dimension must either be a subspace of an original dimension,
+    ///   or only span across original dimensions \(d, d+1, \dots, d+kd,d+1,…,d+k\) that satisfy the following contiguity-like condition that
+    ///   \(\forall i = d, \dots, d+k-1∀i=d,…,d+k−1 ,\) \[\text{stride}[i] = \text{stride}[i+1] \times \text{size}[i+1]\]
+    /// </remarks>
+    /// <param name="other">The result tensor has the same size as other.</param>
+    member a.viewAs(other:Tensor) = a.view(other.shape)
 
-    /// <summary>TBD</summary>
+    /// <summary>Flattens a contiguous range of dims in a tensor.</summary>
+    /// <param name="startDim">The first dim to flatten.</param>
+    /// <param name="endDim">The last dim to flatten.</param>
     member a.flatten(?startDim:int, ?endDim:int) =
         if a.dim < 2 then 
             a
@@ -1574,10 +1611,13 @@ type Tensor =
         | TensorF(ap,ad,at)    -> let result, mask = ap.clampWithMask(?low=low, ?high=high) in TensorF(result, ad * mask, at), mask
         | TensorR(ap,_,_,_,at) -> let result, mask = ap.clampWithMask(?low=low, ?high=high) in TensorR(result, ref (a.zeroLike()), ClampT(a, mask), ref 0u, at), mask
 
-    /// <summary>TBD</summary>
+    /// <summary>Clamp all elements in input into the range [ low..high] and return a resulting tensor</summary>
+    /// <param name="low">The lower-bound of the range to be clamped to.</param>
+    /// <param name="high">The upper-bound of the range to be clamped to.</param>
     member a.clamp(?low:scalar, ?high:scalar) = a.clampWithMask(?low=low, ?high=high) |> fst
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the signs of the elements of input.</summary>
+    /// <remarks>The tensor will have the same element type as the input tensor.</remarks>
     member a.sign() =
         let fRaw(a:RawTensor) = a.SignT()
         let fTensor(a:Tensor) = a.sign()
@@ -1586,7 +1626,8 @@ type Tensor =
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
     // static member Sign(a:Tensor) = a.sign() // not supported becaose FSharp.Core sign operator returns int
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the floor of the elements of input, the largest integer less than or equal to each element.</summary>
+    /// <remarks>The tensor will have the same element type as the input tensor.</remarks>
     member a.floor() =
         let fRaw(a:RawTensor) = a.FloorT()
         let fTensor(a:Tensor) = a.floor()
@@ -1594,10 +1635,11 @@ type Tensor =
         let dfTensorRev(a) = FloorT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>floor</c>.</summary>
     static member Floor(a:Tensor) = a.floor() // needed for FSharp.Core floor operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the ceil of the elements of input, the smallest integer greater than or equal to each element.</summary>
+    /// <remarks>The tensor will have the same element type as the input tensor.</remarks>
     member a.ceil() =
         let fRaw(a:RawTensor) = a.CeilT()
         let fTensor(a:Tensor) = a.ceil()
@@ -1605,10 +1647,11 @@ type Tensor =
         let dfTensorRev(a) = CeilT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>ceil</c>.</summary>
     static member Ceiling(a:Tensor) = a.ceil() // needed for FSharp.Core ceil operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with each of the elements of input rounded to the closest integer.</summary>
+    /// <remarks>The tensor will have the same element type as the input tensor.</remarks>
     member a.round() =
         let fRaw(a:RawTensor) = a.RoundT()
         let fTensor(a:Tensor) = a.round()
@@ -1616,10 +1659,10 @@ type Tensor =
         let dfTensorRev(a) = RoundT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>round</c>.</summary>
     static member Round(a:Tensor) = a.round() // needed for FSharp.Core round operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Computes the element-wise absolute value of the given input tensor.</summary>
     member a.abs() =
         let fRaw(a:RawTensor) = a.AbsT()
         let fTensor(a:Tensor) = a.abs()
@@ -1627,10 +1670,10 @@ type Tensor =
         let dfTensorRev(a) = AbsT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>abs</c>.</summary>
     static member Abs(a:Tensor) = a.abs() // needed for FSharp.Core abs operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies the rectified linear unit function element-wise.</summary>
     member a.relu() =
         let fRaw(a:RawTensor) = a.ReluT()
         let fTensor(a:Tensor) = a.relu()
@@ -1638,12 +1681,15 @@ type Tensor =
         let dfTensorRev(a) = ReluT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies the leaky rectified linear unit function element-wise</summary>
+    /// <remarks>\[\text{LeakyReLU}(x) = \max(0, x) + \text{negative\_slope} * \min(0, x)\]</remarks>
+    /// <param name="negativeSlope">Controls the angle of the negative slope. Default: 0.01.</param>
     member a.leakyRelu(?negativeSlope:float) =
         let negativeSlope = defaultArg negativeSlope 0.01
         let zeros = a.zerosLike() in zeros.max(a) + negativeSlope * zeros.min(a)
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies the sigmoid element-wise function</summary>
+    /// <remarks>\[\text{Sigmoid}(x) = \frac{1}{1 + \exp(-x)}\]</remarks>
     member a.sigmoid() =
         let fRaw(a:RawTensor) = a.SigmoidT()
         let fTensor(a:Tensor) = a.sigmoid()
@@ -1651,7 +1697,7 @@ type Tensor =
         let dfTensorRev(a) = SigmoidT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies the exp function element-wise.</summary>
     member a.exp() =
         let fRaw(a:RawTensor) = a.ExpT()
         let fTensor(a:Tensor) = a.exp()
@@ -1659,10 +1705,11 @@ type Tensor =
         let dfTensorRev(a) = ExpT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>exp</c>.</summary>
     static member Exp(a:Tensor) = a.exp() // needed for FSharp.Core exp operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the natural logarithm of the elements of input.</summary>
+    /// <remarks> \[y_{i} = \log_{e} (x_{i})\]</remarks>
     member a.log() =
         let fRaw(a:RawTensor) = a.LogT()
         let fTensor(a:Tensor) = a.log()
@@ -1670,10 +1717,11 @@ type Tensor =
         let dfTensorRev(a) = LogT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>log</c>.</summary>
     static member Log(a:Tensor) = a.log() // needed for FSharp.Core log operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies the softplus function element-wise.</summary>
+    /// <remarks>\[\text{Softplus}(x) = \frac{1}{\beta} * \log(1 + \exp(\beta * x))\]</remarks>
     member a.softplus() =
         let fRaw(a:RawTensor) = a.SoftplusT()
         let fTensor(a:Tensor) = a.softplus()
@@ -1681,7 +1729,8 @@ type Tensor =
         let dfTensorRev(a) = SoftplusT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the logarithm to the base 10 of the elements of input.</summary>
+    /// <remarks>\[y_{i} = \log_{10} (x_{i})\]</remarks>
     member a.log10() =
         let fRaw(a:RawTensor) = a.Log10T()
         let fTensor(a:Tensor) = a.log10()
@@ -1689,10 +1738,10 @@ type Tensor =
         let dfTensorRev(a) = Log10T(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>log10</c>.</summary>
     static member Log10(a:Tensor) = a.log10() // needed for FSharp.Core log10 operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the square-root of the elements of input.</summary>
     member a.sqrt() =
         let fRaw(a:RawTensor) = a.SqrtT()
         let fTensor(a:Tensor) = a.sqrt()
@@ -1700,10 +1749,10 @@ type Tensor =
         let dfTensorRev(a) = SqrtT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>sqrt</c>.</summary>
     static member Sqrt(a:Tensor) = a.sqrt() // needed for FSharp.Core sqrt operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the sine of the elements of input</summary>
     member a.sin() =
         let fRaw(a:RawTensor) = a.SinT()
         let fTensor(a:Tensor) = a.sin()
@@ -1711,10 +1760,10 @@ type Tensor =
         let dfTensorRev(a) = SinT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>sin</c>.</summary>
     static member Sin(a:Tensor) = a.sin() // needed for FSharp.Core sin operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the cosine of the elements of input</summary>
     member a.cos() =
         let fRaw(a:RawTensor) = a.CosT()
         let fTensor(a:Tensor) = a.cos()
@@ -1722,10 +1771,10 @@ type Tensor =
         let dfTensorRev(a) = CosT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>cos</c>.</summary>
     static member Cos(a:Tensor) = a.cos() // needed for FSharp.Core cos operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the tangent of the elements of input</summary>
     member a.tan() =
         let fRaw(a:RawTensor) = a.TanT()
         let fTensor(a:Tensor) = a.tan()
@@ -1733,10 +1782,10 @@ type Tensor =
         let dfTensorRev(a) = TanT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>tan</c>.</summary>
     static member Tan(a:Tensor) = a.tan() // needed for FSharp.Core tan operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the hyperbolic sine of the elements of input.</summary>
     member a.sinh() =
         let fRaw(a:RawTensor) = a.SinhT()
         let fTensor(a:Tensor) = a.sinh()
@@ -1744,10 +1793,10 @@ type Tensor =
         let dfTensorRev(a) = SinhT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>A method to enable the use of the F# function <c>sinh</c>.</summary>
     static member Sinh(a:Tensor) = a.sinh() // needed for FSharp.Core sinh operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the hyperbolic cosine of the elements of input.</summary>
     member a.cosh() =
         let fRaw(a:RawTensor) = a.CoshT()
         let fTensor(a:Tensor) = a.cosh()
@@ -1755,10 +1804,10 @@ type Tensor =
         let dfTensorRev(a) = CoshT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
-    static member Cosh(a:Tensor) = a.cosh() // needed for FSharp.Core cosh operator overload
+    /// <summary>A method to enable the use of the F# function <c>cosh</c>.</summary>
+    static member Cosh(t:Tensor) = t.cosh() // needed for FSharp.Core cosh operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the hyperbolic tangent of the elements of input.</summary>
     member a.tanh() =
         let fRaw(a:RawTensor) = a.TanhT()
         let fTensor(a:Tensor) = a.tanh()
@@ -1766,10 +1815,10 @@ type Tensor =
         let dfTensorRev(a) = TanhT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
-    static member Tanh(a:Tensor) = a.tanh() // needed for FSharp.Core tanh operator overload
+    /// <summary>A method to enable the use of the F# function <c>tanh</c>.</summary>
+    static member Tanh(t:Tensor) = t.tanh() // needed for FSharp.Core tanh operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the arcsine of the elements of input.</summary>
     member a.asin() =
         let fRaw(a:RawTensor) = a.AsinT()
         let fTensor(a:Tensor) = a.asin()
@@ -1777,10 +1826,10 @@ type Tensor =
         let dfTensorRev(a) = AsinT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
-    static member Asin(a:Tensor) = a.asin() // needed for FSharp.Core asin operator overload
+    /// <summary>A method to enable the use of the F# function <c>asin</c>.</summary>
+    static member Asin(t:Tensor) = t.asin() // needed for FSharp.Core asin operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the arccosine of the elements of input.</summary>
     member a.acos() =
         let fRaw(a:RawTensor) = a.AcosT()
         let fTensor(a:Tensor) = a.acos()
@@ -1788,10 +1837,10 @@ type Tensor =
         let dfTensorRev(a) = AcosT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
-    static member Acos(a:Tensor) = a.acos() // needed for FSharp.Core acos operator overload
+    /// <summary>A method to enable the use of the F# function <c>acos</c>.</summary>
+    static member Acos(t:Tensor) = t.acos() // needed for FSharp.Core acos operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Returns a new tensor with the arctangent of the elements of input.</summary>
     member a.atan() =
         let fRaw(a:RawTensor) = a.AtanT()
         let fTensor(a:Tensor) = a.atan()
@@ -1799,10 +1848,10 @@ type Tensor =
         let dfTensorRev(a) = AtanT(a)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
-    static member Atan(a:Tensor) = a.atan() // needed for FSharp.Core atan operator overload
+    /// <summary>A method to enable the use of the F# function <c>atan</c>.</summary>
+    static member Atan(t:Tensor) = t.atan() // needed for FSharp.Core atan operator overload
 
-    /// <summary>TBD</summary>
+    /// <summary>Add the given tensor as a slice at the given location.</summary>
     member a.addSlice(location:seq<int>, b:Tensor) =
         let location = location |> Seq.toArray
         Shape.checkCanAddSlice a.shape location b.shape
@@ -1816,19 +1865,24 @@ type Tensor =
         let dfTensorRevCT(a,b) = AddTConstTSlice(location,b)
         Tensor.OpBinary(a, b, fRaw, fTensor, dfTensorFwdTT, dfTensorFwdTC, dfTensorFwdCT, dfTensorRevTT, dfTensorRevTC, dfTensorRevCT)
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies a softmax function.</summary>
+    /// <remarks>Softmax is defined as: \text{Softmax}(x_{i}) = \frac{\exp(x_i)}{\sum_j \exp(x_j)}.</remarks>
+    /// <param name="dim">A dimension along which softmax will be computed.</param>
     member a.softmax(dim:int) =
         let dim = Shape.completeDim a.dim dim  // Handles -1 semantics
         let e = (a - a.max().noDiff()).exp()
         let esum = e.sum(dim, keepDim=true).repeat(dim, a.shape.[dim])
         e / esum
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies a softmax followed by a logarithm.</summary>
+    /// <param name="dim">A dimension along which softmax will be computed.</param>
     member a.logsoftmax(dim:int) =
         let dim = Shape.completeDim a.dim dim  // Handles -1 semantics
         a - a.logsumexp(dim, keepDim=true)
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies a logsumexp.</summary>
+    /// <param name="dim">The dimension to reduce.</param>
+    /// <param name="keepDim">Whether the output tensor has dim retained or not.</param>
     member a.logsumexp(dim:int, ?keepDim:bool) =
         let dim = Shape.completeDim a.dim dim  // Handles -1 semantics
         let keepDim = defaultArg keepDim false
@@ -1837,7 +1891,9 @@ type Tensor =
         let res = amax + e.sum(dim).add(System.Single.Epsilon).log()
         if keepDim then res.unsqueeze(dim) else res
 
-    /// <summary>TBD</summary>
+    /// <summary>Creates a criterion that measures the mean squared error (squared L2 norm) between each element in the input and the target.</summary>
+    /// <param name="target">The target tensor.</param>
+    /// <param name="reduction">Optionally specifies the reduction to apply to the output: 'none' | 'mean' | 'sum'. 'none': no reduction will be applied, 'mean': the sum of the output will be divided by the number of elements in the output, 'sum': the output will be summed. Note: size_average and reduce are in the process of being deprecated, and in the meantime, specifying either of those two args will override reduction. Default: 'mean'.</param>
     member input.mseLoss(target:Tensor, ?reduction:string) = 
         if input.shape <> target.shape then failwithf "Expecting input.shape (%A) and target.shape (%A) to be the same" input.shape target.shape
         let reduction = defaultArg reduction "mean"
@@ -1851,7 +1907,10 @@ type Tensor =
         else // reduction = "sum"
             l.sum()
 
-    /// <summary>TBD</summary>
+    /// <summary>Creates a criterion that measures the Binary Cross Entropy between the target and the output</summary>
+    /// <param name="target">The target tensor.</param>
+    /// <param name="weight">A manual rescaling weight given to the loss of each batch element.</param>
+    /// <param name="reduction">Optionally specifies the reduction to apply to the output: 'none' | 'mean' | 'sum'. 'none': no reduction will be applied, 'mean': the sum of the output will be divided by the number of elements in the output, 'sum': the output will be summed. Note: size_average and reduce are in the process of being deprecated, and in the meantime, specifying either of those two args will override reduction. Default: 'mean'.</param>
     member input.bceLoss(target:Tensor, ?weight:Tensor, ?reduction:string) =
         if input.shape <> target.shape then failwithf "Expecting input shape (%A) and target shape (%A) to be the same" input.shape target.shape
         if target.max() > target.oneLike() || target.min() < target.zeroLike() then failwith "Expecting target values to be between 0 and 1."
@@ -1871,11 +1930,17 @@ type Tensor =
         else // reduction = "sum"
             l.sum()
 
-    /// <summary>TBD</summary>
+    /// <summary>This criterion combines logsoftmax and nllLoss in a single function</summary>
+    /// <param name="target">The target tensor.</param>
+    /// <param name="weight">A optional manual rescaling weight given to the loss of each batch element.</param>
+    /// <param name="reduction">Optionally specifies the reduction to apply to the output: 'none' | 'mean' | 'sum'. 'none': no reduction will be applied, 'mean': the sum of the output will be divided by the number of elements in the output, 'sum': the output will be summed. Note: size_average and reduce are in the process of being deprecated, and in the meantime, specifying either of those two args will override reduction. Default: 'mean'.</param>
     member input.crossEntropyLoss(target:Tensor, ?weight:Tensor, ?reduction:string) =
         input.logsoftmax(dim=1).nllLoss(target, ?weight=weight, ?reduction=reduction)
 
-    /// <summary>TBD</summary>
+    /// <summary>The negative log likelihood loss.</summary>
+    /// <param name="target">The target tensor.</param>
+    /// <param name="weight">A optional manual rescaling weight given to the loss of each batch element.</param>
+    /// <param name="reduction">Optionally specifies the reduction to apply to the output: 'none' | 'mean' | 'sum'. 'none': no reduction will be applied, 'mean': the sum of the output will be divided by the number of elements in the output, 'sum': the output will be summed. Note: size_average and reduce are in the process of being deprecated, and in the meantime, specifying either of those two args will override reduction. Default: 'mean'.</param>
     member input.nllLoss(target:Tensor, ?weight:Tensor, ?reduction:string) =
         let n, classes, d = 
             if input.dim < 2 
@@ -1928,7 +1993,8 @@ type Tensor =
             else // reduction = "sum"
                 l.sum()
 
-    /// <summary>TBD</summary>
+    /// <summary>Add zero padding to each side of a tensor</summary>
+    /// <param name="paddings">The implicit paddings on corresponding sides of the input.</param>
     member a.pad(paddings:seq<int>) =
         let paddings = paddings |> Array.ofSeq
         Shape.checkCanPad a.shape paddings
@@ -1941,7 +2007,10 @@ type Tensor =
             let ret = a.zerosLike(shape)
             ret.addSlice(paddings, a)
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies a 1D max pooling over an input signal composed of several input planes, returning the max indices along with the outputs.</summary>
+    /// <param name="kernelSize">The size of the window to take a max over.</param>
+    /// <param name="stride">The stride of the window. Default value is kernelSize.</param>
+    /// <param name="padding">The implicit zero padding to be added on both sides.</param>
     member a.maxpool1di(kernelSize:int, ?stride:int, ?padding:int) =
         let stride = defaultArg stride kernelSize
         let padding = defaultArg padding 0
@@ -1951,10 +2020,18 @@ type Tensor =
         | TensorF(ap,ad,at)    -> let result, indices = ap.maxpool1di(kernelSize, stride, padding) in TensorF(result, ad.gather(dim=2, indices=indices), at), indices
         | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool1di(kernelSize, stride, padding) in TensorR(result, ref (a.zeroLike()), MaxPool1DT(a, indices, kernelSize), ref 0u, at), indices
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies a 1D max pooling over an input signal composed of several input planes.</summary>
+    /// <param name="kernelSize">The size of the window to take a max over.</param>
+    /// <param name="stride">The stride of the window. Default value is kernelSize.</param>
+    /// <param name="padding">The implicit zero padding to be added on both sides.</param>
     member a.maxpool1d(kernelSize:int, ?stride:int, ?padding:int) = a.maxpool1di(kernelSize, ?stride=stride, ?padding=padding) |> fst
 
-    /// <summary>TBD</summary>
+    /// <summary>Computes a partial inverse of maxpool1di</summary>
+    /// <param name="indices">The indices selected by maxpool1di.</param>
+    /// <param name="kernelSize">The size of the window to take a max over.</param>
+    /// <param name="stride">The stride of the window. Default value is kernelSize.</param>
+    /// <param name="padding">The implicit zero padding to be added on both sides.</param>
+    /// <param name="outputSize">The targeted output size.</param>
     member a.maxunpool1d(indices:Tensor, kernelSize:int, ?stride:int, ?padding:int, ?outputSize:seq<int>) =
         let stride = defaultArg stride kernelSize
         let padding = defaultArg padding 0
@@ -1971,7 +2048,13 @@ type Tensor =
         let dfTensorRev(a) = MaxUnpool1DT(a, indices)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies a 2D max pooling over an input signal composed of several input planes, returning the max indices along with the outputs.</summary>
+    /// <param name="kernelSize">The size of the window to take a max over.</param>
+    /// <param name="stride">The stride of the window. Default value is kernelSize.</param>
+    /// <param name="padding">The implicit zero padding to be added on both sides.</param>
+    /// <param name="kernelSizes">The sizes of the window to take a max over.</param>
+    /// <param name="strides">The strides of the window. Default value is kernelSize.</param>
+    /// <param name="paddings">The implicit zero paddings to be added on corresponding sides.</param>
     member a.maxpool2di(?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) =
         let kernelSizes =
             match kernelSize, kernelSizes with
@@ -1997,10 +2080,24 @@ type Tensor =
         | TensorF(ap,ad,at)    -> let result, indices = ap.maxpool2di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorF(result, ad.flatten(startDim=2).gather(dim=2, indices=indices.flatten(startDim=2)).viewAs(indices), at), indices
         | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool2di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorR(result, ref (a.zeroLike()), MaxPool2DT(a, indices, kernelSizes), ref 0u, at), indices
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies a 2D max pooling over an input signal composed of several input planes.</summary>
+    /// <param name="kernelSize">The size of the window to take a max over.</param>
+    /// <param name="stride">The stride of the window. Default value is kernelSize.</param>
+    /// <param name="padding">The implicit zero padding to be added on both sides.</param>
+    /// <param name="kernelSizes">The sizes of the window to take a max over.</param>
+    /// <param name="strides">The strides of the window. Default value is kernelSize.</param>
+    /// <param name="paddings">The implicit zero paddings to be added on corresponding sides.</param>
     member a.maxpool2d(?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) = a.maxpool2di(?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings) |> fst
 
-    /// <summary>TBD</summary>
+    /// <summary>Computes a partial inverse of maxpool2di</summary>
+    /// <param name="indices">The indices selected by maxpool2di.</param>
+    /// <param name="kernelSize">The size of the window to take a max over.</param>
+    /// <param name="stride">The stride of the window. Default value is kernelSize.</param>
+    /// <param name="padding">The implicit zero padding to be added on both sides.</param>
+    /// <param name="kernelSizes">The sizes of the window to take a max over.</param>
+    /// <param name="strides">The strides of the window. Default value is kernelSizes.</param>
+    /// <param name="paddings">The implicit zero paddings to be added on corresponding sides.</param>
+    /// <param name="outputSize">The targeted output size.</param>
     member a.maxunpool2d(indices:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?outputSize:seq<int>) =
         let kernelSizes =
             match kernelSize, kernelSizes with
@@ -2034,7 +2131,13 @@ type Tensor =
         let dfTensorRev(a) = MaxUnpool2DT(a, indices)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies a 3D max pooling over an input signal composed of several input planes, returning the max indices along with the outputs.</summary>
+    /// <param name="kernelSize">The size of the window to take a max over.</param>
+    /// <param name="stride">The stride of the window. Default value is kernelSize.</param>
+    /// <param name="padding">The implicit zero padding to be added on both sides.</param>
+    /// <param name="kernelSizes">The sizes of the window to take a max over.</param>
+    /// <param name="strides">The strides of the window. Default value is kernelSize.</param>
+    /// <param name="paddings">The implicit zero paddings to be added on corresponding sides.</param>
     member a.maxpool3di(?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) =
         let kernelSizes =
             match kernelSize, kernelSizes with
@@ -2060,10 +2163,24 @@ type Tensor =
         | TensorF(ap,ad,at)    -> let result, indices = ap.maxpool3di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorF(result, ad.flatten(startDim=2).gather(dim=2, indices=indices.flatten(startDim=2)).viewAs(indices), at), indices
         | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool3di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorR(result, ref (a.zeroLike()), MaxPool3DT(a, indices, kernelSizes), ref 0u, at), indices
 
-    /// <summary>TBD</summary>
+    /// <summary>Applies a 3D max pooling over an input signal composed of several input planes.</summary>
+    /// <param name="kernelSize">The size of the window to take a max over.</param>
+    /// <param name="stride">The stride of the window. Default value is kernelSize.</param>
+    /// <param name="padding">The implicit zero padding to be added on both sides.</param>
+    /// <param name="kernelSizes">The sizes of the window to take a max over.</param>
+    /// <param name="strides">The strides of the window. Default value is kernelSizes.</param>
+    /// <param name="paddings">The implicit zero paddings to be added on corresponding sides.</param>
     member a.maxpool3d(?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>) = a.maxpool3di(?kernelSize=kernelSize, ?stride=stride, ?padding=padding, ?kernelSizes=kernelSizes, ?strides=strides, ?paddings=paddings) |> fst
 
-    /// <summary>TBD</summary>
+    /// <summary>Computes a partial inverse of maxpool3di</summary>
+    /// <param name="indices">The indices selected by maxpool3di.</param>
+    /// <param name="kernelSize">The size of the window to take a max over.</param>
+    /// <param name="stride">The stride of the window. Default value is kernelSize.</param>
+    /// <param name="padding">The implicit zero padding to be added on both sides.</param>
+    /// <param name="kernelSizes">The sizes of the window to take a max over.</param>
+    /// <param name="strides">The strides of the window. Default value is kernelSizes.</param>
+    /// <param name="paddings">The implicit zero paddings to be added on corresponding sides.</param>
+    /// <param name="outputSize">The targeted output size.</param>
     member a.maxunpool3d(indices:Tensor, ?kernelSize:int, ?stride:int, ?padding:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?outputSize:seq<int>) =
         let kernelSizes =
             match kernelSize, kernelSizes with
@@ -2098,9 +2215,13 @@ type Tensor =
         let dfTensorRev(a) = MaxUnpool3DT(a, indices)
         Tensor.OpUnary(a, fRaw, fTensor, dfTensorFwd, dfTensorRev)
 
-    /// <summary>TBD</summary>
-    member a.conv1d(b:Tensor, ?stride:int, ?padding:int, ?dilation:int) =
-        // a: input, b: filter
+    /// <summary>Applies a 1D convolution over an input signal composed of several input planes</summary>
+    /// <param name="filters">The filters.</param>
+    /// <param name="stride">The stride of the convolving kernel.</param>
+    /// <param name="padding">The implicit paddings on both sides of the input.</param>
+    /// <param name="dilation">The spacing between kernel elements.</param>
+    member a.conv1d(filters:Tensor, ?stride:int, ?padding:int, ?dilation:int) =
+        let b = filters
         let stride = defaultArg stride 1
         let padding = defaultArg padding 0
         let dilation = defaultArg dilation 1
@@ -2165,14 +2286,20 @@ type Tensor =
                     bderivative <- bderivative.addSlice([|k; 0; 0|], bd)
         aderivative, bderivative
     
-    /// <summary>TBD</summary>
-    member a.convTranspose1d(b:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int) =
+    /// <summary>Applies a 1D transposed convolution operator over an input signal composed of several input planes, sometimes also called 'deconvolution'.</summary>
+    /// <param name="filters">The filters.</param>
+    /// <param name="stride">The stride of the convolving kernel.</param>
+    /// <param name="padding">The implicit padding on both sides of the input.</param>
+    /// <param name="dilation">The spacing between kernel elements.</param>
+    /// <param name="outputPadding">The additional size added to one side of each dimension in the output shape.</param>
+    member a.convTranspose1d(filters:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int) =
+        let b = filters
         let stride = defaultArg stride 1
         let padding = defaultArg padding 0
         let dilation = defaultArg dilation 1
         let outputPadding = defaultArg outputPadding 0
 
-        let batchSize, inputChannels, kernelLength, outputChannels, outputSize, outputShape =
+        let _, _, _, _, _, outputShape =
             Shape.checkCanConvTranspose1d a.deviceType b.deviceType a.dtype b.dtype a.shape b.shape stride padding dilation outputPadding
         print outputShape
         let mutable b = b
@@ -2184,8 +2311,16 @@ type Tensor =
         let (aderivative:Tensor), _ = Tensor.conv1dReverseDiff(a, b, cderivative, aConst=false, bConst=true, stride=stride, padding=padding)
         aderivative
 
-    /// <summary>TBD</summary>
-    member a.conv2d(b:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>) =
+    /// <summary>Applies a 2D convolution over an input signal composed of several input planes</summary>
+    /// <param name="filters">The filters.</param>
+    /// <param name="stride">The stride of the convolving kernel.</param>
+    /// <param name="padding">The implicit padding on corresponding sides of the input.</param>
+    /// <param name="dilation">The spacing between kernel elements.</param>
+    /// <param name="strides">The strides of the convolving kernel.</param>
+    /// <param name="paddings">The implicit paddings on corresponding sides of the input.</param>
+    /// <param name="dilations">The spacings between kernel elements.</param>
+    member a.conv2d(filters:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>) =
+        let b = filters
         let strides = 
             match stride, strides with
             | Some _, Some _ -> failwithf "Expecting only one of stride, strides"
@@ -2218,7 +2353,6 @@ type Tensor =
         let dfTensorRevCT(a,b) = Conv2DTConstT(a,b, strides, paddings)
         Tensor.OpBinary(a, b, fRaw, fTensor, dfTensorFwdTT, dfTensorFwdTC, dfTensorFwdCT, dfTensorRevTT, dfTensorRevTC, dfTensorRevCT)
 
-    /// <summary>TBD</summary>
     // a: input, NxCxHxW (batchSize x inputChannels x inputHeight x inputWidth)
     // b: filters, KxCxFxG (outputChannels x inputChannels x kernelHeight x kernelWidth)
     // t: output, NxKxLxM (batchSize x outputChannels x outputHeight x outputWidth)
@@ -2273,8 +2407,18 @@ type Tensor =
                     bderivative <- bderivative.addSlice([|k; 0; 0; 0|], bd)
         aderivative, bderivative
     
-    /// <summary>TBD</summary>
-    member a.convTranspose2d(b:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?outputPaddings:seq<int>) =
+    /// <summary>Applies a 2D transposed convolution operator over an input signal composed of several input planes, sometimes also called 'deconvolution'.</summary>
+    /// <param name="filters">The filters.</param>
+    /// <param name="stride">The stride of the convolving kernel.</param>
+    /// <param name="padding">The implicit padding on both sides of the input.</param>
+    /// <param name="dilation">The spacing between kernel elements.</param>
+    /// <param name="strides">The strides of the convolving kernel.</param>
+    /// <param name="paddings">The implicit paddings on corresponding sides of the input.</param>
+    /// <param name="dilations">The spacings between kernel elements.</param>
+    /// <param name="outputPadding">The additional size added to one side of each dimension in the output shape.</param>
+    /// <param name="outputPaddings">The additional sizes added to one side of each dimension in the output shape.</param>
+    member a.convTranspose2d(filters:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?outputPaddings:seq<int>) =
+        let b = filters
         let strides = 
             match stride, strides with
             | Some _, Some _ -> failwithf "Expecting only one of stride, strides"
@@ -2300,7 +2444,7 @@ type Tensor =
             | None, Some p -> let p = p |> Array.ofSeq in if p.Length <> 2 then failwithf "Expecting outputPaddings to be 2-dimensional" else p
             | _ -> [|0; 0|]
 
-        let batchSize, inputChannels, (kernelHeight, kernelWidth), (outputChannels, outputHeight, outputWidth), outputShape =
+        let _, _, _, _, outputShape =
             Shape.checkCanConvTranspose2d a.deviceType b.deviceType a.dtype b.dtype a.shape b.shape strides paddings dilations outputPaddings
         print outputShape
         let mutable b = b
@@ -2312,8 +2456,16 @@ type Tensor =
         let (aderivative:Tensor), _ = Tensor.conv2dReverseDiff(a, b, cderivative, aConst=false, bConst=true, strides=strides, paddings=paddings)
         aderivative
 
-    /// <summary>TBD</summary>
-    member a.conv3d(b:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>) =
+    /// <summary>Applies a 3D convolution over an input signal composed of several input planes</summary>
+    /// <param name="filters">The filters.</param>
+    /// <param name="stride">The stride of the convolving kernel.</param>
+    /// <param name="padding">The implicit padding on corresponding sides of the input.</param>
+    /// <param name="dilation">The spacing between kernel elements.</param>
+    /// <param name="strides">The strides of the convolving kernel.</param>
+    /// <param name="paddings">The implicit paddings on corresponding sides of the input.</param>
+    /// <param name="dilations">The spacings between kernel elements.</param>
+    member a.conv3d(filters:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>) =
+        let b = filters
         let strides = 
             match stride, strides with
             | Some _ , Some _ -> failwithf "Expecting only one of stride, strides"
@@ -2346,7 +2498,6 @@ type Tensor =
         let dfTensorRevCT(a,b) = Conv3DTConstT(a,b, strides, paddings)
         Tensor.OpBinary(a, b, fRaw, fTensor, dfTensorFwdTT, dfTensorFwdTC, dfTensorFwdCT, dfTensorRevTT, dfTensorRevTC, dfTensorRevCT)
 
-    /// <summary>TBD</summary>
     // a: input, NxCxDxHxW (batchSize x inputChannels x inputDepth x inputHeight x inputWidth)
     // b: filters, KxCxExFxG (outputChannels x inputChannels x kernelDepth x kernelHeight x kernelWidth)
     // t: output, NxKxLxMxN (batchSize x outputChannels x outputDepth x outputHeight x outputWidth)
@@ -2405,8 +2556,18 @@ type Tensor =
                     bderivative <- bderivative.addSlice([|k; 0; 0; 0; 0|], bd)
         aderivative, bderivative
 
-    /// <summary>TBD</summary>
-    member a.convTranspose3d(b:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?outputPaddings:seq<int>) =
+    /// <summary>Applies a 3D transposed convolution operator over an input signal composed of several input planes, sometimes also called 'deconvolution'.</summary>
+    /// <param name="filters">The filters.</param>
+    /// <param name="stride">The stride of the convolving kernel.</param>
+    /// <param name="padding">The implicit padding on both sides of the input.</param>
+    /// <param name="dilation">The spacing between kernel elements.</param>
+    /// <param name="strides">The strides of the convolving kernel.</param>
+    /// <param name="paddings">The implicit paddings on corresponding sides of the input.</param>
+    /// <param name="dilations">The spacings between kernel elements.</param>
+    /// <param name="outputPadding">The additional size added to one side of each dimension in the output shape.</param>
+    /// <param name="outputPaddings">The additional sizes added to one side of each dimension in the output shape.</param>
+    member a.convTranspose3d(filters:Tensor, ?stride:int, ?padding:int, ?dilation:int, ?outputPadding:int, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?outputPaddings:seq<int>) =
+        let b = filters
         let strides = 
             match stride, strides with
             | Some _ , Some _ -> failwithf "Expecting only one of stride, strides"
@@ -2432,7 +2593,7 @@ type Tensor =
             | None, Some p -> let p = p |> Array.ofSeq in if p.Length <> 3 then failwithf "Expecting outputPaddings to be 3-dimensional" else p
             | _ -> [|0; 0; 0|]
 
-        let batchSize, inputChannels, (kernelDepth, kernelHeight, kernelWidth), (outputChannels, outputDepth, outputHeight, outputWidth), outputShape =
+        let _, _, _, _, outputShape =
             Shape.checkCanConvTranspose3d a.deviceType b.deviceType a.dtype b.dtype a.shape b.shape strides paddings dilations outputPaddings
         print outputShape
         let mutable b = b
@@ -2444,7 +2605,9 @@ type Tensor =
         let (aderivative:Tensor), _ = Tensor.conv3dReverseDiff(a, b, cderivative, aConst=false, bConst=true, strides=strides, paddings=paddings)
         aderivative
 
-    /// <summary>TBD</summary>
+    /// <summary>Compute the reverse-mode derivative at the given output tensor.</summary>
+    /// <param name="value">The value to apply.</param>
+    /// <param name="zeroDerivatives">Indicates whether the derivatives should be zeroed or not.</param>
     member t.reverse(?value:Tensor, ?zeroDerivatives:bool) =
         let value = defaultArg value (t.onesLike())
         let zeroDerivatives = defaultArg zeroDerivatives true
@@ -2452,10 +2615,10 @@ type Tensor =
         t.reverseReset(zeroDerivatives)
         t.reversePush(value)
 
-    /// <summary>TBD</summary>
+    /// <summary>See <c>reverse</c></summary>
     member inline t.backward(value) = t.reverse(value)
 
-    /// <summary>TBD</summary>
+    /// <summary>Reset the reverse mode computation associated with the given output tensor.</summary>
     member t.reverseReset(zeroDerivatives:bool) =
         let rec reset (ts: Tensor list) =
             match ts with
@@ -2573,7 +2736,8 @@ type Tensor =
                 | _ -> reset tt
         reset [t]
 
-    /// <summary>TBD</summary>
+    /// <summary>Push the given value as part of the reverse-mode computation at the given output tensor.</summary>
+    /// <param name="value">The value to apply.</param>
     member t.reversePush(value:Tensor) =
         let rec push (ts:(Tensor*Tensor) list) =
             match ts with


### PR DESCRIPTION

This copies across the docs from DiffSHarp.fs to the corresponding member notation functions in Tensor.fs

Also renames the `b` parameter of convolutions to `filters` which is, I believe, much clearer.  