### PR TITLE
remove MyGet feed reference from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To use locally in [Visual Studio Code](https://code.visualstudio.com/):
 
 To use locally in Jupyter, first install Jupyter and then:
 
-    dotnet tool install -g --add-source "https://dotnet.myget.org/F/dotnet-try/api/v3/index.json" microsoft.dotnet-interactive
+    dotnet tool install -g microsoft.dotnet-interactive
     dotnet interactive jupyter install
 
 When using .NET Interactive it is best to completely turn off automatic HTML displays of outputs:


### PR DESCRIPTION
The referenced feed is no longer active. I'd recommend just using the latest version available on nuget.org now.