### PR TITLE
improve tensor printing

### DIFF
--- a/src/DiffSharp.Core/Backend.fs
+++ b/src/DiffSharp.Core/Backend.fs
@@ -23,6 +23,8 @@ type Backend =
         | Torch -> "Torch"
         | Other (name, _) -> name
 
+    override x.ToString() = x.Name
+
 /// Contains functions and settings related to backend specifications.
 module Backend = 
     let internal count = ref 0

--- a/src/DiffSharp.Core/Device.fs
+++ b/src/DiffSharp.Core/Device.fs
@@ -48,6 +48,8 @@ type Device =
         | DeviceType.XLA -> "xla"
         | _ -> failwith "unknown device type") + string x.DeviceIndex
 
+    override x.ToString() = x.Name
+
 /// Contains functions and settings related to device specifications.
 module Device = 
 

--- a/src/DiffSharp.Core/Dtype.fs
+++ b/src/DiffSharp.Core/Dtype.fs
@@ -39,6 +39,8 @@ type Dtype =
         | Bool | Byte | Int8 | Int16 | Int32 | Int64 -> Dtype.Int64
         | dt -> dt
 
+    override x.ToString() = x.Name
+
 /// Contains functions and settings related to tensor element types
 module Dtype =
     /// Matches all floating point tensor element types

--- a/src/DiffSharp.Core/RawTensor.fs
+++ b/src/DiffSharp.Core/RawTensor.fs
@@ -104,7 +104,7 @@ type RawTensor() =
     /// backend is used this will be the corresponding TorchSharp TorchTensor.
     abstract member Handle : obj
 
-    override t.ToString() = t.GetString()
+    override t.ToString() = t.GetString("")
     
     /// Gets a tensor containing arbitrary values for the given shape and configuration
     static member Empty(shape:Shape, ?dtype, ?device, ?backend) = 
@@ -286,7 +286,7 @@ type RawTensor() =
     abstract member SplitT: sizes: int[] * dim: int -> RawTensor[]
 
     /// Get a textual representation of the tensors
-    abstract member GetString: unit -> string
+    abstract member GetString: extra: string -> string
     
     /// <summary> Get a slice of the given tensor.</summary>
     ///
@@ -543,7 +543,7 @@ type RawTensor() =
         | Dtype.IntegralOrBool -> t.FullLike(t.Shape, false, dtype=Dtype.Bool)
         | _ -> t.NeqTT(t)
 
-    default t.GetString() =
+    default t.GetString(extra: string) =
         // sprintf "RawTensor(Value=%A, Shape=%A, Dim=%A, Length=%A)" t.Value t.Shape t.Dim t.Length
         let printVal (x:obj) = 
            match x with 
@@ -557,10 +557,12 @@ type RawTensor() =
            | :? bool as v -> if v then "true" else "false"
            | _ -> sprintf "%A" x
 
+        let sb = System.Text.StringBuilder()
+        sb.Append("tensor(") |> ignore
         match t.Dim with
-        | 0 -> printVal (t.ToScalar())
+        | 0 -> 
+            sb.Append(printVal (t.ToScalar())) |> ignore
         | _ ->
-            let sb = System.Text.StringBuilder()
             let rec print (shape:Shape) externalCoords = 
                 if shape.Length = 1 then
                     sb.Append("[") |> ignore
@@ -574,14 +576,25 @@ type RawTensor() =
                 else
                     sb.Append("[") |> ignore
                     let mutable prefix = ""
-                    let prefix2 = sprintf ", %s%s" (String.replicate (max 1 (shape.Length-1)) "\n") (String.replicate (externalCoords.Length+1) " ")
+                    let prefix2 = sprintf ",%s%s" (String.replicate (max 1 (shape.Length-1)) "\n       ") (String.replicate (externalCoords.Length+1) " ")
                     for i=0 to shape.[0]-1 do
                         sb.Append(prefix) |> ignore
                         print shape.[1..] (Array.append externalCoords [|i|])
                         prefix <- prefix2
                     sb.Append("]") |> ignore
             print t.Shape [||]
