### PR TITLE
[WIP] feature/activations

### DIFF
--- a/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
+++ b/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
@@ -349,6 +349,13 @@ type RawTensorCPU<'T when 'T : equality and 'T :> scalar>(values: 'T[], shape: S
     override t.RoundInPlace() = t.SetValues <| t.RoundT()
     override t.AbsInPlace() = t.SetValues <| t.AbsT()
     override t.ReluInPlace() = t.SetValues <| t.ReluT()
+    override t.LeakyReluInPlace(negativeSlope) = t.SetValues <| t.LeakyReluT(negativeSlope)
+    override t.EluInPlace(alpha, scale, inputScale) = t.SetValues <| t.EluT(alpha, scale, inputScale)
+    override t.GeluInPlace() = t.SetValues <| t.GeluT()
+    override t.HardsigmoidInPlace() = t.SetValues <| t.HardsigmoidT()
+    override t.HardswishInPlace() = t.SetValues <| t.HardswishT()
+    override t.Relu6InPlace() = t.SetValues <| t.Relu6T()
+    override t.SiluInPlace() = t.SetValues <| t.SiluT()
     override t.SoftplusInPlace() = t.SetValues <| t.SoftplusT()
     override t.SigmoidInPlace() = t.SetValues <| t.SigmoidT()
     override t.ExpInPlace() = t.SetValues <| t.ExpT()
@@ -845,6 +852,44 @@ module internal RawTensorCPU =
         let result = t.Values |> Array.map (max zero< ^T >) 
         (result, t.Shape)
 
+    let inline LeakyReluT fromDouble (t: RawTensorCPU< ^T >, negativeSlope: double) : (^T[] * Shape) =
+        let result = t.Values |> Array.map (fun x -> if x < zero< ^T > then fromDouble (negativeSlope * double x) else x) 
+        (result, t.Shape)
+
+    let inline EluT(t: RawTensorCPU< ^T >, alpha: double, scale: double, inputScale: double) : (^T[] * Shape) =
+        failwith "tbd"
+        //let result = t.Values |> Array.map (max zero< ^T >) 
+        //(result, t.Shape)
+
+    // Taken from https://mlfromscratch.com/activation-functions-explained/#/
+    let inline GeluT ofDouble (t: RawTensorCPU< ^T >) : (^T[] * Shape) =
+        let result =
+            t.Values |> Array.map (fun x -> 
+                let x = double x
+                let res = 0.5 * x * (1.0 + tanh(0.7978845608 * (x+0.044715*x*x*x)))
+                ofDouble res)
+        (result, t.Shape)
+
+    let inline HardsigmoidT(t: RawTensorCPU< ^T >) : (^T[] * Shape) =
+        failwith "tbd"
+        //let result = t.Values |> Array.map (max zero< ^T >) 
+        //(result, t.Shape)
+
+    let inline HardswishT(t: RawTensorCPU< ^T >) : (^T[] * Shape) =
+        failwith "tbd"
+        //let result = t.Values |> Array.map (max zero< ^T >) 
+        //(result, t.Shape)
+
+    let inline Relu6T(t: RawTensorCPU< ^T >) : (^T[] * Shape) =
+        failwith "tbd"
+        //let result = t.Values |> Array.map (max zero< ^T >) 
+        //(result, t.Shape)
+
+    let inline SiluT(t: RawTensorCPU< ^T >) : (^T[] * Shape) =
+        failwith "tbd"
+        //let result = t.Values |> Array.map (max zero< ^T >) 
+        //(result, t.Shape)
+
     let inline SoftplusT(t: RawTensorCPU< ^T >) : (^T[] * Shape) =
         let result = t.Values |> Array.map (fun x -> (max zero< ^T > x) + log(one< ^T > + exp(-abs(x))))
         (result, t.Shape)
@@ -980,6 +1025,13 @@ type RawTensorFloat32(values: float32[], shape:Shape, device) =
     override t.RoundT() = RawTensorCPU.RoundT(t) |> create
     override t.AbsT() = RawTensorCPU.AbsT abs t |> create
     override t.ReluT() = RawTensorCPU.ReluT(t) |> create
