### PR TITLE
Reverse derivative improvements

### DIFF
--- a/src/DiffSharp.Core/DiffSharp.fs
+++ b/src/DiffSharp.Core/DiffSharp.fs
@@ -1285,7 +1285,13 @@ type dsharp with
     static member evalReverseDiff f x =
         let x = x |> dsharp.reverseDiff (GlobalNestingLevel.Next())
         let fx = f x
-        let r = fun v -> fx |> dsharp.reverse v; x.derivative
+        let r = 
+            fun v -> 
+                fx |> dsharp.reverse v
+                // We create the derivative as zero in cases where fx does not depend on x, as this is mathematically correct
+                // Alternatively, we can introduce a "strict" mode like PyTorch and raise an exception when this situation occurs
+                if x.derivative.shape = [|0|] then (x.zerosLike())
+                else x.derivative
         fx.primal, r
 
     /// <summary>TBD</summary>
@@ -1309,7 +1315,7 @@ type dsharp with
     /// <param name="v">TBD</param>
     /// <remarks>The <c>x</c> and <c>v</c> tensors should have the same number of elements.</remarks>
     static member fjacobianv f (x:Tensor) (v:Tensor) = 
-        if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
+        if x.shape <> v.shape then failwithf "x and v must have the same shape, encountered: %A %A" x.shape v.shape
         let fx, d = dsharp.evalForwardDiff f x v
         if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, d
@@ -1323,7 +1329,7 @@ type dsharp with
     /// <param name="v">TBD</param>
     /// <remarks>The <c>x</c> and <c>v</c> tensors should have the same number of elements.</remarks>
     static member fgradv f (x:Tensor) (v:Tensor) =
-        if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
+        if x.shape <> v.shape then failwithf "x and v must have the same shape, encountered: %A %A" x.shape v.shape
         let fx, d = dsharp.evalForwardDiff f x v
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, d
@@ -1364,8 +1370,8 @@ type dsharp with
     /// <param name="v">Vector</param>
     static member fjacobianTv f x (v:Tensor) =
         let fx, r = dsharp.evalReverseDiff f x
-        if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
-        if fx.nelement <> v.nelement then failwithf "(f x) and v must have the same number of elements"
+        if x.dim <> 1 || fx.dim > 1 then failwithf "f must be a vector or scalar valued function of a vector, encountered f:%A->%A" x.shape fx.shape
+        if fx.shape <> v.shape then failwithf "(f x) and v must have the same shape, encountered: %A %A" fx.shape v.shape
         fx, r v
 
     /// <summary>Transposed Jacobian-vector product of a vector-to-vector function `f`, at point `x`, along vector `v`</summary>
@@ -1379,9 +1385,9 @@ type dsharp with
         let fx, r = dsharp.evalReverseDiff f x
         if x.dim <> 1 || fx.dim <> 1 then failwithf "f must be a vector-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         if x.nelement > fx.nelement then
-            fx, dsharp.stack(Array.init fx.nelement (fun i -> r (x.onehotLike(fx.nelement, i))), 0)
+            fx, dsharp.stack(Array.init fx.nelement (fun i -> r (fx.onehotLike(fx.nelement, i).viewAs(fx))), 0)
         else
-            fx, dsharp.stack(Array.init x.nelement (fun j -> dsharp.jacobianv f x (x.onehotLike(x.nelement, j))), 1)
+            fx, dsharp.stack(Array.init x.nelement (fun j -> dsharp.jacobianv f x (x.onehotLike(x.nelement, j).viewAs(x))), 1)
 
     /// <summary>TBD</summary>
     static member jacobian f x = dsharp.fjacobian f x |> snd
@@ -1400,11 +1406,11 @@ type dsharp with
 
     /// <summary>TBD</summary>
     static member fgradhessianv f (x:Tensor) (v:Tensor) =
