### PR TITLE
remove warnings

### DIFF
--- a/bundles/DiffSharp-lite/DiffSharp-lite.fsproj
+++ b/bundles/DiffSharp-lite/DiffSharp-lite.fsproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-  
+    <PlatformTarget>x64</PlatformTarget>
+
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Empty.fs" />

--- a/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
+++ b/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
@@ -5,6 +5,7 @@
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Anything referencing the Torch backend is 64-bit only 