### PR TITLE
turn of eval of sample model training

### DIFF
--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -123,7 +123,7 @@ dsharp.grad f (dsharp.tensor(1.83))
 (**
 Define a model and optimize it:
 *)
-
+(*** do-not-eval-file ****)
 open DiffSharp.Data
 open DiffSharp.Model
 open DiffSharp.Util


### PR DESCRIPTION

Documentation generation is taking too long when it includes training the sample model

So do not eval this part of the docs