### PR TITLE
Make Random.UUID reproducible

### DIFF
--- a/src/DiffSharp.Core/Util.fs
+++ b/src/DiffSharp.Core/Util.fs
@@ -55,6 +55,17 @@ type Random() =
     /// Samples a random value from the normal distribution with the given mean and standard deviation.
     static member Normal(mean, stddev) = mean + Random.Normal() * stddev
 
+    /// Samples a double value in the range [0, 1)
+    static member Double() = rnd.NextDouble()
+
+    /// Samples a double value in the given range [low, high)
+    static member Double(low, high) = 
+        if high <= low then failwithf "Expecting high > low"
+        low + rnd.NextDouble() * (high-low)
+
+    /// Samples a non-negative random integer
+    static member Integer() = rnd.Next()
+
     /// Samples a random integer in the given range [low, high).
     static member Integer(low, high) = rnd.Next(low, high)
 
@@ -88,7 +99,13 @@ type Random() =
     static member Bernoulli() = Random.Bernoulli(0.5)
 
     /// Returns a universally unique identifier (UUID) string
-    static member UUID() = System.Guid.NewGuid().ToString()
+    // https://en.wikipedia.org/wiki/Universally_unique_identifier
+    static member UUID() = 
+        // We don't use System.Guid.NewGuid().ToString() because it relies on a separate randomness source whose seed we cannot control through System.Random(seed)
+        let bytes = Array.zeroCreate (sizeof<Guid>)
+        rnd.NextBytes(bytes)
+        let guid = new Guid(bytes)
+        guid.ToString()
 
     /// Returns an array that is a randomly-shuffled version of the given array, using the Durstenfeld/Knuth shuffle.
     static member Shuffle(array:_[]) =

--- a/src/DiffSharp.Core/Util.fs
+++ b/src/DiffSharp.Core/Util.fs
@@ -60,7 +60,7 @@ type Random() =
 
     /// Samples a double value in the given range [low, high)
     static member Double(low, high) = 
-        if high <= low then failwithf "Expecting high > low"
+        if high < low then failwithf "Expecting high >= low"
         low + rnd.NextDouble() * (high-low)
 
     /// Samples a non-negative random integer

--- a/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
+++ b/tests/DiffSharp.Tests/DiffSharp.Tests.fsproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="TestUtil.fs" />
+    <Compile Include="TestUtils.fs" />
     <Compile Include="TestCombo.fs" />
     <Compile Include="TestCombos.fs" />
     <Compile Include="TestTensor.fs" />
@@ -30,6 +30,7 @@
     <Compile Include="TestDerivatives.Conv.fs" />
     <Compile Include="TestDerivatives.MaxPool.fs" />
     <Compile Include="TestDerivatives.Nested.fs" />
+    <Compile Include="TestRandom.fs" />
     <Compile Include="TestDistributions.fs" />
     <Compile Include="TestExtensions.fs" />
     <Compile Include="TestData.fs" />

--- a/tests/DiffSharp.Tests/TestRandom.fs
+++ b/tests/DiffSharp.Tests/TestRandom.fs
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-     University of Oxford (Atilim Gunes Baydin <gunes@robots.ox.ac.uk>)
+// and other contributors, see LICENSE in root of repository.
+//
+// BSD 2-Clause License. See LICENSE in root of repository.
+
+namespace Tests
+
+open NUnit.Framework
+open DiffSharp.Util
+
+[<TestFixture>]
+type TestRandom () =
+
+    [<Test>]
+    member _.TestRandomSeed () =
+        Random.Seed(1)
+        let a1 = Random.Uniform()
+        Random.Seed(1)
+        let a2 = Random.Uniform()
+        let a3 = Random.Uniform()
+
+        Assert.AreEqual(a1, a2)
+        Assert.AreNotEqual(a2, a3)
+
+    [<Test>]
+    member _.TestRandomUUID () =
+        Random.Seed(1)
+        let a1 = Random.UUID()
+        Random.Seed(1)
+        let a2 = Random.UUID()
+        let a3 = Random.UUID()
+
+        Assert.AreEqual(a1, a2)
+        Assert.AreNotEqual(a2, a3)

--- a/tests/DiffSharp.Tests/TestUtils.fs
+++ b/tests/DiffSharp.Tests/TestUtils.fs
@@ -17,7 +17,7 @@ module TestUtils =
 
     type Assert with 
 
-        /// Like Assert.AreEqual bute requires theat the actual and expected are the same type
+        /// Like Assert.AreEqual bute requires that the actual and expected are the same type
         static member CheckEqual (expected: 'T, actual: 'T) = Assert.AreEqual(box expected, box actual)
 
     type dsharp with


### PR DESCRIPTION
This is fixing an issue I noticed with `Random.UUID` which we expect to be reproducible given the random number seed. Previous implementation relying on `System.Guid.NewGuid()` was using a separate randomness source whose seed we cannot set as a part of `Random.Seed`.

In general we expect every random behavior based on diffsharp to be reproducible given the random number seed. It's an essential requirement for many ML experiments and pipelines.