### PR TITLE
Upgrade test library versions

### DIFF
--- a/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
+++ b/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Update="FSharp.Core" Version="$(FSharpCoreVersion)" />
   </ItemGroup>
 

--- a/tests/DiffSharp.Tests/TestModel.fs
+++ b/tests/DiffSharp.Tests/TestModel.fs
@@ -946,7 +946,7 @@ type TestModel () =
         let rnn = RNN(din, dout, numLayers=numLayers, bidirectional=false)
         let output = input --> rnn
         let outputShape = output.shape
-        let outputShapeCorrect = [seqLen; batchSize; dout]
+        let outputShapeCorrect = [|seqLen; batchSize; dout|]
         Assert.AreEqual(outputShapeCorrect, outputShape)
 
         // Batch first
@@ -954,16 +954,16 @@ type TestModel () =
         let rnn = RNN(din, dout, numLayers=numLayers, batchFirst=true, bidirectional=false)
         let output = input --> rnn
         let outputShape = output.shape
-        let outputShapeCorrect = [batchSize; seqLen; dout]
+        let outputShapeCorrect = [|batchSize; seqLen; dout|]
         Assert.AreEqual(outputShapeCorrect, outputShape)
 
         let hiddenShape = rnn.hidden.shape
-        let hiddenShapeCorrect = [numLayers*numDirections; batchSize; dout]
+        let hiddenShapeCorrect = [|numLayers*numDirections; batchSize; dout|]
         Assert.AreEqual(hiddenShapeCorrect, hiddenShape)
 
         rnn.reset()
         let hiddenShape = rnn.hidden.shape
-        let hiddenShapeCorrect = [0]
+        let hiddenShapeCorrect = [|0|]
         Assert.AreEqual(hiddenShapeCorrect, hiddenShape)
 
         let steps = 64
@@ -1006,7 +1006,7 @@ type TestModel () =
         let lstm = LSTM(din, dout, numLayers=numLayers, bidirectional=false)
         let output = input --> lstm
         let outputShape = output.shape
-        let outputShapeCorrect = [seqLen; batchSize; dout]
+        let outputShapeCorrect = [|seqLen; batchSize; dout|]
         Assert.AreEqual(outputShapeCorrect, outputShape)
 
         // Batch first
@@ -1014,21 +1014,21 @@ type TestModel () =
         let lstm = LSTM(din, dout, numLayers=numLayers, batchFirst=true, bidirectional=false)
         let output = input --> lstm
         let outputShape = output.shape
-        let outputShapeCorrect = [batchSize; seqLen; dout]
+        let outputShapeCorrect = [|batchSize; seqLen; dout|]
         Assert.AreEqual(outputShapeCorrect, outputShape)
 
         let hiddenShape = lstm.hidden.shape
-        let hiddenShapeCorrect = [numLayers*numDirections; batchSize; dout]
+        let hiddenShapeCorrect = [|numLayers*numDirections; batchSize; dout|]
         let cellShape = lstm.cell.shape
-        let cellShapeCorrect = [numLayers*numDirections; batchSize; dout]
+        let cellShapeCorrect = [|numLayers*numDirections; batchSize; dout|]
         Assert.AreEqual(hiddenShapeCorrect, hiddenShape)
         Assert.AreEqual(cellShapeCorrect, cellShape)
 
         lstm.reset()
         let hiddenShape = lstm.hidden.shape
-        let hiddenShapeCorrect = [0]
+        let hiddenShapeCorrect = [|0|]
         let cellShape = lstm.cell.shape
-        let cellShapeCorrect = [0]
+        let cellShapeCorrect = [|0|]
         Assert.AreEqual(hiddenShapeCorrect, hiddenShape)
         Assert.AreEqual(cellShapeCorrect, cellShape)
 


### PR DESCRIPTION
This is updating 

```
<PackageReference Include="coverlet.msbuild" Version="2.9.0">
  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
  <PrivateAssets>all</PrivateAssets>
</PackageReference>
<PackageReference Include="nunit" Version="3.12.0" />
<PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
```

to
```
<PackageReference Include="coverlet.msbuild" Version="3.0.3">
  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
  <PrivateAssets>all</PrivateAssets>
</PackageReference>
<PackageReference Include="nunit" Version="3.13.1" />
<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
```

I noticed nunit is suggesting >3.13 for net 5.0 and also updated other testing-related library versions to their latest stable versions as well.
https://docs.nunit.org/articles/nunit/release-notes/framework.html