-        if x.nelement <> v.nelement then failwithf "x and v must have the same number of elements"
-        let x = x |> dsharp.reverseDiff (GlobalNestingLevel.Next())
-        let fx, gv = dsharp.fgradv f x v
-        gv.reverse()
-        fx.primal, gv.primal, x.derivative
+        if x.shape <> v.shape then failwithf "x and v must have the same shape, encountered: %A %A" x.shape v.shape
+        let mutable fx = x.zerosLike([])
+        let gradv x_ = let fx_, gv_ = dsharp.fgradv f x_ v in fx <- fx_; gv_
+        let gv, hv = dsharp.fjacobianTv gradv x (dsharp.tensor(1.))
+        fx, gv, hv
 
     /// <summary>TBD</summary>
     static member gradhessianv f x v = let _, gv, hv = dsharp.fgradhessianv f x v in gv, hv
@@ -1417,8 +1423,8 @@ type dsharp with
 
     /// <summary>TBD</summary>
     static member fgradhessian (f:Tensor->Tensor) (x:Tensor) =
-        let mutable fx = dsharp.zero()
-        let gvs, hvs = Array.init x.nelement (fun j -> let ffxx, gv, hv = dsharp.fgradhessianv f x (x.onehotLike(x.nelement, j)) in fx <- ffxx; gv, hv) |> Array.unzip
+        let mutable fx = x.zerosLike([])
+        let gvs, hvs = Array.init x.nelement (fun j -> let ffxx, gv, hv = dsharp.fgradhessianv f x (x.onehotLike(x.nelement, j).viewAs(x)) in fx <- ffxx; gv, hv) |> Array.unzip
         let h = dsharp.stack(hvs, 1)
         let g = dsharp.stack(gvs)
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
@@ -1429,8 +1435,8 @@ type dsharp with
 
     /// <summary>TBD</summary>
     static member fhessian (f:Tensor->Tensor) (x:Tensor) =
-        let mutable fx = dsharp.zero()
-        let h = dsharp.stack(Array.init x.nelement (fun j -> let ffxx, hv = dsharp.fhessianv f x (x.onehotLike(x.nelement, j)) in fx <- ffxx; hv), 1)
+        let mutable fx = x.zerosLike([])
+        let h = dsharp.stack(Array.init x.nelement (fun j -> let ffxx, hv = dsharp.fhessianv f x (x.onehotLike(x.nelement, j).viewAs(x)) in fx <- ffxx; hv), 1)
         if x.dim <> 1 || fx.dim <> 0 then failwithf "f must be a scalar-valued function of a vector, encountered f:%A->%A" x.shape fx.shape
         fx, h
 

--- a/src/DiffSharp.Core/Shape.fs
+++ b/src/DiffSharp.Core/Shape.fs
@@ -27,12 +27,12 @@ module rec Shape =
 
     /// Checks if the given shapes are appropriate for a stack operation and returns information related to the resulting shape.
     let checkCanStack (shapes:Shape[]) (dim: int) =
-        if not (Seq.allEqual shapes) then failwith "Cannot stack Tensors with different shapes"
+        if not (Seq.allEqual shapes) then failwithf "Cannot stack tensors with different shapes: %A" shapes
         let n = shapes.Length
-        if n = 0 then failwithf "Expecting a non-empty sequence of Tensors"
+        if n = 0 then failwithf "Expecting a non-empty sequence of tensors"
         let shape = shapes.[0]
-        if dim < 0 || dim > shape.Length then invalidArg "dim" "invalid dimension"
-        if dim < 0 || dim > n then invalidArg "dim" "invalid dimension"
+        if dim < 0 || dim > shape.Length then failwithf "Expecting 0 <= dim (%A) <= %A" dim shape.Length
+        if dim < 0 || dim > n then failwithf "Expecting 0 <= dim (%A) <= %A" dim n
         let shape1 = shape.[0..dim-1]
         let shape2 = shape.[dim..]
         let outputShape = [| yield! shape1; yield n; yield! shape2 |]

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -234,7 +234,7 @@ type Tensor =
     /// </remarks>
     member t.reverseDiff(?tag:uint32) = 
         let tag = defaultArg tag GlobalNestingLevel.Current
