### PR TITLE
bump .NET SDK version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,10 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:
+        dotnet-version: 3.1.301
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
         dotnet-version: 5.0.100
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.100
     - name: Install dependencies
       run: dotnet restore
     - name: Install tool dependencies

--- a/.github/workflows/pull-request-debug.yml
+++ b/.github/workflows/pull-request-debug.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.100
     - name: Install dependencies
       run: dotnet restore
     - name: Install tool dependencies

--- a/.github/workflows/pull-request-debug.yml
+++ b/.github/workflows/pull-request-debug.yml
@@ -15,6 +15,10 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:
+        dotnet-version: 3.1.301
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
         dotnet-version: 5.0.100
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/pull-request-debug.yml
+++ b/.github/workflows/pull-request-debug.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install tool dependencies
       run: dotnet tool restore
     - name: Build
-      run: dotnet build --configuration Debug --no-restore
+      run: dotnet build --configuration Debug --no-restore --verbosity normal
     - name: Test
       run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover --configuration Debug --no-restore --verbosity normal
     - name: Codecov

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.100
     - name: Install dependencies
       run: dotnet restore
     - name: Install tool dependencies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install tool dependencies
       run: dotnet tool restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore --verbosity normal
     - name: Test
       run: dotnet test --configuration Release --no-restore --verbosity normal
     - name: Run fsdocs

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,6 +15,10 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:
+        dotnet-version: 3.1.301
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
         dotnet-version: 5.0.100
     - name: Install dependencies
       run: dotnet restore


### PR DESCRIPTION
Bump so we can use F# 5.0 features (.NET 5.0 SDK is now requried)

Looks like we also requires a .NET 3.1 SDK to actually run tests