### PR TITLE
skip test until #289 is fixed

### DIFF
--- a/tests/DiffSharp.Tests/TestData.fs
+++ b/tests/DiffSharp.Tests/TestData.fs
@@ -15,6 +15,7 @@ open DiffSharp.Util
 type TestData () =
 
     [<Test>]
+    [<Ignore("https://github.com/DiffSharp/DiffSharp/issues/289")>]
     member _.TestMNISTDataset () =
         // Note: this test can fail if http://yann.lecun.com website goes down or file urls change
         let cd = Directory.GetCurrentDirectory()


### PR DESCRIPTION
Skipping the MNIST download test on CI for now, though of course the issue needs to be fixed (the CI system may be being black-listed, or the server is just down)

See issue https://github.com/DiffSharp/DiffSharp/issues/289

