### PR TITLE
Update fsdocs

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fsharp.formatting.commandtool": {
-      "version": "10.0.11",
+      "version": "10.0.17",
       "commands": [
         "fsdocs"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fsharp.formatting.commandtool": {
-      "version": "9.0.4",
+      "version": "10.0.11",
       "commands": [
         "fsdocs"
       ]

--- a/docs/content/fsdocs-custom.css
+++ b/docs/content/fsdocs-custom.css
@@ -3,11 +3,3 @@
   Customize your CSS here
 /*--------------------------------------------------------------------------*/
 
-.fsdocs-example-header {
-  font-size: 1.0rem;
-  line-height: 1.375rem;
-  letter-spacing: 0.01px;
-  font-weight: 700;
-  color: #262626;    
-}
-

--- a/docs/content/fsdocs-custom.css
+++ b/docs/content/fsdocs-custom.css
@@ -3,3 +3,11 @@
   Customize your CSS here
 /*--------------------------------------------------------------------------*/
 
+.fsdocs-example-header {
+  font-size: 1.0rem;
+  line-height: 1.375rem;
+  letter-spacing: 0.01px;
+  font-weight: 700;
+  color: #262626;    
+}
+

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -89,6 +89,12 @@ body {
 #fsdocs-content a {
     color: #4974D1;
 }
+/* remove the default bootstrap bold on dt elements */
+#fsdocs-content dt {
+    font-weight: normal;
+}
+
+
 
 /*--------------------------------------------------------------------------
   Formatting tables in fsdocs-content, using docs.microsoft.com tables
@@ -205,41 +211,13 @@ body {
     font-weight: bold;
 }
 
-.fsdocs-member-list .fsdocs-member-name {
+.fsdocs-member-list .fsdocs-member-usage {
     width: 35%;
 }
 
 /*--------------------------------------------------------------------------
   Formatting xmldoc sections in fsdocs-content
 /*--------------------------------------------------------------------------*/
-
-.fsdocs-xmldoc {
-    font-size: 1.0rem;
-    line-height: 1.375rem;
-    letter-spacing: 0.01px;
-    font-weight: 500;
-    color: #262626;    
-}
-
-.fsdocs-xmldoc h1 {
-    font-size: 1.2rem;
-    margin: 10px 0px 0px 0px;
-}
-
-.fsdocs-xmldoc h2 {
-    font-size: 1.2rem;
-    margin: 10px 0px 0px 0px;
-}
-
-.fsdocs-xmldoc h3 {
-    font-size: 1.1rem;
-    margin: 10px 0px 0px 0px;
-}
-
-/* #fsdocs-nav .searchbox {
-    margin-top: 30px;
-    margin-bottom: 30px;
-} */
 
 #fsdocs-nav img.logo{
     width:90%;
@@ -327,7 +305,7 @@ body {
 }
 
 #fsdocs-content pre.fssnip code {
-    font: 0.85rem 'Roboto Mono', monospace;
+        font: 9pt 'Droid Sans Mono',consolas,monospace;
 }
 
 #fsdocs-content table.pre pre {
@@ -350,14 +328,6 @@ body {
 
 #fsdocs-content pre {
     word-wrap: inherit;
-}
-
-.fsdocs-example-header {
-    font-size: 1.0rem;
-    line-height: 1.375rem;
-    letter-spacing: 0.01px;
-    font-weight: 700;
-    color: #262626;    
 }
 
 /*--------------------------------------------------------------------------

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -219,6 +219,34 @@ body {
   Formatting xmldoc sections in fsdocs-content
 /*--------------------------------------------------------------------------*/
 
+.fsdocs-xmldoc, .fsdocs-entity-xmldoc, .fsdocs-member-xmldoc {
+    font-size: 1.0rem;
+    line-height: 1.375rem;
+    letter-spacing: 0.01px;
+    font-weight: 500;
+    color: #262626;    
+}
+
+.fsdocs-xmldoc h1 {
+    font-size: 1.2rem;
+    margin: 10px 0px 0px 0px;
+}
+
+.fsdocs-xmldoc h2 {
+    font-size: 1.2rem;
+    margin: 10px 0px 0px 0px;
+}
+
+.fsdocs-xmldoc h3 {
+    font-size: 1.1rem;
+    margin: 10px 0px 0px 0px;
+}
+
+/* #fsdocs-nav .searchbox {
+    margin-top: 30px;
+    margin-bottom: 30px;
+} */
+
 #fsdocs-nav img.logo{
     width:90%;
     /* height:140px; */
@@ -305,7 +333,7 @@ body {
 }
 
 #fsdocs-content pre.fssnip code {
-        font: 9pt 'Droid Sans Mono',consolas,monospace;
+    font: 0.85rem 'Roboto Mono', monospace;
 }
 
 #fsdocs-content table.pre pre {
@@ -328,6 +356,14 @@ body {
 
 #fsdocs-content pre {
     word-wrap: inherit;
+}
+
+.fsdocs-example-header {
+    font-size: 1.0rem;
+    line-height: 1.375rem;
+    letter-spacing: 0.01px;
+    font-weight: 700;
+    color: #262626;    
 }
 
 /*--------------------------------------------------------------------------


### PR DESCRIPTION
Updates fsdocs to latest which allows API cross-references to be used

This update also adds buttons to copy the markdown or XML text needed for cross references, e.g. 

![image](https://user-images.githubusercontent.com/7204669/114573829-a137f000-9c70-11eb-9b3c-888e9a467dd0.png)

We should likely use a "link" logo rather than a clipboard but hey

These are currently added to every member and entiry in the generated lists.  This makes them a little visually intrusive but we should just live with it for now.  When we switch to generating a page for each member we can switch to having these on each actual target page rather than in the long generated lists