-        TensorR(t, ref (t.zeroLike()), NewT, ref 0u, tag)
+        TensorR(t, ref (t.zerosLike([0])), NewT, ref 0u, tag)
 
     ///  Returns the input tensor but with any support for automatic differentiation removed.
     member t.noDiff() = t.primalDeep
@@ -324,7 +324,7 @@ type Tensor =
 
     /// Returns the tensor after standardization (z-score normalization)
     member t.standardize() =
-        let stddev = t.stddev()
+        let stddev:Tensor = t.stddev()
         if stddev = t.zeroLike() || stddev.hasnan() then
             t.zerosLike()
         else
@@ -341,7 +341,6 @@ type Tensor =
             sprintf "TensorR %A %s" t.shape c.Name
 
     /// A debugging routine to compute the parents of a tensor involved in reverse-mode automatic differentiation
-
     member t.parents() =
         let mutable p = []
         let rec parents (t:obj) d =
@@ -703,7 +702,7 @@ type Tensor =
                 TensorF(fp,fd,at)
             | TensorR(ap,_,_,_,at) ->
                 let fp = ap.expand(newShape)
-                TensorR(fp, ref (a.zeroLike()), ExpandT(a), ref 0u, at)
+                TensorR(fp, ref (a.zerosLike([0])), ExpandT(a), ref 0u, at)
 
     /// <summary>Expand this tensor to the same size as the other.</summary>
     member a.expandAs(b:Tensor) = a.expand(b.shape)
@@ -788,7 +787,7 @@ type Tensor =
         match t with
         | TensorC(ap) -> TensorC(ap.GetSlice(fullBounds))
         | TensorF(ap,ad,at) -> TensorF(ap.GetSlice(fullBounds), ad.GetSlice(fullBounds), at)
-        | TensorR(ap,_,_,_,at) -> TensorR(ap.GetSlice(fullBounds), ref (ap.zeroLike()), SliceT(t, fullBounds), ref 0u, at)
+        | TensorR(ap,_,_,_,at) -> TensorR(ap.GetSlice(fullBounds), ref (ap.zerosLike([0])), SliceT(t, fullBounds), ref 0u, at)
 
     /// <summary>Get the item at the given index as a scalar tensor.</summary>
     member t.Item
@@ -857,7 +856,7 @@ type Tensor =
         | TensorR(_,_,_,_,at) ->
             let ap = tensors |> Seq.map (fun t -> t.primal)
             let fp = Tensor.stack(ap,dim=dim)
-            TensorR(fp, ref (fp.zeroLike()), StackTs(tensors, dim), ref 0u, at)
+            TensorR(fp, ref (fp.zerosLike([0])), StackTs(tensors, dim), ref 0u, at)
 
     /// <summary>Removes a tensor dimension.</summary>
     /// <param name="dim">The dimension to remove, defaults to 0.</param>
@@ -868,7 +867,7 @@ type Tensor =
         match a with
         | TensorC(ap) -> ap.UnstackT(dim) |> Array.map TensorC
         | TensorF(ap,ad,at) -> Array.map2 (fun p d -> TensorF(p,d,at)) (ap.unstack(dim)) (ad.unstack(dim))
-        | TensorR(ap,_,_,_,at) -> Array.mapi (fun i p -> TensorR(p, ref (p.zeroLike()), UnstackT(a, dim, i), ref 0u, at)) (ap.unstack(dim))
+        | TensorR(ap,_,_,_,at) -> Array.mapi (fun i p -> TensorR(p, ref (p.zerosLike([0])), UnstackT(a, dim, i), ref 0u, at)) (ap.unstack(dim))
 
     /// <summary>Concatenates the given sequence of seq tensors in the given dimension.</summary>
     /// <remarks>All tensors must either have the same shape (except in the concatenating dimension) or be empty.</remarks>
@@ -893,7 +892,7 @@ type Tensor =
         | TensorR(_,_,_,_,at) ->
             let ap = tensors |> Seq.map (fun t -> t.primal)
             let fp = Tensor.cat(ap, dim=dim)
