### PR TITLE
Document that libtorch-{version} may need to be changed.

### DIFF
--- a/docs/getting-started-torch.fsx
+++ b/docs/getting-started-torch.fsx
@@ -14,14 +14,16 @@
 (*** condition: fsx ***)
 #if FSX
 // This is a workaround for https://github.com/dotnet/fsharp/issues/10136, necessary in F# scripts and .NET Interactive
-System.Runtime.InteropServices.NativeLibrary.Load(let path1 = System.IO.Path.GetDirectoryName(typeof<DiffSharp.dsharp>.Assembly.Location) in if System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux) then path1 + "/../../../../libtorch-cpu/1.5.6/runtimes/linux-x64/native/libtorch.so" else path1 + "/../../../../libtorch-cpu/1.5.6/runtimes/win-x64/native/torch_cpu.dll")
+// Make sure to update the parts of the native load path related to version number ([cpu](https://www.nuget.org/packages/libtorch-cpu/),[gpu](https://www.nuget.org/packages/libtorch-cuda-10.2-win-x64/) and cpu/gpu depending on your backend choice.
+System.Runtime.InteropServices.NativeLibrary.Load(let path1 = System.IO.Path.GetDirectoryName(typeof<DiffSharp.dsharp>.Assembly.Location) in if System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux) then path1 + "/../../../../libtorch-cpu/1.7.0.1/runtimes/linux-x64/native/libtorch.so" else path1 + "/../../../../libtorch-cpu/1.7.0.1/runtimes/win-x64/native/torch_cpu.dll")
 #r "nuget: DiffSharp-cpu,{{fsdocs-package-version}}"
 #endif // FSX
 
 (*** condition: ipynb ***)
 #if IPYNB
 // This is a workaround for https://github.com/dotnet/fsharp/issues/10136, necessary in F# scripts and .NET Interactive
-System.Runtime.InteropServices.NativeLibrary.Load(let path1 = System.IO.Path.GetDirectoryName(typeof<DiffSharp.dsharp>.Assembly.Location) in if System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux) then path1 + "/../../../../libtorch-cpu/1.5.6/runtimes/linux-x64/native/libtorch.so" else path1 + "/../../../../libtorch-cpu/1.5.6/runtimes/win-x64/native/torch_cpu.dll")
+// Make sure to update the parts of the native load path related to version number ([cpu](https://www.nuget.org/packages/libtorch-cpu/),[gpu](https://www.nuget.org/packages/libtorch-cuda-10.2-win-x64/) and cpu/gpu depending on your backend choice.
+System.Runtime.InteropServices.NativeLibrary.Load(let path1 = System.IO.Path.GetDirectoryName(typeof<DiffSharp.dsharp>.Assembly.Location) in if System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux) then path1 + "/../../../../libtorch-cpu/1.7.0.1/runtimes/linux-x64/native/libtorch.so" else path1 + "/../../../../libtorch-cpu/1.7.0.1/runtimes/win-x64/native/torch_cpu.dll")
 
 // Set up formatting for notebooks
 Formatter.SetPreferredMimeTypeFor(typeof<obj>, "text/plain")


### PR DESCRIPTION
The documentation NativeLibrary.Load paths referred to outdated libtorch versions. This needed to be updated. It does not look like there is a {{fsdocs-content}} tag that will work to dynamically insert the proper libtorch reference. So instead I updated the libtorch version and added a comment that this may need to be changed.