### PR TITLE
Improvement in Torch backend slicing

### DIFF
--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -134,8 +134,9 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
             let stop = fullBounds.[i,1] + 1
 
             let len = stop - start
-            use idxs = Int64Tensor.Arange((int64 start).ToScalar(), (int64 stop).ToScalar(), 1L.ToScalar(), tt.DeviceType, tt.DeviceIndex)
-            res <- res.IndexSelect(int64 dim, idxs)  // yield len // if len=1 then squeeze this dimension
+            if len <> t.Shape.[i] then // Slice only when there is something to slice in this dimension
+                use idxs = Int64Tensor.Arange((int64 start).ToScalar(), (int64 stop).ToScalar(), 1L.ToScalar(), tt.DeviceType, tt.DeviceIndex)
+                res <- res.IndexSelect(int64 dim, idxs)  // yield len // if len=1 then squeeze this dimension
             if fullBounds.[i, 2] = 1 && len = 1 then 
                 res <- res.Squeeze(int64 dim)  // yield len // if len=1 then squeeze this dimension
             else

--- a/src/DiffSharp.Core/Shape.fs
+++ b/src/DiffSharp.Core/Shape.fs
@@ -727,6 +727,9 @@ module ShapeAutoOpens =
              let len = bounds.[i, 1] - bounds.[i, 0] + 1
              yield len|]
 
+    let shapeToFullBounds (shape: Shape) =
+        Array2D.init (shape.Length) 3 (fun i j -> if j=0 then 0 elif j=1 then shape.[i]-1 else 0)
+
     /// Mirrors the coordinates in the given dimensions in the context of the given shape.
     let mirrorCoordinates (coordinates: int[]) (shape: int[]) (mirrorDims: int[]) =
         if coordinates.Length <> shape.Length then failwithf "Expecting coordinates and shape of the same dimension, received %A, %A" coordinates.Length shape.Length


### PR DESCRIPTION
This relates to #277 and a performance issue with the way Torch backend slicing is currently implemented.

In the meantime, I have measured the modification in this PR to give approx. 2x speed up for a GAN prototype code I'm working on (which is mainly convolutions, transposed convolutions and lots of slicing within the reverse mode of these).