### PR TITLE
Tighten assert in reverse

### DIFF
--- a/src/DiffSharp.Core/Shape.fs
+++ b/src/DiffSharp.Core/Shape.fs
@@ -714,7 +714,7 @@ module ShapeAutoOpens =
         [|for i=0 to bounds.GetLength(0) - 1 do yield bounds.[i, 0]|]
 
     /// Converts the array of three-position bounds specifications to a shape without squeezing out scalars
-    let boundsToShapeKeepDims (bounds: int[,]) =
+    let boundsToShape (bounds: int[,]) =
         [|for i=0 to bounds.GetLength(0) - 1 do 
              let len = bounds.[i, 1] - bounds.[i, 0] + 1
              yield len|]

--- a/src/DiffSharp.Core/Shape.fs
+++ b/src/DiffSharp.Core/Shape.fs
@@ -713,15 +713,8 @@ module ShapeAutoOpens =
     let boundsToLocation (bounds: int[,]) =
         [|for i=0 to bounds.GetLength(0) - 1 do yield bounds.[i, 0]|]
 
-    /// Converts the array of three-position bounds specifications to a shape.
-    let boundsToShape (bounds: int[,]) =
-        [|for i=0 to bounds.GetLength(0) - 1 do 
-             let len = bounds.[i, 1] - bounds.[i, 0] + 1
-             if bounds.[i, 2] = 0 || len > 1 then 
-                 yield len |]
-
     /// Converts the array of three-position bounds specifications to a shape without squeezing out scalars
-    let boundsToShapeNoSqueeze (bounds: int[,]) =
+    let boundsToShapeKeepDims (bounds: int[,]) =
         [|for i=0 to bounds.GetLength(0) - 1 do 
              let len = bounds.[i, 1] - bounds.[i, 0] + 1
              yield len|]

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -2670,9 +2670,12 @@ type Tensor =
     /// <param name="value">The value to apply.</param>
     member t.reversePush(value:Tensor) =
         let check (v:Tensor,t:Tensor) = 
-            // check the shapes of the tangent derivatives match the nodes to which they are being propagated
+            // Check the shapes of the tangent derivatives match the nodes to which they are being propagated
+            // In some places the 'zero' tensor is being used for the initial tangent derivative so 
+            // the assert takes that into account.
             assert (v.shape.Length = 0 || t.derivative.shape.Length = 0 || v.shape = t.derivative.shape)
             (v,t)
+
         let rec push (ts:(Tensor*Tensor) list) =
             match ts with
             | [] -> ()

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -2793,7 +2793,7 @@ type Tensor =
                         | SliceT(a,bounds) -> 
                             // TODO: a.zerosLike() below is to handle non-scalar TensorRs with a scalar derivative Tensor(0.) (representing the initialization before accumulation). This is correct but can be changed to eliminate the extra op.
                             if a.derivative.dim = 0 then a.derivative <- a.zerosLike() + a.derivative
-                            a.derivative <- a.derivative.addSlice(boundsToLocation bounds, td.view(boundsToShapeKeepDims bounds))
+                            a.derivative <- a.derivative.addSlice(boundsToLocation bounds, td.view(boundsToShape bounds))
                             push (check(a.zeroLike(), a) :: tt)
                         | AddTTSlice(a,location,b) -> push (check(td, a) :: check(td.GetSlice(Shape.locationToBounds b.shape location), b):: tt)
                         | AddTTConstSlice(a) -> push (check(td, a) :: tt)

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -2670,8 +2670,8 @@ type Tensor =
     /// <param name="value">The value to apply.</param>
     member t.reversePush(value:Tensor) =
         let check (v:Tensor,t:Tensor) = 
