### PR TITLE
docs for models and namespaces

### DIFF
--- a/src/DiffSharp.Core/Data.fs
+++ b/src/DiffSharp.Core/Data.fs
@@ -8,6 +8,11 @@ open System.Net
 open System.IO
 open System.IO.Compression
 
+/// <namespacedoc>
+///   <summary>Contains data sets and components related to data loading.</summary>
+/// </namespacedoc>
+///
+/// <summary>Represents a data set that can load images in batches.</summary>
 [<AbstractClass>]
 type Dataset() =
     abstract member length: int

--- a/src/DiffSharp.Core/Distributions.fs
+++ b/src/DiffSharp.Core/Distributions.fs
@@ -17,8 +17,12 @@ module internal Utils =
         elif logits.dim = 0 then logits.exp() else dsharp.softmax(logits, -1)
 
 
+/// <namespacedoc>
+///   <summary>Contains types and functionality related to probabilitity distributions.</summary>
+/// </namespacedoc>
+///
+/// <summary>Represents a distribution.</summary>
 [<AbstractClass>]
-/// <summary>TBD</summary>
 type Distribution<'T>() =
 
     /// <summary>TBD</summary>

--- a/src/DiffSharp.Core/Model.fs
+++ b/src/DiffSharp.Core/Model.fs
@@ -4,7 +4,12 @@ open DiffSharp.Util
 open System.Collections.Generic
 
 
-/// <summary>TBD</summary>
+/// <namespacedoc>
+///   <summary>Contains types and functionality related to describing models.</summary>
+/// </namespacedoc>
+///
+/// <summary>Represents a parameter in a model.</summary>
+/// <remarks>A parameter is a mutable register holding a tensor.</remarks>
 type Parameter =
     val mutable value:Tensor
     new(value) = {value=value}
@@ -25,7 +30,7 @@ type Parameter =
     override p.ToString() = sprintf "Parameter(shape:%A, value:%A)" p.value.shape p.value
 
 
-/// <summary>TBD</summary>
+/// <summary>Represents a collection of named parameters in a model.</summary>
 type ParameterDict() =
 
     /// <summary>TBD</summary>
@@ -127,13 +132,13 @@ type ParameterDict() =
         sb.ToString()
 
 
-/// <summary>TBD</summary>
+/// <summary>Indicates the training or evaluation mode for a model.</summary>
 type Mode =
     | Train = 0
     | Eval = 1
 
+/// <summary>Represents a model, primarily a collection of named parameters and sub-models and a function governed by them.</summary>
 [<AbstractClass>]
-/// <summary>TBD</summary>
 type Model() =
     [<DefaultValue>]
     val mutable mode: Mode
@@ -262,8 +267,8 @@ type Model() =
         m.save(fileName)
         Model.load(fileName)
 
-/// <summary>TBD</summary>
-type Weight() =
+/// <summary>Contains functionality related to generating initial paramerter weights.</summary>
+type Weight =
 
     /// <summary>TBD</summary>
     static member kaiming(fanIn, fanOut, ?a:float) = 
@@ -278,7 +283,7 @@ type Weight() =
         -k + dsharp.rand(shape) * 2*k
 
 
-/// <summary>TBD</summary>
+/// <summary>A model that applies a linear transformation to the incoming data: \(y = xA^T + b\)</summary>
 type Linear(inFeatures, outFeatures, ?bias:bool) =
     inherit Model()
     let bias = defaultArg bias true
@@ -296,7 +301,7 @@ type Linear(inFeatures, outFeatures, ?bias:bool) =
         if bias then f + b.value else f
 
 
-/// <summary>TBD</summary>
+/// <summary>A model that applies a 1D convolution over an input signal composed of several input planes</summary>
 type Conv1d(inChannels:int, outChannels:int, kernelSize:int, ?stride:int, ?padding:int, ?dilation:int, ?bias:bool) =
     inherit Model()
     let bias = defaultArg bias true
