### PR TITLE
bump versions

### DIFF
--- a/.github/workflows/pull-request-debug.yml
+++ b/.github/workflows/pull-request-debug.yml
@@ -6,9 +6,9 @@ on:
       - '**'
 
 jobs:
-  build:
+  build_windows:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,7 @@ on:
       - '**'
 
 jobs:
-  build ubuntu:
+  build_ubuntu:
 
     runs-on: ubuntu-latest
 
@@ -29,7 +29,7 @@ jobs:
     - name: Run fsdocs
       run: dotnet fsdocs build --eval --strict --properties Configuration=Release
 
-  build windows:
+  build_windows:
 
     runs-on: windows-latest
 
@@ -43,14 +43,12 @@ jobs:
       run: dotnet restore
     - name: Install tool dependencies
       run: dotnet tool restore
-    - name: Build (Debug, for doc scripts)
-      run: dotnet build --configuration Debug --no-restore --verbosity normal
     - name: Build (Release)
       run: dotnet build --configuration Release --no-restore --verbosity normal
     - name: Test
       run: dotnet test --configuration Release --no-restore --verbosity normal
 
-  build macos:
+  build_macos:
 
     runs-on: macos-latest
 
@@ -64,8 +62,6 @@ jobs:
       run: dotnet restore
     - name: Install tool dependencies
       run: dotnet tool restore
-    - name: Build (Debug, for doc scripts)
-      run: dotnet build --configuration Debug --no-restore --verbosity normal
     - name: Build (Release)
       run: dotnet build --configuration Release --no-restore --verbosity normal
     - name: Test

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,7 @@ on:
       - '**'
 
 jobs:
-  build:
+  build ubuntu:
 
     runs-on: ubuntu-latest
 
@@ -28,3 +28,45 @@ jobs:
       run: dotnet test --configuration Release --no-restore --verbosity normal
     - name: Run fsdocs
       run: dotnet fsdocs build --eval --strict --properties Configuration=Release
+
+  build windows:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.100
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Install tool dependencies
+      run: dotnet tool restore
+    - name: Build (Debug, for doc scripts)
+      run: dotnet build --configuration Debug --no-restore --verbosity normal
+    - name: Build (Release)
+      run: dotnet build --configuration Release --no-restore --verbosity normal
+    - name: Test
+      run: dotnet test --configuration Release --no-restore --verbosity normal
+
+  build macos:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.100
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Install tool dependencies
+      run: dotnet tool restore
+    - name: Build (Debug, for doc scripts)
+      run: dotnet build --configuration Debug --no-restore --verbosity normal
+    - name: Build (Release)
+      run: dotnet build --configuration Release --no-restore --verbosity normal
+    - name: Test
+      run: dotnet test --configuration Release --no-restore --verbosity normal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
 
-    <LibTorchNugetVersion>1.8.0.7</LibTorchNugetVersion>
-    <TorchSharpVersion>0.91.52518</TorchSharpVersion>
+    <LibTorchNugetVersion>1.9.0.3</LibTorchNugetVersion>
+    <TorchSharpVersion>0.91.52661</TorchSharpVersion>
     <FSharpCoreVersion>5.0.1</FSharpCoreVersion>
     <!-- Standard nuget.org location -->
     <RestoreSources>https://api.nuget.org/v3/index.json</RestoreSources>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
 
-    <LibTorchNugetVersion>1.9.0.3</LibTorchNugetVersion>
-    <TorchSharpVersion>0.91.52661</TorchSharpVersion>
+    <LibTorchNugetVersion>1.9.0.5</LibTorchNugetVersion>
+    <TorchSharpVersion>0.91.52666</TorchSharpVersion>
     <FSharpCoreVersion>5.0.1</FSharpCoreVersion>
     <!-- Standard nuget.org location -->
     <RestoreSources>https://api.nuget.org/v3/index.json</RestoreSources>

--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -280,7 +280,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
     override t.SplitT(sizes, dim) =
         let shape = t.Shape
         let outShapes = Shape.checkCanSplit shape sizes dim
-        let results = tt.split_with_sizes(int64s sizes, dim)
+        let results = tt.split(int64s sizes, dim)
         (results, outShapes) ||> Array.map2 (fun rvalues outShape -> 
             t.MakeLike(rvalues, shape=outShape))
 
@@ -833,7 +833,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
     override t.SinhT() =
         match dtype with 
         | Dtype.IntegralOrBool -> opNotSupported "SinhT" dtype
-        | _ ->  t.MakeLike(tt.Sinh())
+        | _ ->  t.MakeLike(tt.sinh())
 
     override t.CoshT() =
         match dtype with 
@@ -1055,7 +1055,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
 
     override _.TanInPlace() = checkMutable(); tt.tan_() |> ignore
 
-    override _.SinhInPlace() = checkMutable(); tt.Sinh_() |> ignore
+    override _.SinhInPlace() = checkMutable(); tt.sinh_() |> ignore
 
     override _.CoshInPlace() = checkMutable(); tt.cosh_() |> ignore
 


### PR DESCRIPTION

Note to self: The libtorch-cpu package is now split into

* libtorch-cpu-win-x64
* libtorch-cpu-linux-x64
* libtorch-cpu-macos-x64
* libtorch-cpu referencing the last three

DiffSharp-cpu references the last one, and is simple, but means the user getting started download all three of the other packages.   We could create corresponding bundles 

* DiffSharp-cpu-win-x64
* DiffSharp-cpu-linux-x64
* DiffSharp-cpu-macos-x64