-            // check the shapes of the adjoints match the nodes to which they are being propagated
-            assert (Shape.canExpand v.shape t.derivative.shape || Shape.canExpand t.derivative.shape v.shape)
+            // check the shapes of the tangent derivatives match the nodes to which they are being propagated
+            assert (v.shape.Length = 0 || t.derivative.shape.Length = 0 || v.shape = t.derivative.shape)
             (v,t)
         let rec push (ts:(Tensor*Tensor) list) =
             match ts with

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -2793,7 +2793,7 @@ type Tensor =
                         | SliceT(a,bounds) -> 
                             // TODO: a.zerosLike() below is to handle non-scalar TensorRs with a scalar derivative Tensor(0.) (representing the initialization before accumulation). This is correct but can be changed to eliminate the extra op.
                             if a.derivative.dim = 0 then a.derivative <- a.zerosLike() + a.derivative
-                            a.derivative <- a.derivative.addSlice(boundsToLocation bounds, td.view(boundsToShapeNoSqueeze bounds))
+                            a.derivative <- a.derivative.addSlice(boundsToLocation bounds, td.view(boundsToShapeKeepDims bounds))
                             push (check(a.zeroLike(), a) :: tt)
                         | AddTTSlice(a,location,b) -> push (check(td, a) :: check(td.GetSlice(Shape.locationToBounds b.shape location), b):: tt)
                         | AddTTConstSlice(a) -> push (check(td, a) :: tt)

--- a/tests/DiffSharp.Tests/TestDerivatives.fs
+++ b/tests/DiffSharp.Tests/TestDerivatives.fs
@@ -2410,6 +2410,21 @@ type TestDerivatives () =
             Assert.True(revyd.allclose(revydCorrect, 0.01))
 
     [<Test>]
+    member _.TestDerivativeSliceT_2D () =
+        for combo in Combos.AllDevicesAndBackendsFloat32 do
+
+            let revx = combo.tensor([[54.7919; 70.6440; 16.0868; 74.5486; 82.9318]; 
+                                     [54.7919; 70.6440; 16.0868; 74.5486; 82.9318]]).reverseDiff()
+            let revz = revx.[*,2..2]
+            let revzCorrect = combo.tensor([16.0868; 16.0868])
+            revz.reverse(combo.tensor([0.9360;0.9360]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([[0.; 0.; 0.9360; 0.; 0.];[0.; 0.; 0.9360; 0.; 0.]])
+
+            Assert.True(revz.allclose(revzCorrect, 0.01))
+            Assert.True(revxd.allclose(revxdCorrect, 0.01))
+
+    [<Test>]
     member _.TestDerivativeAddTTConstSlice () =
         for combo in Combos.AllDevicesAndBackendsFloat32 do
             let fwdx = combo.tensor([[-0.2754;  0.0172;  0.7105];

--- a/tests/DiffSharp.Tests/TestDerivatives.fs
+++ b/tests/DiffSharp.Tests/TestDerivatives.fs
@@ -2354,6 +2354,20 @@ type TestDerivatives () =
             Assert.True(revz.allclose(revzCorrect, 0.01))
             Assert.True(revxd.allclose(revxdCorrect, 0.01))
 
+
+    [<Test>]
+    member _.TestDerivativeSliceTFinalColumn () =
+        for combo in Combos.AllDevicesAndBackendsFloat32 do
+            let revx = combo.tensor([54.7919; 70.6440; 16.0868]).reverseDiff()
+            let revz = revx.[2..]
+            let revzCorrect = combo.tensor([16.0868])
+            revz.reverse(combo.tensor([0.9360]))
+            let revxd = revx.derivative
+            let revxdCorrect = combo.tensor([0.; 0.; 0.9360])
+
+            Assert.True(revz.allclose(revzCorrect, 0.01))
+            Assert.True(revxd.allclose(revxdCorrect, 0.01))
+
     [<Test>]
     member _.TestDerivativeAddTTSlice () =
         for combo in Combos.AllDevicesAndBackendsFloat32 do


### PR DESCRIPTION
Address issues raised about #235 in review #258

* add test that shows slicing fix in #235 fixes a real problem (I've verified TestDerivativeSliceTFinalColumn failed before #235)

* add test that shows that `boundsToShape` change in #235 was not necessary (it was actually a no-op brought over mistakenly from #237), and revert that

* show we can tighten the assert added in #235 per discussion in #258 to prove there's no strange broadcasting going on.