-            TensorR(fp, ref (fp.zeroLike()), CatTs(tensors, dim), ref 0u, at)
+            TensorR(fp, ref (fp.zerosLike([0])), CatTs(tensors, dim), ref 0u, at)
 
     /// <summary>Splits the tensor into chunks. Each chunk is a view of the original tensor.</summary>
     /// <param name="sizes">List of sizes for each chunk</param>
@@ -904,7 +903,7 @@ type Tensor =
         match a with
         | TensorC(ap) -> ap.SplitT(sizes, dim=dim) |> Array.map TensorC
         | TensorF(ap,ad,at) -> Array.map2 (fun p d -> TensorF(p,d,at)) (ap.split(sizes)) (ad.split(sizes, dim=dim))
-        | TensorR(ap,_,_,_,at) -> Array.mapi (fun i p -> TensorR(p, ref (p.zeroLike()), SplitT(a, sizes, dim, i), ref 0u, at)) (ap.split(sizes, dim=dim))
+        | TensorR(ap,_,_,_,at) -> Array.mapi (fun i p -> TensorR(p, ref (p.zerosLike([0])), SplitT(a, sizes, dim, i), ref 0u, at)) (ap.split(sizes, dim=dim))
 
     /// <summary>Pipeline the tensor into a function.</summary>
     static member inline (-->) (t:Tensor, f:Tensor -> ^a) = f t
@@ -913,27 +912,27 @@ type Tensor =
         match a with
         | TensorC(ap)           -> TensorC(fRaw(ap))
         | TensorF(ap,ad,at)    -> let fp = fTensor(ap) in TensorF(fp, dfFwd(ap,ad,fp), at)
-        | TensorR(ap,_,_,_,at) -> let fp = fTensor(ap) in TensorR(fp, ref (a.zeroLike()), dfRev(a), ref 0u, at)
+        | TensorR(ap,_,_,_,at) -> let fp = fTensor(ap) in TensorR(fp, ref (a.zerosLike([0])), dfRev(a), ref 0u, at)
 
     static member inline internal OpBinary(a, b, fRaw: RawTensor * RawTensor -> RawTensor, fTensor, dfFwdTT, dfFwdTC, dfFwdCT, dfRevTT, dfRevTC, dfRevCT) =
         match a, b with
         | TensorC(ap),          TensorC(bp)                     -> TensorC(fRaw(ap, bp))
         | TensorC(_),           TensorF(bp,bd,bt)               -> let fp = fTensor(a,bp)  in TensorF(fp, dfFwdCT(bp,bd,fp), bt)
-        | TensorC(_),           TensorR(bp,_,_,_,bt)            -> let fp = fTensor(a,bp)  in TensorR(fp, ref (a.zeroLike()), dfRevCT(a,b), ref 0u, bt)
+        | TensorC(_),           TensorR(bp,_,_,_,bt)            -> let fp = fTensor(a,bp)  in TensorR(fp, ref (a.zerosLike([0])), dfRevCT(a,b), ref 0u, bt)
         | TensorF(ap,ad,at),    TensorC(_)                      -> let fp = fTensor(ap,b)  in TensorF(fp, dfFwdTC(ap,ad,fp), at)
         | TensorF(ap,ad,at),    TensorF(bp,bd,bt)    when at=bt -> let fp = fTensor(ap,bp) in TensorF(fp, dfFwdTT(ap,ad,bp,bd,fp), at)
         | TensorF(ap,ad,at),    TensorF(_,_,bt)      when at>bt -> let fp = fTensor(ap,b)  in TensorF(fp, dfFwdTC(ap,ad,fp), at)
         | TensorF(_,_,at),      TensorF(bp,bd,bt)    when at<bt -> let fp = fTensor(a,bp)  in TensorF(fp, dfFwdCT(bp,bd,fp), bt)
         | TensorF(_,_,at),      TensorR(_,_,_,_,bt)  when at=bt -> failwith "Cannot have TensorF and TensorR in the same nesting level"
         | TensorF(ap,ad,at),    TensorR(_,_,_,_,bt)  when at>bt -> let fp = fTensor(ap,b)  in TensorF(fp, dfFwdTC(ap,ad,fp), at)