@@ -314,7 +319,7 @@ type Conv1d(inChannels:int, outChannels:int, kernelSize:int, ?stride:int, ?paddi
         if bias then f + b.value.expand([value.shape.[0]; outChannels]).view([value.shape.[0]; outChannels; 1]) else f
 
 
-/// <summary>TBD</summary>
+/// <summary>A model that applies a 2D convolution over an input signal composed of several input planes</summary>
 type Conv2d(inChannels:int, outChannels:int, ?kernelSize:int, ?stride:int, ?padding:int, ?dilation:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?bias:bool) =
     inherit Model()
     let kernelSizes = 
@@ -338,7 +343,7 @@ type Conv2d(inChannels:int, outChannels:int, ?kernelSize:int, ?stride:int, ?padd
         if bias then f + b.value.expand([value.shape.[0]; outChannels]).view([value.shape.[0]; outChannels; 1; 1]) else f
 
 
-/// <summary>TBD</summary>
+/// <summary>A model that applies a 3D convolution over an input signal composed of several input planes</summary>
 type Conv3d(inChannels:int, outChannels:int, ?kernelSize:int, ?stride:int, ?padding:int, ?dilation:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?bias:bool) =
     inherit Model()
     let kernelSizes = 
@@ -362,7 +367,7 @@ type Conv3d(inChannels:int, outChannels:int, ?kernelSize:int, ?stride:int, ?padd
         if bias then f + b.value.expand([value.shape.[0]; outChannels]).view([value.shape.[0]; outChannels; 1; 1; 1]) else f
 
 
-/// <summary>TBD</summary>
+/// <summary>A model that applies a 1D transposed convolution operator over an input image composed of several input planes.</summary>
 type ConvTranspose1d(inChannels:int, outChannels:int, kernelSize:int, ?stride:int, ?padding:int, ?dilation:int, ?bias:bool) =
     inherit Model()
     let bias = defaultArg bias true
@@ -380,7 +385,7 @@ type ConvTranspose1d(inChannels:int, outChannels:int, kernelSize:int, ?stride:in
         if bias then f + b.value.expand([value.shape.[0]; outChannels]).view([value.shape.[0]; outChannels; 1]) else f
 
 
-/// <summary>TBD</summary>
+/// <summary>A model that applies a 2D transposed convolution operator over an input image composed of several input planes.</summary>
 type ConvTranspose2d(inChannels:int, outChannels:int, ?kernelSize:int, ?stride:int, ?padding:int, ?dilation:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?bias:bool) =
     inherit Model()
     let kernelSizes = 
@@ -404,7 +409,7 @@ type ConvTranspose2d(inChannels:int, outChannels:int, ?kernelSize:int, ?stride:i
         if bias then f + b.value.expand([value.shape.[0]; outChannels]).view([value.shape.[0]; outChannels; 1; 1]) else f
 
 
-/// <summary>TBD</summary>
+/// <summary>A model that applies a 3D transposed convolution operator over an input image composed of several input planes.</summary>
 type ConvTranspose3d(inChannels:int, outChannels:int, ?kernelSize:int, ?stride:int, ?padding:int, ?dilation:int, ?kernelSizes:seq<int>, ?strides:seq<int>, ?paddings:seq<int>, ?dilations:seq<int>, ?bias:bool) =
     inherit Model()
     let kernelSizes = 
@@ -428,7 +433,7 @@ type ConvTranspose3d(inChannels:int, outChannels:int, ?kernelSize:int, ?stride:i
         if bias then f + b.value.expand([value.shape.[0]; outChannels]).view([value.shape.[0]; outChannels; 1; 1; 1]) else f
 
 
-/// <summary>TBD</summary>
+/// <summary>A model which during training, randomly zeroes some of the elements of the input tensor with probability p using samples from a Bernoulli distribution. Each channel will be zeroed out independently on every forward call.</summary>
 type Dropout(?p:double) =
     inherit Model()
 
@@ -440,7 +445,7 @@ type Dropout(?p:double) =
         if m.mode = Mode.Train then value.dropout(?p=p) else value
 
 
-/// <summary>TBD</summary>
+/// <summary>A model which during training, randomly zero out entire channels. Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.</summary>
 type Dropout2d(?p:double) =
     inherit Model()
 
@@ -452,7 +457,7 @@ type Dropout2d(?p:double) =
         if m.mode = Mode.Train then value.dropout2d(?p=p) else value
 
 
-/// <summary>TBD</summary>
+/// <summary>A model which during training, randomly zero out entire channels. Each channel will be zeroed out independently on every forward call with probability p using samples from a Bernoulli distribution.</summary>
 type Dropout3d(?p:double) =
     inherit Model()
 
@@ -464,7 +469,25 @@ type Dropout3d(?p:double) =
         if m.mode = Mode.Train then value.dropout3d(?p=p) else value
 
 
-/// <summary>TBD</summary>
+/// <summary>Applies Batch Normalization over a 2D or 3D input (a mini-batch of 1D inputs with optional additional channel dimension)</summary>
+/// <remarks>
+///    <para>
+///        The mean and standard-deviation are calculated per-dimension over the mini-batches and
+///        \(\gamma\( and \(\beta\) are learnable parameter vectors of size \(C\) (where \(C\) is the
+///        input size). By default, the elements of \(\gamma\) are set to 1 and the elements of 
+///        \(\beta\) are set to 0. The standard-deviation is calculated via the biased estimator,
+///        equivalent to <c>dsharp.variance(input, unbiased=False)</c>.
+///    </para>
+///    <para>
+///        Also by default, during training this layer keeps running estimates of its computed mean
+///        and variance, which are then used for normalization during evaluation. The running estimates
+///        are kept with a default momentum of 0.1.
+///    </para>
+///    <para>
+///       If trackRunningStats is set to False, this layer then does not keep running estimates,
+///       and batch statistics are instead used during evaluation time as well.
+///    </para>
+/// </remarks>
 type BatchNorm1d(numFeatures:int, ?eps:double, ?momentum:Tensor, ?affine:bool, ?trackRunningStats:bool, ?reversible:bool) =
     inherit Model()
     let eps = defaultArg eps 1e-5
@@ -537,7 +560,25 @@ type BatchNorm1d(numFeatures:int, ?eps:double, ?momentum:Tensor, ?affine:bool, ?
         else failwithf "Expecting value to have shape NxL (batchSize x Length) or NxCxL (batchSize x numChannels x Length), received value with shape %A" value.shape
 
 
-/// <summary>TBD</summary>
+/// <summary>Applies Batch Normalization over a 4D input (a mini-batch of 2D inputs with optional additional channel dimension)</summary>
+/// <remarks>
+///    <para>
+///        The mean and standard-deviation are calculated per-dimension over the mini-batches and
+///        \(\gamma\( and \(\beta\) are learnable parameter vectors of size \(C\) (where \(C\) is the
+///        input size). By default, the elements of \(\gamma\) are set to 1 and the elements of 
+///        \(\beta\) are set to 0. The standard-deviation is calculated via the biased estimator,
+///        equivalent to <c>dsharp.variance(input, unbiased=False)</c>.
+///    </para>
+///    <para>
+///        Also by default, during training this layer keeps running estimates of its computed mean
+///        and variance, which are then used for normalization during evaluation. The running estimates
+///        are kept with a default momentum of 0.1.
+///    </para>
+///    <para>
+///       If trackRunningStats is set to False, this layer then does not keep running estimates,
+///       and batch statistics are instead used during evaluation time as well.
+///    </para>
+/// </remarks>
 type BatchNorm2d(numFeatures:int, ?eps:double, ?momentum:Tensor, ?affine:bool, ?trackRunningStats:bool, ?reversible:bool) =
     inherit Model()
     let eps = defaultArg eps 1e-5
@@ -596,7 +637,25 @@ type BatchNorm2d(numFeatures:int, ?eps:double, ?momentum:Tensor, ?affine:bool, ?
         if affine then res * w.value.view([1;numFeatures;1;1]) + b.value.view([1;numFeatures;1;1]) else res
 
 
-/// <summary>TBD</summary>
+/// <summary>Applies Batch Normalization over a 5D input (a mini-batch of 3D inputs with optional additional channel dimension)</summary>
+/// <remarks>
+///    <para>
+///        The mean and standard-deviation are calculated per-dimension over the mini-batches and
+///        \(\gamma\( and \(\beta\) are learnable parameter vectors of size \(C\) (where \(C\) is the
+///        input size). By default, the elements of \(\gamma\) are set to 1 and the elements of 
+///        \(\beta\) are set to 0. The standard-deviation is calculated via the biased estimator,
+///        equivalent to <c>dsharp.variance(input, unbiased=False)</c>.
+///    </para>
+///    <para>
+///        Also by default, during training this layer keeps running estimates of its computed mean
+///        and variance, which are then used for normalization during evaluation. The running estimates
+///        are kept with a default momentum of 0.1.
+///    </para>
+///    <para>
+///       If trackRunningStats is set to False, this layer then does not keep running estimates,
+///       and batch statistics are instead used during evaluation time as well.
+///    </para>
+/// </remarks>
 type BatchNorm3d(numFeatures:int, ?eps:double, ?momentum:Tensor, ?affine:bool, ?trackRunningStats:bool, ?reversible:bool) =
     inherit Model()
     let eps = defaultArg eps 1e-5

--- a/src/DiffSharp.Core/Optim.fs
+++ b/src/DiffSharp.Core/Optim.fs
@@ -6,8 +6,12 @@ open DiffSharp.Data
 open DiffSharp.Util
 
 
+/// <namespacedoc>
+///   <summary>Contains types and functionality related to optimizing tensor models and functions.</summary>
+/// </namespacedoc>
+///
+/// <summary>Represents an optimizer.</summary>
 [<AbstractClass>]
-/// <summary>TBD</summary>
 type Optimizer(model:Model) =
 
     /// <summary>TBD</summary>


### PR DESCRIPTION

Adds docs for the remaining namespaces and some docs on the Model types

@gbaydin please review - the docs are taken from PyTorch as before.  We could also jsut use links across to the PyTorch docs instead of have the repeated `<remarks>` sections, let me know what you'd like.