+    override t.LeakyReluT(negativeSlope) = RawTensorCPU.LeakyReluT float32 (t, negativeSlope) |> create
+    override t.EluT(alpha, scale, inputScale) = RawTensorCPU.EluT(t, alpha, scale, inputScale) |> create
+    override t.GeluT() = RawTensorCPU.GeluT float32 (t) |> create
+    override t.HardsigmoidT() = RawTensorCPU.HardsigmoidT(t) |> create
+    override t.HardswishT() = RawTensorCPU.HardswishT(t) |> create
+    override t.Relu6T() = RawTensorCPU.Relu6T(t) |> create
+    override t.SiluT() = RawTensorCPU.SiluT(t) |> create
     override t.SigmoidT() = RawTensorCPU.SigmoidT(t) |> create
     override t.ExpT() = RawTensorCPU.ExpT(t) |> create
     override t.LogT() = RawTensorCPU.LogT(t) |> create
@@ -1070,6 +1122,13 @@ type RawTensorFloat64(values: double[], shape:Shape, device) =
     override t.RoundT() = RawTensorCPU.RoundT(t) |> create
     override t.AbsT() = RawTensorCPU.AbsT abs t |> create
     override t.ReluT() = RawTensorCPU.ReluT(t) |> create
+    override t.LeakyReluT(negativeSlope) = RawTensorCPU.LeakyReluT double (t, negativeSlope) |> create
+    override t.EluT(alpha, scale, inputScale) = RawTensorCPU.EluT(t, alpha, scale, inputScale) |> create
+    override t.GeluT() = RawTensorCPU.GeluT double (t) |> create
+    override t.HardsigmoidT() = RawTensorCPU.HardsigmoidT(t) |> create
+    override t.HardswishT() = RawTensorCPU.HardswishT(t) |> create
+    override t.Relu6T() = RawTensorCPU.Relu6T(t) |> create
+    override t.SiluT() = RawTensorCPU.SiluT(t) |> create
     override t.SigmoidT() = RawTensorCPU.SigmoidT(t) |> create
     override t.ExpT() = RawTensorCPU.ExpT(t) |> create
     override t.LogT() = RawTensorCPU.LogT(t) |> create
@@ -1149,6 +1208,13 @@ type RawTensorInt8(values: int8[], shape:Shape, device) =
     override t.SignT() = RawTensorCPU.SignT (sign >> int8) t |> create
     override t.AbsT() = RawTensorCPU.AbsT abs t |> create
     override t.ReluT() = RawTensorCPU.ReluT(t) |> create
+    override t.LeakyReluT(negativeSlope) = RawTensorCPU.LeakyReluT int8 (t, negativeSlope) |> create
+    override t.EluT(alpha, scale, inputScale) = RawTensorCPU.EluT(t, alpha, scale, inputScale) |> create
+    override t.GeluT() = RawTensorCPU.GeluT int8 (t) |> create
+    override t.HardsigmoidT() = RawTensorCPU.HardsigmoidT(t) |> create
+    override t.HardswishT() = RawTensorCPU.HardswishT(t) |> create
+    override t.Relu6T() = RawTensorCPU.Relu6T(t) |> create
+    override t.SiluT() = RawTensorCPU.SiluT(t) |> create
 
     override t.SoftplusT() = opNotSupported "SoftplusT" t.Dtype
     override t1.PowTT(t2) = opNotSupported2 "PowTT" t1.Dtype t2.Dtype
@@ -1236,6 +1302,13 @@ type RawTensorByte(values: byte[], shape:Shape, device) =
     override t.SignT() = RawTensorCPU.SignT (min 1uy) t |> create
     override t.AbsT() = RawTensorCPU.AbsT id t |> create
     override t.ReluT() = RawTensorCPU.ReluT(t) |> create