-        | TensorF(_,_,at),      TensorR(bp,_,_,_,bt) when at<bt -> let fp = fTensor(a,bp)  in TensorR(fp, ref (a.zeroLike()), dfRevCT(a,b), ref 0u, bt)
-        | TensorR(ap,_,_,_,at), TensorC(_)                      -> let fp = fTensor(ap,b)  in TensorR(fp, ref (a.zeroLike()), dfRevTC(a,b), ref 0u, at)
+        | TensorF(_,_,at),      TensorR(bp,_,_,_,bt) when at<bt -> let fp = fTensor(a,bp)  in TensorR(fp, ref (a.zerosLike([0])), dfRevCT(a,b), ref 0u, bt)
+        | TensorR(ap,_,_,_,at), TensorC(_)                      -> let fp = fTensor(ap,b)  in TensorR(fp, ref (a.zerosLike([0])), dfRevTC(a,b), ref 0u, at)
         | TensorR(_,_,_,_,at),  TensorF(_,_,bt)      when at=bt -> failwith "Cannot have TensorR and TensorF in the same nesting level"
-        | TensorR(ap,_,_,_,at), TensorF(_,_,bt)      when at>bt -> let fp = fTensor(ap,b) in TensorR(fp, ref (a.zeroLike()), dfRevTC(a,b), ref 0u, at)
+        | TensorR(ap,_,_,_,at), TensorF(_,_,bt)      when at>bt -> let fp = fTensor(ap,b) in TensorR(fp, ref (a.zerosLike([0])), dfRevTC(a,b), ref 0u, at)
         | TensorR(_,_,_,_,at),  TensorF(bp,bd,bt)    when at<bt -> let fp = fTensor(a,bp)  in TensorF(fp, dfFwdCT(bp,bd,fp), bt)
-        | TensorR(ap,_,_,_,at), TensorR(bp,_,_,_,bt) when at=bt -> let fp = fTensor(ap,bp) in TensorR(fp, ref (a.zeroLike()), dfRevTT(a,b), ref 0u, at)
-        | TensorR(ap,_,_,_,at), TensorR(_,_,_,_,bt)  when at>bt -> let fp = fTensor(ap,b)  in TensorR(fp, ref (a.zeroLike()), dfRevTC(a,b), ref 0u, at)
-        | TensorR(_,_,_,_,at),  TensorR(bp,_,_,_,bt) when at<bt -> let fp = fTensor(a,bp)  in TensorR(fp, ref (a.zeroLike()), dfRevCT(a,b), ref 0u, bt)
+        | TensorR(ap,_,_,_,at), TensorR(bp,_,_,_,bt) when at=bt -> let fp = fTensor(ap,bp) in TensorR(fp, ref (a.zerosLike([0])), dfRevTT(a,b), ref 0u, at)
+        | TensorR(ap,_,_,_,at), TensorR(_,_,_,_,bt)  when at>bt -> let fp = fTensor(ap,b)  in TensorR(fp, ref (a.zerosLike([0])), dfRevTC(a,b), ref 0u, at)
+        | TensorR(_,_,_,_,at),  TensorR(bp,_,_,_,bt) when at<bt -> let fp = fTensor(a,bp)  in TensorR(fp, ref (a.zerosLike([0])), dfRevCT(a,b), ref 0u, bt)
         | _ -> failwith "Unexpected combination of Tensors" // Won't happen, added for suppressing "incomplete matches" warning
 
     /// <summary>Each element of the tensor <paramref name="a" /> is added to each corresponding element of the tensor <paramref name="b" />. The resulting tensor is returned.</summary>
@@ -1723,7 +1722,7 @@ type Tensor =
         match a with
         | TensorC(ap)          -> let result, mask = ap.ClampT(lowTensor.primalRaw, highTensor.primalRaw), mask() in TensorC(result), mask
         | TensorF(ap,ad,at)    -> let result, mask = ap.clampWithMask(?low=low, ?high=high) in TensorF(result, ad * mask, at), mask
