### PR TITLE
use deploy key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Deploy docs
       uses: peaceiris/actions-gh-pages@v3
       with:
-        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        deploy_key: ${{ secrets.DIFFSHARP_GITHUB_IO_DEPLOY_DOCS_PRIVATE_KEY }}
         external_repository: DiffSharp/diffsharp.github.io
         publish_dir: ./output
         publish_branch: master


### PR DESCRIPTION
Use a deploy key for the docs. See https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-ssh-private-key-deploy_key for instructions.

* This is a key specifically with write access to diffsharp.github.io
* The key was generated locally per instructions
* The private key is registered a secret in this repo https://github.com/DiffSharp/DiffSharp/settings/secrets/actions
* The public key is added as a deploy key to https://github.com/DiffSharp/diffsharp.github.io/settings/keys