+    override t.LeakyReluT(negativeSlope) = RawTensorCPU.LeakyReluT byte (t, negativeSlope) |> create
+    override t.EluT(alpha, scale, inputScale) = RawTensorCPU.EluT(t, alpha, scale, inputScale) |> create
+    override t.GeluT() = RawTensorCPU.GeluT byte (t) |> create
+    override t.HardsigmoidT() = RawTensorCPU.HardsigmoidT(t) |> create
+    override t.HardswishT() = RawTensorCPU.HardswishT(t) |> create
+    override t.Relu6T() = RawTensorCPU.Relu6T(t) |> create
+    override t.SiluT() = RawTensorCPU.SiluT(t) |> create
 
     override t.SoftplusT() = opNotSupported "SoftplusT" t.Dtype
     override t1.PowTT(t2) = opNotSupported2 "PowTT" t1.Dtype t2.Dtype
@@ -1323,6 +1396,13 @@ type RawTensorInt16(values: int16[], shape:Shape, device) =
     override t.SignT() = RawTensorCPU.SignT (sign >> int16) t |> create
     override t.AbsT() = RawTensorCPU.AbsT abs t |> create
     override t.ReluT() = RawTensorCPU.ReluT(t) |> create
+    override t.LeakyReluT(negativeSlope) = RawTensorCPU.LeakyReluT int16 (t, negativeSlope) |> create
+    override t.EluT(alpha, scale, inputScale) = RawTensorCPU.EluT(t, alpha, scale, inputScale) |> create
+    override t.GeluT() = RawTensorCPU.GeluT int16 (t) |> create
+    override t.HardsigmoidT() = RawTensorCPU.HardsigmoidT(t) |> create
+    override t.HardswishT() = RawTensorCPU.HardswishT(t) |> create
+    override t.Relu6T() = RawTensorCPU.Relu6T(t) |> create
+    override t.SiluT() = RawTensorCPU.SiluT(t) |> create
 
     override t.SoftplusT() = opNotSupported "SoftplusT" t.Dtype
     override t1.PowTT(t2) = opNotSupported2 "PowTT" t1.Dtype t2.Dtype
@@ -1410,6 +1490,13 @@ type RawTensorInt32(values: int32[], shape:Shape, device) =
     override t.SignT() = RawTensorCPU.SignT (sign >> int32) t |> create
     override t.AbsT() = RawTensorCPU.AbsT abs t |> create
     override t.ReluT() = RawTensorCPU.ReluT(t) |> create
+    override t.LeakyReluT(negativeSlope) = RawTensorCPU.LeakyReluT int32 (t, negativeSlope) |> create
+    override t.EluT(alpha, scale, inputScale) = RawTensorCPU.EluT(t, alpha, scale, inputScale) |> create
+    override t.GeluT() = RawTensorCPU.GeluT int32 (t) |> create
+    override t.HardsigmoidT() = RawTensorCPU.HardsigmoidT(t) |> create
+    override t.HardswishT() = RawTensorCPU.HardswishT(t) |> create
+    override t.Relu6T() = RawTensorCPU.Relu6T(t) |> create
+    override t.SiluT() = RawTensorCPU.SiluT(t) |> create
 
     override t.SoftplusT() = opNotSupported "SoftplusT" t.Dtype
     override t1.PowTT(t2) = opNotSupported2 "PowTT" t1.Dtype t2.Dtype
@@ -1501,6 +1588,13 @@ type RawTensorInt64(values: int64[], shape:Shape, device) =
     override t.SignT() = RawTensorCPU.SignT (sign >> int64) t |> create
     override t.AbsT() = RawTensorCPU.AbsT abs t |> create
     override t.ReluT() = RawTensorCPU.ReluT(t) |> create