-        | TensorR(ap,_,_,_,at) -> let result, mask = ap.clampWithMask(?low=low, ?high=high) in TensorR(result, ref (a.zeroLike()), ClampT(a, mask), ref 0u, at), mask
+        | TensorR(ap,_,_,_,at) -> let result, mask = ap.clampWithMask(?low=low, ?high=high) in TensorR(result, ref (a.zerosLike([0])), ClampT(a, mask), ref 0u, at), mask
 
     /// <summary>Clamp all elements in input into the range [ low..high] and return a resulting tensor</summary>
     /// <param name="low">The lower-bound of the range to be clamped to.</param>
@@ -2141,7 +2140,7 @@ type Tensor =
         match a with
         | TensorC(ap)          -> let result, indices = ap.MaxPool1D(kernelSize, stride, padding) in TensorC(result), TensorC(indices)
         | TensorF(ap,ad,at)    -> let result, indices = ap.maxpool1di(kernelSize, stride, padding) in TensorF(result, ad.gather(dim=2, indices=indices), at), indices
-        | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool1di(kernelSize, stride, padding) in TensorR(result, ref (a.zeroLike()), MaxPool1DT(a, indices, kernelSize), ref 0u, at), indices
+        | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool1di(kernelSize, stride, padding) in TensorR(result, ref (a.zerosLike([0])), MaxPool1DT(a, indices, kernelSize), ref 0u, at), indices
 
     /// <summary>Applies a 1D max pooling over an input signal composed of several input planes.</summary>
     /// <param name="kernelSize">The size of the window to take a max over.</param>
@@ -2184,7 +2183,7 @@ type Tensor =
         match a with
         | TensorC(ap)          -> let result, indices = ap.MaxPool2D(kernelSizes, strides, paddings) in TensorC(result), TensorC(indices)
         | TensorF(ap,ad,at)    -> let result, indices = ap.maxpool2di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorF(result, ad.flatten(startDim=2).gather(dim=2, indices=indices.flatten(startDim=2)).viewAs(indices), at), indices
-        | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool2di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorR(result, ref (a.zeroLike()), MaxPool2DT(a, indices, kernelSizes), ref 0u, at), indices
+        | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool2di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorR(result, ref (a.zerosLike([0])), MaxPool2DT(a, indices, kernelSizes), ref 0u, at), indices
 
     /// <summary>Applies a 2D max pooling over an input signal composed of several input planes.</summary>
     /// <param name="kernelSize">The size of the window to take a max over.</param>
@@ -2233,7 +2232,7 @@ type Tensor =
         match a with
         | TensorC(ap)          -> let result, indices = ap.MaxPool3D(kernelSizes, strides, paddings) in TensorC(result), TensorC(indices)
         | TensorF(ap,ad,at)    -> let result, indices = ap.maxpool3di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorF(result, ad.flatten(startDim=2).gather(dim=2, indices=indices.flatten(startDim=2)).viewAs(indices), at), indices
-        | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool3di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorR(result, ref (a.zeroLike()), MaxPool3DT(a, indices, kernelSizes), ref 0u, at), indices
+        | TensorR(ap,_,_,_,at) -> let result, indices = ap.maxpool3di(kernelSizes=kernelSizes, strides=strides, paddings=paddings) in TensorR(result, ref (a.zerosLike([0])), MaxPool3DT(a, indices, kernelSizes), ref 0u, at), indices
 
     /// <summary>Applies a 3D max pooling over an input signal composed of several input planes.</summary>
     /// <param name="kernelSize">The size of the window to take a max over.</param>
@@ -2553,6 +2552,7 @@ type Tensor =
     member inline t.backward(value) = t.reverse(value)
 
     /// <summary>Reset the reverse mode computation associated with the given output tensor.</summary>
