### PR TITLE
Fix numerical precision of the variance(dim) calculation

### DIFF
--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -1417,18 +1417,20 @@ type Tensor =
         let sBounds = Array2D.init a.dim 3 (fun i j -> if j=0 then 0 elif j=1 then a.shape.[i]-1 else 0)
         sBounds.[dim, 1] <- 0
         sBounds.[dim, 2] <- 1
-        let mutable s = a.zerosLike().GetSlice(sBounds)
-        let mutable sSquare = a.zerosLike().GetSlice(sBounds)
+        let mutable mean = a.zerosLike().GetSlice(sBounds)
+        let mutable sse = a.zerosLike().GetSlice(sBounds)
         let n = a.shape.[dim]
         for i=0 to n-1 do
             sBounds.[dim,0] <- i
             sBounds.[dim,1] <- i
             sBounds.[dim,2] <- 1
             let slice = a.GetSlice(sBounds)
-            s <- s + slice
-            sSquare <- sSquare + slice * slice
+            let delta = slice - mean
+            mean <- mean + delta / (i + 1)
+            let delta2 = slice - mean 
+            sse <- sse + delta * delta2
         let nn = if unbiased then n - 1 else n
-        let res = (sSquare - (s * s) / n) / nn
+        let res = sse / nn
         if keepDim then res.unsqueeze(dim) else res
 
     /// <summary>Returns the standard deviation of each row of the input tensor in the given dimension dim.</summary>

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -2609,6 +2609,13 @@ type TestTensor () =
             Assert.CheckEqual(tVarianceBiased1.dtype, combo.dtype)
             Assert.CheckEqual(tVarianceBiased2.dtype, combo.dtype)
 
+        let tPrecisionCheckData = dsharp.tensor([1e10+4.0; 1e10+7.0; 1e10+13.0;1e10+16.0],dtype=Float64)
+        let tPrecisionCheck = tPrecisionCheckData.variance()
+        let tPrecisionCheck0 = tPrecisionCheckData.variance(0)
+        let tPrecisionCheckCorrect = dsharp.tensor(30.0,dtype=Float64)
+        Assert.True(tPrecisionCheck.allclose(tPrecisionCheckCorrect, 0.01, 0.01))
+        Assert.True(tPrecisionCheck0.allclose(tPrecisionCheckCorrect, 0.01, 0.01))
+
     [<Test>]
     member _.TestTensorVarianceKeepDim () =
         for combo in Combos.FloatingPoint do 


### PR DESCRIPTION
The prior naive variance(dim) algorithm had issues with numerical precision. See https://github.com/DiffSharp/DiffSharp/issues/336

This uses Welford's online algorithm and includes tests to catch numerical precision issues. I also added a test case to catch precision issues when the algorithm is rewritten (the precision test is only done for Float64).

The algorithm is discussed on [wikipedia](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) with the original source [here](https://www.jstor.org/stable/1266577).

This is the same algorithm used by FSharp.Stats ([source link](https://github.com/fslaborg/FSharp.Stats/blob/a4005abc1232e5336c31ee6dae0e6179eb848407/src/FSharp.Stats/Seq.fs#L316))