+    override t.LeakyReluT(negativeSlope) = RawTensorCPU.LeakyReluT int64 (t, negativeSlope) |> create
+    override t.EluT(alpha, scale, inputScale) = RawTensorCPU.EluT(t, alpha, scale, inputScale) |> create
+    override t.GeluT() = RawTensorCPU.GeluT int64 (t) |> create
+    override t.HardsigmoidT() = RawTensorCPU.HardsigmoidT(t) |> create
+    override t.HardswishT() = RawTensorCPU.HardswishT(t) |> create
+    override t.Relu6T() = RawTensorCPU.Relu6T(t) |> create
+    override t.SiluT() = RawTensorCPU.SiluT(t) |> create
 
     override t.SoftplusT() = opNotSupported "SoftplusT" t.Dtype
     override t1.PowTT(t2) = opNotSupported2 "PowTT" t1.Dtype t2.Dtype
@@ -1592,6 +1686,7 @@ type RawTensorBool(values: bool[], shape:Shape, device) =
     override t.NegT() = opNotSupported "NegT" t.Dtype
     override t.AbsT() = opNotSupported "AbsT" t.Dtype
     override t.ReluT() = opNotSupported "ReluT" t.Dtype
+    override t.LeakyReluT(_negativeSlope) = opNotSupported "LeakyReluT" t.Dtype
     override t.SoftplusT() = opNotSupported "SoftplusT" t.Dtype
     override t1.PowTT(t2) = opNotSupported2 "PowTT" t1.Dtype t2.Dtype
     override t2.PowFromT0T(_t1) = opNotSupported "PowT0T" t2.Dtype
@@ -1599,6 +1694,12 @@ type RawTensorBool(values: bool[], shape:Shape, device) =
     override t.FloorT() = opNotSupported "FloorT" t.Dtype
     override t.CeilT() = opNotSupported "CeilT" t.Dtype
     override t.RoundT() = opNotSupported "RoundT" t.Dtype
+    override t.EluT(_, _, _) = opNotSupported "EluT" t.Dtype
+    override t.GeluT() = opNotSupported "GeluT" t.Dtype
+    override t.HardsigmoidT() = opNotSupported "HardsigmoidT" t.Dtype
+    override t.HardswishT() = opNotSupported "HardswishT" t.Dtype
+    override t.Relu6T() = opNotSupported "Relu6T" t.Dtype
+    override t.SiluT() = opNotSupported "SiluT" t.Dtype
     override t.SigmoidT() = opNotSupported "SigmoidT" t.Dtype
     override t.ExpT() = opNotSupported "ExpT" t.Dtype
     override t.LogT() = opNotSupported "LogT" t.Dtype
@@ -1689,6 +1790,13 @@ type RawTensorFloat16(values: float32[], shape:Shape, device) =
     override t.RoundT() = RawTensorCPU.RoundT(t) |> create
     override t.AbsT() = RawTensorCPU.AbsT abs t |> create
     override t.ReluT() = RawTensorCPU.ReluT(t) |> create
+    override t.LeakyReluT(negativeSlope) = RawTensorCPU.LeakyReluT float32 (t, negativeSlope) |> create
+    override t.EluT(alpha, scale, inputScale) = RawTensorCPU.EluT(t, alpha, scale, inputScale) |> create
+    override t.GeluT() = RawTensorCPU.GeluT float32 (t) |> create
+    override t.HardsigmoidT() = RawTensorCPU.HardsigmoidT(t) |> create
+    override t.HardswishT() = RawTensorCPU.HardswishT(t) |> create
+    override t.Relu6T() = RawTensorCPU.Relu6T(t) |> create
+    override t.SiluT() = RawTensorCPU.SiluT(t) |> create
     override t.SigmoidT() = RawTensorCPU.SigmoidT(t) |> create
     override t.ExpT() = RawTensorCPU.ExpT(t) |> create
     override t.LogT() = RawTensorCPU.LogT(t) |> create
@@ -1779,6 +1887,13 @@ type RawTensorBFloat16(values: float32[], shape:Shape, device) =
     override t.RoundT() = RawTensorCPU.RoundT(t) |> create
     override t.AbsT() = RawTensorCPU.AbsT abs t |> create
     override t.ReluT() = RawTensorCPU.ReluT(t) |> create
