### PR TITLE
Make PR github actions run in the target branch

### DIFF
--- a/.github/workflows/pull-request-debug.yml
+++ b/.github/workflows/pull-request-debug.yml
@@ -1,7 +1,7 @@
 name: Build/test Debug
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - '**'
 
@@ -23,26 +23,6 @@ jobs:
     - name: Build
       run: dotnet build --configuration Debug --no-restore --verbosity normal
     - name: Test
-      run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover --configuration Debug --no-restore --verbosity normal
-    - name: Get git commit info
-      run: |
-        echo "GIT_COMMIT_AUTHOR=$(git log -1 --pretty=%cn)" >> $GITHUB_ENV
-        echo "GIT_COMMIT_AUTHOR_EMAIL=$(git log -1 --pretty=%ce)" >> $GITHUB_ENV
-        echo "GIT_COMMIT_MESSAGE=$(git log -1 --pretty=%s)" >> $GITHUB_ENV
-    - name: Run coveralls
-      run: >
-        dotnet csmacnz.Coveralls
-        --opencover -i tests/DiffSharp.Tests/coverage.opencover.xml
-        --useRelativePaths
-        --repoToken ${{ secrets.COVERALLS_REPO_TOKEN }}
-        --commitId ${{ github.sha }}
-        --commitBranch ${{ github.ref }}
-        --commitAuthor "${{ env.GIT_COMMIT_AUTHOR }}"
-        --commitEmail ${{ env.GIT_COMMIT_AUTHOR_EMAIL }}
-        --commitMessage "${{ env.GIT_COMMIT_MESSAGE }}"
-        --jobId ${{ github.run_number }}
-    # 16 Apr 2021: disabling codecov due to bash uploader security concern
-    # - name: Codecov
-      # uses: codecov/codecov-action@v1
+      run: dotnet test --configuration Debug --no-restore --verbosity normal
     - name: Run fsdocs
       run: dotnet fsdocs build --eval --strict

--- a/.github/workflows/pull-request-debug.yml
+++ b/.github/workflows/pull-request-debug.yml
@@ -1,7 +1,7 @@
 name: Build/test Debug
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - '**'
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,7 @@
 name: Build/test Release
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - '**'
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,7 @@
 name: Build/test Release
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - '**'
 


### PR DESCRIPTION
This intends to fix the failing CI code coverage upload exemplified in #331. At first I was planning to make secrets available to PRs using the new `pull_request_target` event: https://nathandavison.com/blog/github-actions-and-the-threat-of-malicious-pull-requests 

But later I changed my mind and now think that we can just disable code coverage for PRs altogether. This was prompted by reading https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

So for the time being let's keep this safe and simple without any possibility of repo secrets leaking to forker repo builds.