+    // TODO: other designs without this reverseReset function are possible, but they introduce more complications in the handling of fanout counters and multiple reverse passes of the same graph
     member t.reverseReset(zeroDerivatives:bool) =
         let rec reset (ts: Tensor list) =
             match ts with
@@ -2561,6 +2561,7 @@ type Tensor =
                 match t with
                 | TensorR(_,_,o,_,_) ->
                     if zeroDerivatives then t.derivative <- t.zeroLike()
+                    elif t.derivative.shape = [|0|] then t.derivative <- t.zeroLike()
                     t.fanout <- t.fanout + 1u
                     if t.fanout = 1u then
                         match o with

--- a/tests/DiffSharp.Tests/TestDiffSharp.fs
+++ b/tests/DiffSharp.Tests/TestDiffSharp.fs
@@ -511,6 +511,33 @@ type TestDiffSharp () =
         Assert.True(hCorrect.allclose(nh4, 0.1))
 
     [<Test>]
+    member this.TestHessianNotTwiceDifferentiable () =
+        let x = dsharp.tensor([1.5, 2.5])
+        let f (x:Tensor) = x.sum() // Not twice differentiable
+        let fx1, h1 = dsharp.fhessian f x
+        let fx2, h2 = dsharp.fh f x
+        let h3 = dsharp.hessian f x
+        let h4 = dsharp.h f x
+        let nfx1, nh1 = dsharp.numfhessian 1e-3 f x
+        let nfx2, nh2 = dsharp.numfh 1e-3 f x
+        let nh3 = dsharp.numhessian 1e-3 f x
+        let nh4 = dsharp.numh 1e-3 f x
+        let fxCorrect = f x
+        let hCorrect = dsharp.zeros([2;2]) // Mathematically correct result for a function that is not twice differentiable, not achievable via autodiff
+        Assert.CheckEqual(fxCorrect, fx1)
+        Assert.CheckEqual(fxCorrect, nfx1)
+        Assert.CheckEqual(fxCorrect, fx2)
+        Assert.CheckEqual(fxCorrect, nfx2)
+        Assert.CheckEqual(hCorrect, h1)
+        Assert.CheckEqual(hCorrect, h2)
+        Assert.CheckEqual(hCorrect, h3)
+        Assert.CheckEqual(hCorrect, h4)
+        Assert.True(hCorrect.allclose(nh1, 0.1))
+        Assert.True(hCorrect.allclose(nh2, 0.1))
+        Assert.True(hCorrect.allclose(nh3, 0.1))
+        Assert.True(hCorrect.allclose(nh4, 0.1))
+
+    [<Test>]
     member this.TestLaplacian () =
         let x = dsharp.tensor([1.5, 2.5])
         let fx, l = dsharp.flaplacian rosenbrock x

--- a/tests/DiffSharp.Tests/TestDiffSharp.fs
+++ b/tests/DiffSharp.Tests/TestDiffSharp.fs
@@ -657,3 +657,14 @@ type TestDiffSharp () =
 
         Assert.CheckEqual(y1, y2)
         Assert.CheckEqual(y1, y3)
+
+    [<Test>]
+    member _.TestReverseDiffInit () =
+        // Reverse derivative is initialized to an empty tensor (data: [], shape: [|0|], dim: 1)
+        let x = dsharp.tensor(1.).reverseDiff()
+        Assert.AreEqual(x.derivative.shape, [|0|])
+
+        // After propagation reverse derivative is a scalar tensor (shape: [||], dim: 0])
+        let y = x.exp()
+        y.reverse()
+        Assert.AreEqual(x.derivative.shape, [||])


### PR DESCRIPTION
This provides two improvements for the reverse mode implementation:
- We now distinguish unpropagated reverse derivatives from zero scalar values (`tensor(0.)`). Previously a zero scalar value in a reverse derivative could mean either an unpropagated reverse derivative or a correctly propagated zero scalar derivative. We now use an empty tensor (`tensor([])`) for unpropagated reverse derivatives so these can be noticed when needed.
- We assign all-zero derivatives when a function turns out to be non-differentiable in the reverse mode. This is solving #328 as a side effect.