+    override t.LeakyReluT(negativeSlope) = RawTensorCPU.LeakyReluT float32 (t, negativeSlope) |> create
+    override t.EluT(alpha, scale, inputScale) = RawTensorCPU.EluT(t, alpha, scale, inputScale) |> create
+    override t.GeluT() = RawTensorCPU.GeluT float32 (t) |> create
+    override t.HardsigmoidT() = RawTensorCPU.HardsigmoidT(t) |> create
+    override t.HardswishT() = RawTensorCPU.HardswishT(t) |> create
+    override t.Relu6T() = RawTensorCPU.Relu6T(t) |> create
+    override t.SiluT() = RawTensorCPU.SiluT(t) |> create
     override t.SigmoidT() = RawTensorCPU.SigmoidT(t) |> create
     override t.ExpT() = RawTensorCPU.ExpT(t) |> create
     override t.LogT() = RawTensorCPU.LogT(t) |> create

--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -790,6 +790,41 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         | Dtype.Int8 -> t.Cast(Dtype.Int32).ReluT().Cast(Dtype.Int8) // TODO: there is odd behaviour from torch for relu on int8, may have been fixed in later version?
         | _ ->   t.MakeLike(tt.relu())
 
+    override t.LeakyReluT(negativeSlope) =
+        match dtype with 
+        | Dtype.Bool -> opNotSupported "LeakyReluT" dtype
+        | _ ->   t.MakeLike(tt.leaky_relu_(toTorchScalar negativeSlope))
+
+    override t.EluT(alpha, scale, inputScale) =
+        match dtype with 
+        | Dtype.Bool -> opNotSupported "EluT" dtype
+        | _ ->   t.MakeLike(tt.elu(toTorchScalar alpha, toTorchScalar scale, toTorchScalar inputScale))
+
+    override t.GeluT() =
+        match dtype with 
+        | Dtype.Bool -> opNotSupported "GeluT" dtype
+        | _ ->   t.MakeLike(tt.gelu())
+
+    override t.HardsigmoidT() =
+        match dtype with 
+        | Dtype.Bool -> opNotSupported "HardsigmoidT" dtype
+        | _ ->   t.MakeLike(tt.hardsigmoid())
+
+    override t.Relu6T() =
+        match dtype with 
+        | Dtype.Bool -> opNotSupported "Relu6T" dtype
+        | _ ->   t.MakeLike(tt.relu6())
+
+    override t.HardswishT() =
+        match dtype with 
+        | Dtype.Bool -> opNotSupported "HardswishT" dtype
+        | _ ->   t.MakeLike(tt.hardswish())
+
+    override t.SiluT() =
+        match dtype with 
+        | Dtype.Bool -> opNotSupported "SiluT" dtype
+        | _ ->   t.MakeLike(tt.silu())
+
     override t.SigmoidT() =
         match dtype with 
         | Dtype.IntegralOrBool -> opNotSupported "SigmoidT" dtype
@@ -1036,6 +1071,24 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
     override _.AbsInPlace() = checkMutable(); tt.abs_() |> ignore
 
     override _.ReluInPlace() = checkMutable(); tt.relu_() |> ignore
+
+    override _.Relu6InPlace() = checkMutable(); tt.relu6_() |> ignore
+
+    override _.LeakyReluInPlace(negativeSlope) = 
+        checkMutable();
+        tt.leaky_relu_(toTorchScalar negativeSlope) |> ignore
+
+    override _.EluInPlace(alpha, scale, inputScale) =
+        checkMutable()
+        tt.elu_(toTorchScalar alpha, toTorchScalar scale, toTorchScalar inputScale) |> ignore
+
+    override _.GeluInPlace() = checkMutable(); tt <- tt.gelu() 
+
+    override _.SiluInPlace() = checkMutable(); tt.silu_() |> ignore
+
+    override _.HardsigmoidInPlace() = checkMutable(); tt.hardsigmoid_() |> ignore
+
+    override _.HardswishInPlace() = checkMutable(); tt.hardswish_() |> ignore
 
     override _.SoftplusInPlace() = checkMutable(); tt <- tt.softplus() 
 

