### PR TITLE
Use netstandard2.1 for the core

### DIFF
--- a/src/DiffSharp.Backends.Reference/DiffSharp.Backends.Reference.fsproj
+++ b/src/DiffSharp.Backends.Reference/DiffSharp.Backends.Reference.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DiffSharp.Core/DiffSharp.Core.fsproj
+++ b/src/DiffSharp.Core/DiffSharp.Core.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/DiffSharp.Data/DiffSharp.Data.fsproj
+++ b/src/DiffSharp.Data/DiffSharp.Data.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/DiffSharp.Tests/TestData.fs
+++ b/tests/DiffSharp.Tests/TestData.fs
@@ -15,6 +15,7 @@ open DiffSharp.Util
 type TestData () =
 
     [<Test>]
+    [<Ignore("https://github.com/DiffSharp/DiffSharp/issues/289")>]
     member _.TestMNISTDataset () =
         // Note: this test can fail if http://yann.lecun.com website goes down or file urls change
         let cd = Directory.GetCurrentDirectory()


### PR DESCRIPTION

The core components on DiffSharp shouldn't depend on a specific .NET Runtime, they can just be netstandard2.1

This doesn't make any immediate difference but it's the right thing to do to prevent runtime-specific hacks creeping into the core abstractions 

Examples where we might want this

- we want to cross-compile to Javascript 
- we might want to host inside netstandard2.1 analyzers 
