### PR TITLE
update to latest TorchSharp

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
 
     <LibTorchNugetVersion>1.7.0.1</LibTorchNugetVersion>
-    <TorchSharpVersion>0.3.52345</TorchSharpVersion>
+    <TorchSharpVersion>0.3.52348</TorchSharpVersion>
     <FSharpCoreVersion>5.0.0</FSharpCoreVersion>
     <!-- Standard nuget.org location -->
     <RestoreSources>https://api.nuget.org/v3/index.json</RestoreSources>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,8 @@
   <PropertyGroup>
 
     <LibTorchNugetVersion>1.7.0.1</LibTorchNugetVersion>
-    <TorchSharpVersion>0.3.52338</TorchSharpVersion>
-    <FSharpCoreVersion>4.7.2</FSharpCoreVersion>
+    <TorchSharpVersion>0.3.52345</TorchSharpVersion>
+    <FSharpCoreVersion>5.0.0</FSharpCoreVersion>
     <!-- Standard nuget.org location -->
     <RestoreSources>https://api.nuget.org/v3/index.json</RestoreSources>
     <DIFFSHARP_TESTGPU Condition="'$(COMPUTERNAME)' == 'MSRC-3617253'">true</DIFFSHARP_TESTGPU>


### PR DESCRIPTION

The latest TorchSharp adds a host of functionality, this brings DiffSharp to the latest version

Some signatures of AvgPool were incorrect in TorchSharp, these are being updated here https://github.com/xamarin/TorchSharp/pull/187