--- a/src/DiffSharp.Core/DiffSharp.Activations.fs
+++ b/src/DiffSharp.Core/DiffSharp.Activations.fs
@@ -1,0 +1,81 @@
+﻿namespace DiffSharp
+
+    [<AutoOpen>]
+    module ActivationsExtensions =
+
+        /// Defines an extension as an element-wise operation using the function and its derivative
+        let inline elementwiseOp nm f deriv =
+            Tensor.Op
+                { new UnaryOpElementwise(nm ) with 
+                    member _.fRaw(a) = f a
+                    member t.dfda(a, f) = deriv f a
+                    }
+
+        type Tensor with
+
+            /// <summary>Applies the exponential linear unit function element-wise.</summary>
+            /// <param name="alpha">The alpha parameter to the elu function. Default: 1.0.</param>
+            member a.elu(?alpha: double) =
+                let alpha = defaultArg alpha 1.0
+                elementwiseOp "elu"
+                    (fun a -> a.EluT(alpha, 1.0, 1.0)) 
+                    (fun f a -> failwith "deriv of elu NYI") a
+
+            /// <summary>Applies the sigmoid linear unit function element-wise.</summary>
+            member a.silu() =
+                elementwiseOp "silu"
+                    (fun a -> a.SiluT())
+                    (fun f a -> failwith "deriv of silu NYI") a
+
+            /// <summary>Applies the gaussian error linear unit function element-wise.</summary>
+            member a.gelu() =
+                elementwiseOp  "gelu"
+                    (fun a -> a.GeluT())
+                    (fun f a -> failwith "deriv of gelu NYI") a
+
+            /// <summary>Applies the hardswish function element-wise.</summary>
+            member a.hardswish() = 
+                elementwiseOp "hardswish"
+                    (fun a -> a.HardswishT())
+                    (fun f a -> failwith "deriv of hardswish NYI") a
+
+            /// <summary>Applies the rectified linear unit function (6 max) element-wise.</summary>
+            member a.relu6() =
+                elementwiseOp "relu6"
+                    (fun a -> a.Relu6T())
+                    (fun f a -> failwith "deriv of relu6 NYI") a
+
+            /// <summary>Applies the hardsigmoid function element-wise.</summary>
+            member a.hardsigmoid() =
+                elementwiseOp "hardsigmoid"
+                    (fun a -> a.HardsigmoidT())
+                    (fun f a -> failwith "deriv of hardsigmoid NYI") a
+
+        type dsharp with
+
+            /// <summary>Applies the exponential linear unit function element-wise.</summary>
+            /// <param name="input">The input tensor.</param>
+            /// <param name="alpha">The alpha parameter to the elu function. Default: 1.0.</param>
+            static member elu(input:Tensor, ?alpha: double) =
+                input.elu(?alpha=alpha)
+
+            /// <summary>Applies the sigmoid linear unit function element-wise.</summary>
+            /// <param name="input">The input tensor.</param>
+            static member silu(input:Tensor) = input.silu()
+
+            /// <summary>Applies the gaussian error linear unit function element-wise.</summary>
+            /// <param name="input">The input tensor.</param>
+            static member gelu(input:Tensor) = input.gelu()
+
+            /// <summary>Applies the hardswish function element-wise.</summary>
+            /// <param name="input">The input tensor.</param>
+            static member hardswish(input:Tensor) = input.hardswish()
+
+            /// <summary>Applies the rectified linear unit function (6 max) element-wise.</summary>
+            /// <param name="input">The input tensor.</param>
+            static member relu6(input:Tensor) = input.relu6()
+
+            /// <summary>Applies the hardsigmoid function element-wise.</summary>
+            /// <param name="input">The input tensor.</param>
+            static member hardsigmoid(input:Tensor) = input.hardsigmoid()
+

