### PR TITLE
fix package cuilds on CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,5 @@
+# note, the nuget org token expires around June 2021
+
 name: Build/test/docs/publish
 
 on:
@@ -52,4 +54,60 @@ jobs:
     - name: Publish NuGets
       run: dotnet nuget push "bin/packages/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_TOKEN_2020 }} --skip-duplicate
 
-# note, the nuget org token expires around June 2021
+  pack_cpu:
+
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.100
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Pack
+      run: dotnet pack --configuration Release --verbosity normal
+    - name: Publish NuGets
+      run: dotnet nuget push "bin/packages/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_TOKEN_2020 }} --skip-duplicate
+
+  # Done in a separate job because it downloads the massive Windows CUDA pacakges (though only for reference
+  # during the pacakge build, it doesn't actually use them)
+  pack_windows_cuda:
+
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.100
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Pack (DiffSharp-cuda-windows)
+      run: dotnet pack --configuration Release --verbosity normal bundles/DiffSharp-cuda-windows
+    - name: Publish NuGets
+      run: dotnet nuget push "bin/packages/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_TOKEN_2020 }} --skip-duplicate
+
+  # Done in a separate job because it downloads the massive Linux CUDA pacakges (though only for reference
+  # during the pacakge build, it doesn't actually use them)
+  pack_linux_cuda:
+
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.100
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Pack (DiffSharp-cuda-linux)
+      run: dotnet pack --configuration Release --verbosity normal bundles/DiffSharp-cuda-linux
+    - name: Publish NuGets
+      run: dotnet nuget push "bin/packages/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_TOKEN_2020 }} --skip-duplicate

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,7 +52,7 @@
      <PackageVersion Condition="'$(GITHUB_ACTIONS)' == 'true' AND '$(GITHUB_REF)' == 'refs/tags/v$(Version)'">$(Version)</PackageVersion>
      <!-- untagged build on CI uses unique -->
      <PackageVersion Condition="'$(GITHUB_ACTIONS)' == 'true' AND '$(GITHUB_REF)' != 'refs/tags/v$(Version)'">$(Version)-preview-$(GITHUB_RUN_ID)</PackageVersion>
-     <PackageOutputPath>$(MSBuildThisFileDirectory)/bin/packages</PackageOutputPath>
+     <PackageOutputPath>$(MSBuildThisFileDirectory)bin/packages</PackageOutputPath>
 
      <NuspecProperties>Authors=$(Authors);Owners=$(Owners);ProjectId=$(MSBuildProjectName);PackageVersion=$(PackageVersion);TorchSharpVersion=$(TorchSharpVerion);LibTorchNugetVersion=$(LibTorchNugetVersion)</NuspecProperties>
 

--- a/bundles/DiffSharp-cpu/DiffSharp-cpu.fsproj
+++ b/bundles/DiffSharp-cpu/DiffSharp-cpu.fsproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   
   <ItemGroup>
@@ -11,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DiffSharp.Core\DiffSharp.Core.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Data\DiffSharp.Data.fsproj" />
+    <ProjectReference Include="..\..\src\DiffSharp.Backends.Reference\DiffSharp.Backends.Reference.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Torch\DiffSharp.Backends.Torch.fsproj" />
     <!--  reference a libtorch runtime redist -->
     <PackageReference Include="libtorch-cpu" Version="$(LibTorchNugetVersion)" />

--- a/bundles/DiffSharp-cuda-linux/DiffSharp-cuda-linux.fsproj
+++ b/bundles/DiffSharp-cuda-linux/DiffSharp-cuda-linux.fsproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DiffSharp.Core\DiffSharp.Core.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Data\DiffSharp.Data.fsproj" />
+    <ProjectReference Include="..\..\src\DiffSharp.Backends.Reference\DiffSharp.Backends.Reference.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Torch\DiffSharp.Backends.Torch.fsproj" />
     <!--  reference a libtorch runtime redist -->
     <PackageReference Include="libtorch-cuda-11.1-linux-x64" Version="$(LibTorchNugetVersion)" />

--- a/bundles/DiffSharp-cuda-windows/DiffSharp-cuda-windows.fsproj
+++ b/bundles/DiffSharp-cuda-windows/DiffSharp-cuda-windows.fsproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DiffSharp.Core\DiffSharp.Core.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Data\DiffSharp.Data.fsproj" />
+    <ProjectReference Include="..\..\src\DiffSharp.Backends.Reference\DiffSharp.Backends.Reference.fsproj" />
     <ProjectReference Include="..\..\src\DiffSharp.Backends.Torch\DiffSharp.Backends.Torch.fsproj" />
     <!--  reference a libtorch runtime redist -->
     <PackageReference Include="libtorch-cuda-11.1-win-x64" Version="$(LibTorchNugetVersion)" />

--- a/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
+++ b/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
@@ -47,11 +47,11 @@
 
   <!-- Choose the appropriate version of libtorch for our current OS and environment -->
   <ItemGroup Condition="'$(DIFFSHARP_TESTGPU)' == 'true' AND $([MSBuild]::IsOsPlatform(Linux))">
-    <PackageReference Include="libtorch-cuda-10.2-linux-x64" Version="$(LibTorchNugetVersion)" />
+    <PackageReference Include="libtorch-cuda-11.1-linux-x64" Version="$(LibTorchNugetVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIFFSHARP_TESTGPU)' == 'true' AND $([MSBuild]::IsOsPlatform(Windows))">
-    <PackageReference Include="libtorch-cuda-10.2-win-x64" Version="$(LibTorchNugetVersion)" />
+    <PackageReference Include="libtorch-cuda-11.1-win-x64" Version="$(LibTorchNugetVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIFFSHARP_TESTGPU)' != 'true'">

--- a/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
+++ b/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <PlatformTarget>x64</PlatformTarget>
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
@@ -48,11 +47,11 @@
 
   <!-- Choose the appropriate version of libtorch for our current OS and environment -->
   <ItemGroup Condition="'$(DIFFSHARP_TESTGPU)' == 'true' AND $([MSBuild]::IsOsPlatform(Linux))">
-    <PackageReference Include="libtorch-cuda-11.1-linux-x64" Version="$(LibTorchNugetVersion)" />
+    <PackageReference Include="libtorch-cuda-10.2-linux-x64" Version="$(LibTorchNugetVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIFFSHARP_TESTGPU)' == 'true' AND $([MSBuild]::IsOsPlatform(Windows))">
-    <PackageReference Include="libtorch-cuda-11.1-win-x64" Version="$(LibTorchNugetVersion)" />
+    <PackageReference Include="libtorch-cuda-10.2-win-x64" Version="$(LibTorchNugetVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DIFFSHARP_TESTGPU)' != 'true'">


### PR DESCRIPTION
The package builds are busted on CI due to space limitations.  This splits them out into separate builds.

Also adjust the "DiffSharp-cpu"and "DiffSharp-cuda-*" bundles so they include both Torch and Reference backends (like DiffSharp-lite) as well as the LibTorch package references.