-            sb.ToString()
+        if t.Dtype <> Dtype.Default then
+            sb.Append ",dtype=" |> ignore
+            sb.Append (t.Dtype.ToString()) |> ignore
+        if t.Device <> Device.Default then
+            sb.Append ",device=" |> ignore
+            sb.Append (t.Device.ToString()) |> ignore
+        if t.Backend <> Backend.Default then
+            sb.Append ",backend=" |> ignore
+            sb.Append (t.Backend.ToString()) |> ignore
+        sb.Append(extra) |> ignore
+        sb.Append(")") |> ignore
+        sb.ToString()
 
     override x.Equals(yobj: obj) = 
         match yobj with

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -353,6 +353,14 @@ type Tensor =
         let ps = parents t 1
         p |> List.rev, ps
 
+    override t.ToString() = 
+        let rec fmt extra (t: Tensor) =
+            match t with
+            | Tensor(p) -> p.GetString(extra)
+            | TensorF(tp,_,_) -> fmt (extra + ", fwd") tp
+            | TensorR(tp,_,_,_,_) -> fmt (extra + ", rev") tp
+        fmt "" t
+
     override t.Equals(other) =
         match other with
         | :? Tensor as tensor -> t.primalRaw.Equals(tensor.primalRaw)

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -777,11 +777,28 @@ type TestTensor () =
                 | Int64 -> ""
                 | Float32 -> ".000000"
                 | Float64 -> ".000000"
-            let t0StringCorrect = sprintf "Tensor 2%s" suffix
-            let t1StringCorrect = sprintf "Tensor [[2%s], \n [2%s]]" suffix suffix
-            let t2StringCorrect = sprintf "Tensor [[[2%s, 2%s]]]" suffix suffix
-            let t3StringCorrect = sprintf "Tensor [[1%s, 2%s], \n [3%s, 4%s]]" suffix suffix suffix suffix
-            let t4StringCorrect = sprintf "Tensor [[[[1%s]]]]" suffix
+            let dtypeText = 
+                if combo.dtype = Dtype.Default then
+                    ""
+                else
+                    sprintf ",dtype=%s" (combo.dtype.ToString())
+            let deviceText = 
+                if combo.device = Device.Default then
+                    ""
+                else
+                    sprintf ",device=%s" (combo.device.ToString())
+            let backendText = 
+                if combo.backend = Backend.Default then
+                    ""
+                else
+                    sprintf ",backend=%s" (combo.backend.ToString())
+
+            let extraText = dtypeText + deviceText + backendText
+            let t0StringCorrect = sprintf "tensor(2%s%s)" suffix extraText
+            let t1StringCorrect = sprintf "tensor([[2%s],\n        [2%s]]%s)" suffix suffix extraText
+            let t2StringCorrect = sprintf "tensor([[[2%s, 2%s]]]%s)" suffix suffix extraText
+            let t3StringCorrect = sprintf "tensor([[1%s, 2%s],\n        [3%s, 4%s]]%s)" suffix suffix suffix suffix extraText
+            let t4StringCorrect = sprintf "tensor([[[[1%s]]]]%s)" suffix extraText
             Assert.CheckEqual(t0StringCorrect, t0String)
             Assert.CheckEqual(t1StringCorrect, t1String)
             Assert.CheckEqual(t2StringCorrect, t2String)
@@ -790,12 +807,12 @@ type TestTensor () =
 
         let t0Bool = dsharp.tensor([ 0.5; 1.0 ], dtype=Dtype.Bool)
         let t0BoolToString = t0Bool.ToString()
-        let t0BoolToStringCorrect = sprintf "Tensor [false, true]" 
+        let t0BoolToStringCorrect = sprintf "tensor([false, true],dtype=Bool)" 
         Assert.CheckEqual(t0BoolToString, t0BoolToStringCorrect)
 
         let t1Bool = dsharp.tensor([ false; true ], dtype=Dtype.Bool)
         let t1BoolToString = t1Bool.ToString()
-        let t1BoolToStringCorrect = sprintf "Tensor [false, true]" 
+        let t1BoolToStringCorrect = sprintf "tensor([false, true],dtype=Bool)" 
         Assert.CheckEqual(t1BoolToString, t1BoolToStringCorrect)
 
     [<Test>]


### PR DESCRIPTION

Show tensors as

    tensor([[.... data ]],dtype=Float32,device=cuda:2,backend=Torch)

suppressing the extra information if the values are the current system defaults