### PR TITLE
Improve tensor to scalar conversion support

### DIFF
--- a/src/DiffSharp.Core/RawTensor.fs
+++ b/src/DiffSharp.Core/RawTensor.fs
@@ -638,7 +638,7 @@ type RawTensor() =
         member x.CompareTo(yobj) =
             match yobj with
             | :? RawTensor as y -> Unchecked.compare (x.ToScalar()) (y.ToScalar())
-            | _ -> failwithf "cannot compare RawTensor with object of type %A" (yobj.GetType())
+            | _ -> failwithf "Cannot compare RawTensor with object of type %A" (yobj.GetType())
 
     default t.GetItem(indexes) =
         let t0 = t.GetSlice(Array2D.init indexes.Length 3 (fun i j -> if j = 0 || j = 1 then indexes.[i] else 1))
@@ -646,9 +646,9 @@ type RawTensor() =
 
     /// Returns a .NET object for the value of a scalar tensor
     override t.ToScalar() =
-        match t.Dim with
-        | 0 -> (t.ToValues() :?> scalar)
-        | _ -> failwithf "Cannot convert %Ad tensor to scalar" t.Dim
+        match t.Nelement with
+        | 1 -> t.ViewT([||]).ToValues() :?> scalar
+        | _ -> failwithf "Only one element tensors can be converted to scalars. This tensor has shape %A." t.Shape
 
     /// Returns a .NET array object for the values of a non-scalar tensor
     member t.ToArray() =
@@ -657,7 +657,7 @@ type RawTensor() =
         | _ ->
             match t.ToValues() with 
             | :? System.Array as a -> a
-            | _ -> failwithf "ToValue() should return an array but returned type %A" (t.GetType())
+            | _ -> failwithf "ToValues() should return an array but returned type %A" (t.GetType())
 
     /// A backdoor to switch this tensor to be usable as a mutable tensor. You should have a unique handle to
     /// this tensor for the entire time it is being used as a mutable tensor.

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -480,6 +480,25 @@ type TestTensor () =
             Assert.CheckEqual(t3, t3Correct)
 
     [<Test>]
+    member _.TestTensorToScalar () =
+        for combo in Combos.All do
+            let t = 1.
+            let t0 = combo.tensor(t)
+            let t1 = combo.tensor([t])
+            let t2 = combo.tensor([[t]])
+            let t3 = combo.tensor([[[t]]])
+
+            let t0s = float t0
+            let t1s = float t1
+            let t2s = float t2
+            let t3s = float t3
+
+            Assert.CheckEqual(t, t0s)
+            Assert.CheckEqual(t, t1s)
+            Assert.CheckEqual(t, t2s)
+            Assert.CheckEqual(t, t3s)
+
+    [<Test>]
     member _.TestTensorOnehot () =
         for combo in Combos.All do 
             let t0 = combo.onehot(3, 0)


### PR DESCRIPTION
This enables all one-element tensors to be converted to scalars, regardless their number of dimensions. Compatible with PyTorch behavior.

Previously, only scalar (0d) tensors could be converted to scalars.