--- a/src/DiffSharp.Core/DiffSharp.Core.fsproj
+++ b/src/DiffSharp.Core/DiffSharp.Core.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="DiffSharp.Compose.fs" />
     <Compile Include="DiffSharp.Shorten.fs" />
     <Compile Include="DiffSharp.Numerical.fs" />
+    <Compile Include="DiffSharp.Activations.fs" />
     <Compile Include="Distributions.fs" />
     <Compile Include="Data.fs" />
     <Compile Include="Model.fs" />

--- a/src/DiffSharp.Core/RawTensor.fs
+++ b/src/DiffSharp.Core/RawTensor.fs
@@ -514,8 +514,29 @@ type RawTensor() =
     /// Returns the element-wise absolute value of the tensor
     abstract AbsT: unit -> RawTensor
 
-    /// Returns the element-wise ReLU of the tensor
+    /// Returns the element-wise relu of the tensor
     abstract ReluT: unit -> RawTensor
+
+    /// Returns the element-wise leaky relu of the tensor
+    abstract LeakyReluT: negativeSlope: double -> RawTensor
+
+    /// Returns the element-wise elu of the tensor
+    abstract EluT: alpha: double * scale: double * input_scale: double -> RawTensor
+
+    /// Returns the element-wise gelu of the tensor
+    abstract GeluT: unit -> RawTensor
+
+    /// Returns the element-wise silu of the tensor
+    abstract SiluT: unit -> RawTensor
+
+    /// Returns the element-wise hardswish of the tensor
+    abstract HardswishT: unit -> RawTensor
+
+    /// Returns the element-wise relu6 of the tensor
+    abstract Relu6T: unit -> RawTensor
+
+    /// Returns the element-wise hardsigmoid of the tensor
+    abstract HardsigmoidT: unit -> RawTensor
 
     /// Returns the element-wise softplus of the tensor
     abstract SoftplusT: unit -> RawTensor
@@ -746,6 +767,27 @@ type RawTensor() =
 
     /// Modifies the tensor by the element-wise ReLU of the tensor
     abstract ReluInPlace: unit -> unit
+
+    /// Returns the element-wise leaky relu of the tensor
+    abstract LeakyReluInPlace: negativeSlope: double -> unit
+
+    /// Returns the element-wise elu of the tensor
+    abstract EluInPlace: alpha: double * scale: double * inputScale: double -> unit
+
+    /// Returns the element-wise gelu of the tensor
+    abstract GeluInPlace: unit -> unit
+
+    /// Returns the element-wise silu of the tensor
+    abstract SiluInPlace: unit -> unit
+
+    /// Returns the element-wise hardswish of the tensor
+    abstract HardswishInPlace: unit -> unit
+
+    /// Returns the element-wise relu6 of the tensor
+    abstract Relu6InPlace: unit -> unit
+
+    /// Returns the element-wise hardsigmoid of the tensor
+    abstract HardsigmoidInPlace: unit -> unit
 
     /// Modifies the tensor by the element-wise softplus of the tensor
     abstract SoftplusInPlace: unit -> unit

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -778,6 +778,7 @@ type Tensor =
         sb.ToString()
 
     member internal t.GetSlice(bounds:int[,]) =
+        // printfn "t.GetSlice bounds\n %A" bounds
         if t.dim = 0 then failwith "Cannot slice a scalar Tensor"
         let fullBounds = t.shapeFullBounds |> Array2D.copy
         bounds |> Array2D.iteri (fun i j v -> 


### PR DESCRIPTION

This puts in place the outline of the activation functions necessary for the range of models I've been looking at porting to DiffSharp.

- Like #252 this uses (internall) the extension API of #89 so we don't have to shove everything into Tensor.fs.  It can be done without but then sooner or later we have to refactor.

- The implementations in Reference.RawTensor.fs and derivatives DiffSharp.Activations.fs in still need to be added

- Testing is needed

LibTorch provides primitives for the reverse mode operations though these are not yet available, and we would also need to the 2nd derivatives if we utilise those.

Cheers
don


