### PR TITLE
Update torchsharp to 0.91.52719

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
 
     <LibTorchNugetVersion>1.9.0.10</LibTorchNugetVersion>
-    <TorchSharpVersion>0.91.52681</TorchSharpVersion>
+    <TorchSharpVersion>0.91.52719</TorchSharpVersion>
     <FSharpCoreVersion>5.0.2</FSharpCoreVersion>
     <!-- Standard nuget.org location -->
     <RestoreSources>https://api.nuget.org/v3/index.json</RestoreSources>

--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -10,7 +10,6 @@ open DiffSharp
 open DiffSharp.Backends
 open DiffSharp.Util
 open TorchSharp
-// open TorchSharp.Tensor
 
 type TorchShape = int64[]
 type TorchDevice = Torch.Device

--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -10,7 +10,7 @@ open DiffSharp
 open DiffSharp.Backends
 open DiffSharp.Util
 open TorchSharp
-open TorchSharp.Tensor
+// open TorchSharp.Tensor
 
 type TorchShape = int64[]
 type TorchDevice = Torch.Device
@@ -22,39 +22,39 @@ module internal Utils =
 
     let toTorchType dtype =
         match dtype with 
-        | Dtype.Bool -> ScalarType.Bool
-        | Dtype.Int8 -> ScalarType.Int8
-        | Dtype.Byte -> ScalarType.Byte
-        | Dtype.Int16 -> ScalarType.Int16
-        | Dtype.Int32 -> ScalarType.Int32
-        | Dtype.Int64 -> ScalarType.Int64
-        | Dtype.Float16 -> ScalarType.Float16
-        | Dtype.BFloat16 -> ScalarType.BFloat16
-        | Dtype.Float32 -> ScalarType.Float32
-        | Dtype.Float64 -> ScalarType.Float64
+        | Dtype.Bool -> torch.ScalarType.Bool
+        | Dtype.Int8 -> torch.ScalarType.Int8
+        | Dtype.Byte -> torch.ScalarType.Byte
+        | Dtype.Int16 -> torch.ScalarType.Int16
+        | Dtype.Int32 -> torch.ScalarType.Int32
+        | Dtype.Int64 -> torch.ScalarType.Int64
+        | Dtype.Float16 -> torch.ScalarType.Float16
+        | Dtype.BFloat16 -> torch.ScalarType.BFloat16
+        | Dtype.Float32 -> torch.ScalarType.Float32
+        | Dtype.Float64 -> torch.ScalarType.Float64
 
     let toTorchScalar (x: scalar) =
         match x.GetTypeCode() with 
-        | TypeCode.Single -> TorchScalar.op_Implicit (x.toSingle())
-        | TypeCode.Double -> TorchScalar.op_Implicit (x.toDouble())
-        | TypeCode.Int32 -> TorchScalar.op_Implicit (x.toInt32())
-        | TypeCode.Int64 -> TorchScalar.op_Implicit (x.toInt64())
-        | TypeCode.Byte -> TorchScalar.op_Implicit (x.toByte())
-        | TypeCode.SByte -> TorchScalar.op_Implicit (x.toSByte())
-        | TypeCode.Int16 -> TorchScalar.op_Implicit (x.toInt16())
-        | TypeCode.Boolean -> TorchScalar.op_Implicit (x.toBool())
+        | TypeCode.Single -> Scalar.op_Implicit (x.toSingle())
+        | TypeCode.Double -> Scalar.op_Implicit (x.toDouble())
+        | TypeCode.Int32 -> Scalar.op_Implicit (x.toInt32())
+        | TypeCode.Int64 -> Scalar.op_Implicit (x.toInt64())
+        | TypeCode.Byte -> Scalar.op_Implicit (x.toByte())
+        | TypeCode.SByte -> Scalar.op_Implicit (x.toSByte())
+        | TypeCode.Int16 -> Scalar.op_Implicit (x.toInt16())
+        | TypeCode.Boolean -> Scalar.op_Implicit (x.toBool())
         | t -> failwithf "unknown scalar type '%A'" t
 
     let fromTorchType ttype =
         match ttype with 
-        | ScalarType.Bool -> Dtype.Bool
-        | ScalarType.Int8 -> Dtype.Int8
-        | ScalarType.Byte -> Dtype.Byte
-        | ScalarType.Int16 -> Dtype.Int16
-        | ScalarType.Int32 -> Dtype.Int32
-        | ScalarType.Int64 -> Dtype.Int64
-        | ScalarType.Float32 -> Dtype.Float32
-        | ScalarType.Float64 -> Dtype.Float64
+        | torch.ScalarType.Bool -> Dtype.Bool
+        | torch.ScalarType.Int8 -> Dtype.Int8
+        | torch.ScalarType.Byte -> Dtype.Byte
+        | torch.ScalarType.Int16 -> Dtype.Int16
+        | torch.ScalarType.Int32 -> Dtype.Int32
+        | torch.ScalarType.Int64 -> Dtype.Int64
+        | torch.ScalarType.Float32 -> Dtype.Float32
+        | torch.ScalarType.Float64 -> Dtype.Float64
         |  _ -> failwith "fromTorchType - other type"
 
     let toTorchShape (shape: Shape) : TorchShape = int64s shape
@@ -65,11 +65,11 @@ module internal Utils =
         member x.ToTorch : TorchSharp.DeviceType = enum (int x)
 
     type DiffSharp.Device with 
-        member x.ToTorch = TorchSharp.Device(x.DeviceType.ToTorch, x.DeviceIndex)
+        member x.ToTorch = torch.Device(x.DeviceType.ToTorch, x.DeviceIndex)
 
     let inline combineHashes (h1 : int) (h2 : int) = ((h1 <<< 5) + h1) ^^^ h2
 
-    let torchMoveTo (tt: TorchTensor) (device: Device) =
+    let torchMoveTo (tt: torch.Tensor) (device: Device) =
         tt.``to``(device.ToTorch)
 
     type RawTensor with
@@ -77,7 +77,7 @@ module internal Utils =
 
 /// This is the base class for all RawTensorXyz tuypes.
 /// All type-independent operations are implemented directly on this class. 
-type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device) =
+type TorchRawTensor(tt: torch.Tensor, shape: Shape, dtype: Dtype, device: Device) =
 
     inherit RawTensor()
 
@@ -89,8 +89,8 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
 #if DEBUG
     // Check the invariants associated with the tensors
     do 
-       if tt.Type <> toTorchType dtype then
-           failwithf "mismatched Torch tensor type, expected %A, got %A" (toTorchType dtype) tt.Type
+       if tt.dtype <> toTorchType dtype then
+           failwithf "mismatched Torch tensor type, expected %A, got %A" (toTorchType dtype) tt.dtype
 
        if int tt.device_type <> int device.DeviceType then
            failwithf "mismatched Torch tensor device, expected %A, got %A" tt.device_type device.DeviceType
@@ -124,7 +124,6 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
 
     override t.GetSlice(fullBounds:int[,]) =
         let n = fullBounds.GetLength(0)
-
         let newShape = Shape.checkCanGetSlice t.Shape fullBounds
 
         let indices =
@@ -133,9 +132,9 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
                 let stop = fullBounds.[i,1] + 1
                 let len = stop - start
                 if fullBounds.[i,2] = 1 && len = 1 then
-                    TorchTensorIndex.Single(int64 start)
+                    torch.TensorIndex.Single(int64 start)
                 else
-                    TorchTensorIndex.Slice(start=int64 start, stop=int64 stop))
+                    torch.TensorIndex.Slice(start=int64 start, stop=int64 stop))
         let res = tt.index(indices)
         t.MakeLike(tt=res, shape=newShape)
 
@@ -206,7 +205,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         | Dtype.Float32 -> tt.ToSingle() :> scalar
         | Dtype.Float64 -> tt.ToDouble() :> scalar
 
-    member t.ToValuesTyped<'T>(conv: TorchTensor -> 'T) : obj =
+    member t.ToValuesTyped<'T>(conv: torch.Tensor -> 'T) : obj =
         // Move the tensors to CPU for efficiency since we're accessing all the data anyway
         let tt = torchMoveTo tt Device.CPU
         match t.Shape with
@@ -262,7 +261,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
     override _.StackTs(tensors, dim) =
         let tts, shapes = tensors |> Array.map (fun t -> (t :?> TorchRawTensor).TorchTensor, t.Shape) |> Array.unzip
         let _n, _shape1, _shape2, newShape = Shape.checkCanStack shapes dim
-        let result = tts.stack(int64 dim)
+        let result = torch.stack(tts, int64 dim)
         (tensors.[0] :?> TorchRawTensor).MakeLike(result, newShape)
 
     override t.UnstackT(dim) = 
@@ -274,7 +273,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
     override t.CatTs(tensors, dim) = 
         let values, shapes = tensors |> Array.map (fun t -> t.TorchTensor, t.Shape) |> Array.unzip
         let _n, _shape1, _m2, _shape3, outShape = Shape.checkCanCat shapes dim
-        let result = values.cat(int64 dim)
+        let result = torch.cat(values, int64 dim)
         t.MakeLike(result, outShape)
 
     override t.SplitT(sizes, dim) =
@@ -308,7 +307,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
 
     override t1.SolveTT(t2) =
         let newShape = Shape.checkCanSolve t1.Shape t2.Shape
-        let result = linalg.solve(tt, t2.TorchTensor)
+        let result = torch.linalg.solve(tt, t2.TorchTensor)
         t1.MakeLike(result, shape=newShape)
 
     override t.SqueezeT(dim) = 
@@ -331,9 +330,9 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         // "flip_cuda" not implemented for 'Bool'"
         let result =
             if dtype = Dtype.Bool then 
-                tt.to_type(ScalarType.Byte).flip(int64s dims).to_type(ScalarType.Bool)
+                tt.to_type(torch.ScalarType.Byte).flip(int64s dims).to_type(torch.ScalarType.Bool)
             elif dtype = Dtype.Float16 || dtype = Dtype.BFloat16  then 
-                tt.to_type(ScalarType.Float32).flip(int64s dims).to_type(toTorchType dtype)
+                tt.to_type(torch.ScalarType.Float32).flip(int64s dims).to_type(toTorchType dtype)
             else
                 tt.flip(int64s dims)
         t.MakeLike(result)
@@ -374,7 +373,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         let res = 
             // LibTorch Gather on float16/bfloat16 gives : method_name not implemented for 'BFloat16'
             if dtype = Dtype.Float16 || dtype = Dtype.BFloat16  then 
-                tt.to_type(ScalarType.Float32).gather(int64 dim, indices.TorchTensor).to_type(toTorchType dtype)
+                tt.to_type(torch.ScalarType.Float32).gather(int64 dim, indices.TorchTensor).to_type(toTorchType dtype)
             else
                 t.TorchTensor.gather(int64 dim, indices.TorchTensor)
         t.MakeLike(res, indices.Shape)
@@ -411,7 +410,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
             | Dtype.IntegralOrBool -> t.Equals(t2)
             | Dtype.Float16 | Dtype.BFloat16 -> 
                // Need because LibTorch 1.7.0 says "isfinite" not implemented for 'BFloat16'
-               tt.to_type(ScalarType.Float32).allclose(t2.TorchTensor.to_type(ScalarType.Float32), relativeTolerance, absoluteTolerance)
+               tt.to_type(torch.ScalarType.Float32).allclose(t2.TorchTensor.to_type(torch.ScalarType.Float32), relativeTolerance, absoluteTolerance)
             | _ -> tt.allclose(t2.TorchTensor, relativeTolerance, absoluteTolerance)
         else 
             opNotSupported2 "Equals" dtype t2.Dtype
@@ -455,7 +454,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         // LibTorch 1.7.0: Max on float16/bfloat16 causes grief
         let tt = 
             if dtype = Dtype.Float16 || dtype = Dtype.BFloat16 then 
-                tt.to_type(ScalarType.Float32)
+                tt.to_type(torch.ScalarType.Float32)
             else
                 tt
         let res = Array.zeroCreate<int64> t.Dim
@@ -493,7 +492,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         // LibTorch 1.7.0: Min on float16/bfloat16 causes grief
         let tt = 
             if dtype = Dtype.Float16 || dtype = Dtype.BFloat16 then 
-                tt.to_type(ScalarType.Float32)
+                tt.to_type(torch.ScalarType.Float32)
             else
                 tt
         let res = Array.zeroCreate<int64> t.Dim
@@ -580,7 +579,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         | _ ->
         let result = tt.div(t2.TorchTensor)
         // see https://github.com/DiffSharp/DiffSharp/issues/239
-        let result = if dtype.IsIntegral then result.to_type(ScalarType.Int32).to_type(toTorchType dtype) else result
+        let result = if dtype.IsIntegral then result.to_type(torch.ScalarType.Int32).to_type(toTorchType dtype) else result
         t1.MakeLike(result)
 
     override t2.DivFromT0T(t1: scalar) =
@@ -590,7 +589,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         let t1 = t2.FullLike(Shape.scalar, t1)
         let result = t1.TorchTensor.div(t2.TorchTensor)
         // see https://github.com/DiffSharp/DiffSharp/issues/239
-        let result = if dtype.IsIntegral then result.to_type(ScalarType.Int32).to_type(toTorchType dtype) else result
+        let result = if dtype.IsIntegral then result.to_type(torch.ScalarType.Int32).to_type(toTorchType dtype) else result
         t2.MakeLike(result)
 
     override t1.DivTT0(t2) = 
@@ -638,8 +637,8 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
             // "addmm for CUDA tensors only supports floating-point types. Try converting the tensors with .float()" | const char *
             match t1.DeviceType, dtype with 
             | DiffSharp.DeviceType.CUDA, (Dtype.Integral as dtype) ->
-                let tt1 = tt.to_type(ScalarType.Float64)
-                let tt2 = t2.TorchTensor.to_type(ScalarType.Float64)
+                let tt1 = tt.to_type(torch.ScalarType.Float64)
+                let tt2 = t2.TorchTensor.to_type(torch.ScalarType.Float64)
                 tt1.matmul(tt2).round().to_type(toTorchType dtype) 
             | _ ->
                 tt.matmul(t2.TorchTensor)
@@ -654,8 +653,8 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
             // "addmm for CUDA tensors only supports floating-point types. Try converting the tensors with .float()" | const char *
             match t1.DeviceType, dtype with 
             | DiffSharp.DeviceType.CUDA, (Dtype.Integral as dtype) ->
-                let tt1 = tt.to_type(ScalarType.Float64)
-                let tt2 = t2.TorchTensor.to_type(ScalarType.Float64)
+                let tt1 = tt.to_type(torch.ScalarType.Float64)
+                let tt2 = t2.TorchTensor.to_type(torch.ScalarType.Float64)
                 tt1.bmm(tt2).round().to_type(toTorchType dtype) 
             | _ ->
                 tt.bmm(t2.TorchTensor)
@@ -668,9 +667,9 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
             // "conv1d for CUDA tensors only supports floating-point types."
             match t1.DeviceType, dtype with 
             | DiffSharp.DeviceType.CUDA, (Dtype.Integral as dtype) ->
-                tt.to_type(ScalarType.Float64).conv1d(t2.TorchTensor.to_type(ScalarType.Float64), stride=int64 stride, padding=int64 padding, dilation=1L).round().to_type(toTorchType dtype) 
+                torch.nn.functional.conv1d(tt.to_type(torch.ScalarType.Float64), t2.TorchTensor.to_type(torch.ScalarType.Float64), stride=int64 stride, padding=int64 padding, dilation=1L).round().to_type(toTorchType dtype) 
             | _ ->
-                tt.conv1d(t2.TorchTensor, stride=int64 stride, padding=int64 padding, dilation=1L)
+                torch.nn.functional.conv1d(tt, t2.TorchTensor, stride=int64 stride, padding=int64 padding, dilation=1L)
         t1.MakeLike(resultt, shape=outputShape)
 
     override t1.Conv2D(t2, strides, paddings) = // TODO: bias, dilation and groups
@@ -680,9 +679,9 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
             // "conv2d for CUDA tensors only supports floating-point types."
             match t1.DeviceType, dtype with 
             | DiffSharp.DeviceType.CUDA, (Dtype.Integral as dtype) ->
-                tt.to_type(ScalarType.Float64).conv2d(t2.TorchTensor.to_type(ScalarType.Float64), strides=int64s strides, padding=int64s paddings).round().to_type(toTorchType dtype) 
+                torch.nn.functional.conv2d(tt.to_type(torch.ScalarType.Float64), t2.TorchTensor.to_type(torch.ScalarType.Float64), strides=int64s strides, padding=int64s paddings).round().to_type(toTorchType dtype) 
             | _ ->
-                tt.conv2d(t2.TorchTensor, strides=int64s strides, padding=int64s paddings)
+                torch.nn.functional.conv2d(tt, t2.TorchTensor, strides=int64s strides, padding=int64s paddings)
         t1.MakeLike(resultt, shape=outputShape)
 
     override t1.Conv3D(t2, strides, paddings) = // TODO: bias, dilation and groups
@@ -692,9 +691,9 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
             // "conv2d for CUDA tensors only supports floating-point types."
             match t1.DeviceType, dtype with 
             | DiffSharp.DeviceType.CUDA, (Dtype.Integral as dtype) ->
-                tt.to_type(ScalarType.Float64).conv3d(t2.TorchTensor.to_type(ScalarType.Float64), strides=int64s strides, padding=int64s paddings).round().to_type(toTorchType dtype) 
+                torch.nn.functional.conv3d(tt.to_type(torch.ScalarType.Float64), t2.TorchTensor.to_type(torch.ScalarType.Float64), strides=int64s strides, padding=int64s paddings).round().to_type(toTorchType dtype) 
             | _ ->
-                tt.conv3d(t2.TorchTensor, strides=int64s strides, padding=int64s paddings)
+                torch.nn.functional.conv3d(tt, t2.TorchTensor, strides=int64s strides, padding=int64s paddings)
         t1.MakeLike(resultt, shape=outputShape)
 
     override t1.MaxPool1D(kernelSize, stride, padding) = 
@@ -703,7 +702,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         match dtype with 
         | Dtype.Bool | Dtype.Integral -> opNotSupported "MaxPool1D" dtype
         | _ ->
-        let struct (resultt, indicest) = tt.max_pool1d_with_indices(int64 kernelSize, stride=int64 stride, padding=int64 padding, dilation=1L)
+        let struct (resultt, indicest) = torch.nn.functional.max_pool1d_with_indices(tt, int64 kernelSize, stride=int64 stride, padding=int64 padding, dilation=1L)
         // NOTE: DiffSharp currently expects indices as an Int32 tensor
         let indices = t1.MakeLike(indicest, shape=outputShape, dtype=Dtype.Int64).Cast(Dtype.Int32)
         let result = t1.MakeLike(resultt, shape=outputShape)
@@ -712,7 +711,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
     override t1.MaxPool2D(kernelSize, strides, paddings) = 
         let _batchSize, _channels, _inputDimensions, _kernelDimensions, _outputDimensions, outputShape =
             Shape.checkCanMaxpool2d dtype t1.Shape kernelSize strides paddings
-        let struct (resultt, indicest) = tt.max_pool2d_with_indices(int64s kernelSize, strides=int64s strides, padding=int64s paddings)
+        let struct (resultt, indicest) = torch.nn.functional.max_pool2d_with_indices(tt, int64s kernelSize, strides=int64s strides, padding=int64s paddings)
         // NOTE: DiffSharp currently expects indices as an Int32 tensor, Torch wants Int64
         let indices = t1.MakeLike(indicest, shape=outputShape, dtype=Dtype.Int64).Cast(Dtype.Int32)
         let result = t1.MakeLike(resultt, shape=outputShape)
@@ -721,7 +720,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
     override t1.MaxPool3D(kernelSize, strides, paddings) = 
         let _batchSize, _channels, _inputDimensions, _kernelDimensions, _outputDimensions, outputShape =
             Shape.checkCanMaxpool3d dtype t1.Shape kernelSize strides paddings
-        let struct (resultt, indicest) = tt.max_pool3d_with_indices(int64s kernelSize, strides=int64s strides, padding=int64s paddings)
+        let struct (resultt, indicest) = torch.nn.functional.max_pool3d_with_indices(tt, int64s kernelSize, strides=int64s strides, padding=int64s paddings)
         
         // NOTE: DiffSharp currently expects indices as an Int32 tensor
         let indices = t1.MakeLike(indicest, shape=outputShape, dtype=Dtype.Int64).Cast(Dtype.Int32)
@@ -750,7 +749,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         
         // TODO: consider switching to the torch::nn module for MaxUnpool2d
 
-        let resultt = tt.maxunpool2d(indices.TorchTensor, int64s outputSize)
+        let resultt = torch.nn.functional.max_unpool2d(tt, indices.TorchTensor, int64s outputSize)
         t1.MakeLike(resultt, shape=outputShape)
 
     override t1.MaxUnpool3D(indices, outputSize) = 
@@ -767,7 +766,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         // TODO: consider switching to the torch::nn module for MaxUnpool
         let strides = outputSize |> Array.map (fun _ -> 1L)
         let padding = outputSize |> Array.map (fun _ -> 0L)
-        let resultt = tt.maxunpool3d(indices.TorchTensor, int64s outputSize, strides, padding)
+        let resultt = torch.nn.functional.max_unpool3d(tt, indices.TorchTensor, int64s outputSize, strides, padding)
         t1.MakeLike(resultt, shape=outputShape)
 
     override t1.AvgPool1D(kernelSize, stride, padding) =
@@ -775,7 +774,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         match dtype with 
         | Dtype.Bool | Dtype.Integral -> opNotSupported "AvgPool1D" dtype
         | _ ->
-        let resultt = tt.avg_pool1d(int64 kernelSize, stride=int64 stride, padding=int64 padding)
+        let resultt = torch.nn.functional.avg_pool1d(tt, int64 kernelSize, stride=int64 stride, padding=int64 padding)
         let result = t1.MakeLike(resultt, shape=outputShape)
         result
 
@@ -784,7 +783,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         match dtype with 
         | Dtype.Bool | Dtype.Integral -> opNotSupported "AvgPool2D" dtype
         | _ ->
-        let resultt = tt.avg_pool2d(int64s kernelSize, strides=int64s stride, paddings=int64s padding)
+        let resultt = torch.nn.functional.avg_pool2d(tt, int64s kernelSize, strides=int64s stride, paddings=int64s padding)
         let result = t1.MakeLike(resultt, shape=outputShape)
         result
 
@@ -793,7 +792,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         match dtype with 
         | Dtype.Bool | Dtype.Integral -> opNotSupported "AvgPool3D" dtype
         | _ ->
-        let resultt = tt.avg_pool3d(int64s kernelSize, strides=int64s stride, paddings=int64s padding)
+        let resultt = torch.nn.functional.avg_pool3d(tt, int64s kernelSize, strides=int64s stride, paddings=int64s padding)
         let result = t1.MakeLike(resultt, shape=outputShape)
         result
 
@@ -808,7 +807,7 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         match dtype with 
         | Dtype.Bool | Dtype.Integral -> opNotSupported "AvgPoolReverse2D" dtype
         | _ ->
-        let resultt = tt.avg_pool2d_backward(originalInput.TorchTensor, int64s kernelSize, strides=int64s stride, paddings=int64s padding)
+        let resultt = torch.nn.functional.avg_pool2d_backward(tt, originalInput.TorchTensor, int64s kernelSize, strides=int64s stride, paddings=int64s padding)
         let result = t1.MakeLike(resultt, shape=originalInput.Shape)
         result
 
@@ -816,12 +815,12 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
         match dtype with 
         | Dtype.Bool | Dtype.Integral -> opNotSupported "AvgPoolReverse3D" dtype
         | _ ->
-        let resultt = tt.avg_pool3d_backward(originalInput.TorchTensor, int64s kernelSize, strides=int64s stride, paddings=int64s padding)
+        let resultt = torch.nn.functional.avg_pool3d_backward(tt, originalInput.TorchTensor, int64s kernelSize, strides=int64s stride, paddings=int64s padding)
         let result = t1.MakeLike(resultt, shape=originalInput.Shape)
         result
 
     override t.SumT2Dim0() =
-        let result = tt.sum([| 0L |], ``type``= tt.Type)
+        let result = tt.sum([| 0L |], ``type``= tt.dtype)
         let resultShape = [|t.Shape.[1]|]
         t.MakeLike(result, shape=resultShape)
 
@@ -999,34 +998,34 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
             match dtype with 
             | Dtype.Bool -> 
                 let data = info.GetValue("data", typeof<bool[]>)  :?> bool[]
-                BoolTensor.from (data, toTorchShape shape) 
+                torch.BoolTensor.from (data, toTorchShape shape) 
             | Dtype.Byte -> 
                 let data = info.GetValue("data", typeof<byte[]>)  :?> byte[]
-                ByteTensor.from (data, toTorchShape shape) 
+                torch.ByteTensor.from (data, toTorchShape shape) 
             | Dtype.Int8 -> 
                 let data = info.GetValue("data", typeof<sbyte[]>)  :?> sbyte[]
-                Int8Tensor.from (data, toTorchShape shape) 
+                torch.Int8Tensor.from (data, toTorchShape shape) 
             | Dtype.Int16 -> 
                 let data = info.GetValue("data", typeof<int16[]>)  :?> int16[]
-                Int16Tensor.from (data, toTorchShape shape) 
+                torch.Int16Tensor.from (data, toTorchShape shape) 
             | Dtype.Int32 -> 
                 let data = info.GetValue("data", typeof<int32[]>)  :?> int32[]
-                Int32Tensor.from (data, toTorchShape shape) 
+                torch.Int32Tensor.from (data, toTorchShape shape) 
             | Dtype.Int64 -> 
                 let data = info.GetValue("data", typeof<int64[]>)  :?> int64[]
-                Int64Tensor.from (data, toTorchShape shape) 
+                torch.Int64Tensor.from (data, toTorchShape shape) 
             | Dtype.Float32 -> 
                 let data = info.GetValue("data", typeof<float32[]>)  :?> float32[]
-                Float32Tensor.from (data, toTorchShape shape) 
+                torch.Float32Tensor.from (data, toTorchShape shape) 
             | Dtype.Float64 -> 
                 let data = info.GetValue("data", typeof<double[]>)  :?> double[]
-                Float64Tensor.from (data, toTorchShape shape) 
+                torch.Float64Tensor.from (data, toTorchShape shape) 
             | Dtype.Float16 -> 
                 let data = info.GetValue("data", typeof<float32[]>)  :?> float32[]
-                Float16Tensor.from (data, toTorchShape shape) 
+                torch.Float16Tensor.from (data, toTorchShape shape) 
             | Dtype.BFloat16 -> 
                 let data = info.GetValue("data", typeof<float32[]>)  :?> float32[]
-                BFloat16Tensor.from (data, toTorchShape shape) 
+                torch.BFloat16Tensor.from (data, toTorchShape shape) 
 
         TorchRawTensor(tt, shape, dtype, Device.CPU)
 
@@ -1170,18 +1169,18 @@ type TorchRawTensor(tt: TorchTensor, shape: Shape, dtype: Dtype, device: Device)
 /// make sure we get the correlation with .NET types correct and systematic
 type TorchTensorOps<'T, 'T2>
        (dtype: Dtype, conv: 'T -> 'T2,
-        fromScalar: 'T2 -> TorchTensor,
-        from: 'T2[] * TorchShape -> TorchTensor,
+        fromScalar: 'T2 -> torch.Tensor,
+        from: 'T2[] * TorchShape -> torch.Tensor,
         zero: 'T,
         one: 'T,
-        empty: TorchShape  * Device -> TorchTensor,
-        zeros: TorchShape  * Device -> TorchTensor,
-        ones: TorchShape  * Device -> TorchTensor,
-        random: TorchShape  * Device -> TorchTensor,
-        randomN: TorchShape  * Device -> TorchTensor,
-        randomIntegers: TorchShape * int * int * Device -> TorchTensor,
+        empty: TorchShape  * Device -> torch.Tensor,
+        zeros: TorchShape  * Device -> torch.Tensor,
+        ones: TorchShape  * Device -> torch.Tensor,
+        random: TorchShape  * Device -> torch.Tensor,
+        randomN: TorchShape  * Device -> torch.Tensor,
+        randomIntegers: TorchShape * int * int * Device -> torch.Tensor,
         valueFromScalar: scalar -> 'T,
-        scalarFromConvValue: 'T2 -> TorchScalar) = 
+        scalarFromConvValue: 'T2 -> TorchSharp.Scalar) = 
 
     member _.Zero(device) = TorchRawTensor(torchMoveTo (fromScalar (conv zero)) device, Shape.scalar, dtype, device) :> RawTensor 
     member _.One(device) = TorchRawTensor(torchMoveTo (fromScalar (conv one)) device, Shape.scalar, dtype, device) :> RawTensor
@@ -1209,153 +1208,153 @@ type TorchTensorOps<'T, 'T2>
 type TorchFloat32TensorOps() = 
 
     inherit TorchTensorOps<single, single>(Dtype.Float32, id, 
-        (fun v -> Float32Tensor.from(v)), 
-        (fun (data, shape) -> Float32Tensor.from(data, shape)), 
+        (fun v -> torch.Float32Tensor.from(v)), 
+        (fun (data, shape) -> torch.Float32Tensor.from(data, shape)), 
         0.0f, 1.0f, 
-        (fun (shape, device) -> Float32Tensor.empty(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float32Tensor.zeros(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float32Tensor.ones(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float32Tensor.rand(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float32Tensor.randn(shape, device.ToTorch)), 
-        (fun (shape, low, high, device) -> Float32Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((float low).ToScalar())), 
+        (fun (shape, device) -> torch.Float32Tensor.empty(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float32Tensor.zeros(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float32Tensor.ones(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float32Tensor.rand(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float32Tensor.randn(shape, device.ToTorch)), 
+        (fun (shape, low, high, device) -> torch.Float32Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((float low).ToScalar())), 
         System.Convert.ToSingle, 
-        TorchScalar.op_Implicit)
+        TorchSharp.Scalar.op_Implicit)
 
 type TorchFloat64TensorOps() = 
 
     inherit TorchTensorOps<double, double>(Dtype.Float64, id, 
-        (fun v -> Float64Tensor.from(v)), 
-        (fun (data, shape) -> Float64Tensor.from(data, shape)), 
+        (fun v -> torch.Float64Tensor.from(v)), 
+        (fun (data, shape) -> torch.Float64Tensor.from(data, shape)), 
         0.0, 1.0, 
-        (fun (shape, device) -> Float64Tensor.empty(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float64Tensor.zeros(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float64Tensor.ones(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float64Tensor.rand(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float64Tensor.randn(shape, device.ToTorch)), 
-        (fun (shape, low, high, device) -> Float64Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((double low).ToScalar())), 
+        (fun (shape, device) -> torch.Float64Tensor.empty(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float64Tensor.zeros(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float64Tensor.ones(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float64Tensor.rand(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float64Tensor.randn(shape, device.ToTorch)), 
+        (fun (shape, low, high, device) -> torch.Float64Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((double low).ToScalar())), 
         System.Convert.ToDouble, 
-        TorchScalar.op_Implicit)
+        TorchSharp.Scalar.op_Implicit)
 
 type TorchInt8TensorOps() = 
 
     inherit TorchTensorOps<sbyte, sbyte>(Dtype.Int8, sbyte,
-        (fun v -> Int8Tensor.from(v)), 
-        (fun (data, shape) -> Int8Tensor.from(data, shape)), 
+        (fun v -> torch.Int8Tensor.from(v)), 
+        (fun (data, shape) -> torch.Int8Tensor.from(data, shape)), 
         0y, 1y,
-        (fun (shape, device) -> Int8Tensor.empty(shape, device.ToTorch)), 
-        (fun (shape, device) -> Int8Tensor.zeros(shape, device.ToTorch)), 
-        (fun (shape, device) -> Int8Tensor.ones(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int8Tensor.empty(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int8Tensor.zeros(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int8Tensor.ones(shape, device.ToTorch)), 
         (fun _ -> opNotSupported "Random" Dtype.Int8), 
         (fun _ -> opNotSupported "RandomNormal" Dtype.Int8), 
-        (fun (shape, low, high, device) -> Int8Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((sbyte low).ToScalar())), 
+        (fun (shape, low, high, device) -> torch.Int8Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((sbyte low).ToScalar())), 
         System.Convert.ToSByte, 
-        TorchScalar.op_Implicit)
+        TorchSharp.Scalar.op_Implicit)
 
 type TorchInt16TensorOps() = 
 
     inherit TorchTensorOps<int16, int16>(Dtype.Int16, int16, 
-        (fun v -> Int16Tensor.from(v)), 
-        (fun (data, shape) -> Int16Tensor.from(data, shape)), 
+        (fun v -> torch.Int16Tensor.from(v)), 
+        (fun (data, shape) -> torch.Int16Tensor.from(data, shape)), 
         0s, 1s,
-        (fun (shape, device) -> Int16Tensor.empty(shape, device.ToTorch)), 
-        (fun (shape, device) -> Int16Tensor.zeros(shape, device.ToTorch)), 
-        (fun (shape, device) -> Int16Tensor.ones(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int16Tensor.empty(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int16Tensor.zeros(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int16Tensor.ones(shape, device.ToTorch)), 
         (fun _ -> opNotSupported "Random" Dtype.Int16), 
         (fun _ -> opNotSupported "RandomNormal" Dtype.Int16), 
-        (fun (shape, low, high, device) -> Int16Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((int16 low).ToScalar())), 
+        (fun (shape, low, high, device) -> torch.Int16Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((int16 low).ToScalar())), 
         System.Convert.ToInt16, 
-        TorchScalar.op_Implicit)
+        TorchSharp.Scalar.op_Implicit)
 
 type TorchInt32TensorOps() = 
 
     inherit TorchTensorOps<int32, int32>(Dtype.Int32, int32, 
-        (fun v -> Int32Tensor.from(v)), 
-        Int32Tensor.from, 
+        (fun v -> torch.Int32Tensor.from(v)), 
+        torch.Int32Tensor.from, 
         0, 1,
-        (fun (shape, device) -> Int32Tensor.empty(shape, device.ToTorch)), 
-        (fun (shape, device) -> Int32Tensor.zeros(shape, device.ToTorch)), 
-        (fun (shape, device) -> Int32Tensor.ones(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int32Tensor.empty(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int32Tensor.zeros(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int32Tensor.ones(shape, device.ToTorch)), 
         (fun _ -> opNotSupported "Random" Dtype.Int32), 
         (fun _ -> opNotSupported "RandomNormal" Dtype.Int32), 
-        (fun (shape, low, high, device) -> Int32Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((int32 low).ToScalar())), 
+        (fun (shape, low, high, device) -> torch.Int32Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((int32 low).ToScalar())), 
         System.Convert.ToInt32, 
-        TorchScalar.op_Implicit)
+        TorchSharp.Scalar.op_Implicit)
 
 type TorchInt64TensorOps() = 
 
     inherit TorchTensorOps<int64, int64>(Dtype.Int64, int64, 
-        (fun v -> Int64Tensor.from(v)), 
-        (fun (data, shape) -> Int64Tensor.from(data, shape)), 
+        (fun v -> torch.Int64Tensor.from(v)), 
+        (fun (data, shape) -> torch.Int64Tensor.from(data, shape)), 
         0L, 1L,
-        (fun (shape, device) -> Int64Tensor.empty(shape, device.ToTorch)), 
-        (fun (shape, device) -> Int64Tensor.zeros(shape, device.ToTorch)), 
-        (fun (shape, device) -> Int64Tensor.ones(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int64Tensor.empty(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int64Tensor.zeros(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Int64Tensor.ones(shape, device.ToTorch)), 
         (fun _ -> opNotSupported "Random" Dtype.Int64), 
         (fun _ -> opNotSupported "RandomNormal" Dtype.Int64), 
-        (fun (shape, low, high, device) -> Int64Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((int64 low).ToScalar())), 
+        (fun (shape, low, high, device) -> torch.Int64Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((int64 low).ToScalar())), 
         System.Convert.ToInt64, 
-        TorchScalar.op_Implicit)
+        TorchSharp.Scalar.op_Implicit)
 
 type TorchBoolTensorOps() = 
 
     inherit TorchTensorOps<bool, bool>(Dtype.Bool, id, 
-        (fun v -> BoolTensor.from(v)), 
-        (fun (data, shape) -> BoolTensor.from(data, shape)), 
+        (fun v -> torch.BoolTensor.from(v)), 
+        (fun (data, shape) -> torch.BoolTensor.from(data, shape)), 
         false, true,
-        (fun (shape, device) -> BoolTensor.empty(shape, device.ToTorch)), 
-        (fun (shape, device) -> BoolTensor.zeros(shape, device.ToTorch)), 
-        (fun (shape, device) -> BoolTensor.ones(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.BoolTensor.empty(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.BoolTensor.zeros(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.BoolTensor.ones(shape, device.ToTorch)), 
         (fun _ -> opNotSupported "Random" Dtype.Bool), 
         (fun _ -> opNotSupported "RandomNormal"  Dtype.Bool), 
-        (fun (shape, low, high, device) -> BoolTensor.randint(min 2L (int64 (high-low)), shape, device.ToTorch).add_((low > 0).ToScalar())), 
+        (fun (shape, low, high, device) -> torch.BoolTensor.randint(min 2L (int64 (high-low)), shape, device.ToTorch).add_((low > 0).ToScalar())), 
         System.Convert.ToBoolean, 
-        TorchScalar.op_Implicit)
+        TorchSharp.Scalar.op_Implicit)
 
 type TorchByteTensorOps() = 
 
     inherit TorchTensorOps<byte, byte>(Dtype.Byte, id, 
-        (fun v -> ByteTensor.from(v)), 
-        (fun (data, shape) -> ByteTensor.from(data, shape)), 
+        (fun v -> torch.ByteTensor.from(v)), 
+        (fun (data, shape) -> torch.ByteTensor.from(data, shape)), 
         0uy, 1uy,
-        (fun (shape, device) -> ByteTensor.empty(shape, device.ToTorch)), 
-        (fun (shape, device) -> ByteTensor.zeros(shape, device.ToTorch)), 
-        (fun (shape, device) -> ByteTensor.ones(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.ByteTensor.empty(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.ByteTensor.zeros(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.ByteTensor.ones(shape, device.ToTorch)), 
         (fun _ -> opNotSupported "Random" Dtype.Byte), 
         (fun _ -> opNotSupported "RandomNormal"  Dtype.Byte), 
-        (fun (shape, low, high, device) -> ByteTensor.randint(int64 (high-low), shape, device.ToTorch).add_((byte low).ToScalar())), 
+        (fun (shape, low, high, device) -> torch.ByteTensor.randint(int64 (high-low), shape, device.ToTorch).add_((byte low).ToScalar())), 
         System.Convert.ToByte, 
-        TorchScalar.op_Implicit)
+        TorchSharp.Scalar.op_Implicit)
 
 type TorchFloat16TensorOps() = 
 
     inherit TorchTensorOps<single, single>(Dtype.Float16, id, 
-        (fun v -> Float16Tensor.from(v)), 
-        (fun (data, shape) -> Float16Tensor.from(data, shape)), 
+        (fun v -> torch.Float16Tensor.from(v)), 
+        (fun (data, shape) -> torch.Float16Tensor.from(data, shape)), 
         0.0f, 1.0f, 
-        (fun (shape, device) -> Float16Tensor.empty(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float16Tensor.zeros(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float16Tensor.ones(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float16Tensor.rand(shape, device.ToTorch)), 
-        (fun (shape, device) -> Float16Tensor.randn(shape, device.ToTorch)), 
-        (fun (shape, low, high, device) -> Float16Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((float low).ToScalar())), 
+        (fun (shape, device) -> torch.Float16Tensor.empty(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float16Tensor.zeros(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float16Tensor.ones(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float16Tensor.rand(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.Float16Tensor.randn(shape, device.ToTorch)), 
+        (fun (shape, low, high, device) -> torch.Float16Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((float low).ToScalar())), 
         System.Convert.ToSingle, 
-        TorchScalar.op_Implicit)
+        TorchSharp.Scalar.op_Implicit)
 
 
 type TorchBFloat16TensorOps() = 
 
     inherit TorchTensorOps<single, single>(Dtype.BFloat16, id, 
-        (fun v -> BFloat16Tensor.from(v)), 
-        (fun (data, shape) -> BFloat16Tensor.from(data, shape)), 
+        (fun v -> torch.BFloat16Tensor.from(v)), 
+        (fun (data, shape) -> torch.BFloat16Tensor.from(data, shape)), 
         0.0f, 1.0f, 
-        (fun (shape, device) -> BFloat16Tensor.empty(shape, device.ToTorch)), 
-        (fun (shape, device) -> BFloat16Tensor.zeros(shape, device.ToTorch)), 
-        (fun (shape, device) -> BFloat16Tensor.ones(shape, device.ToTorch)), 
-        (fun (shape, device) -> BFloat16Tensor.rand(shape, device.ToTorch)), 
-        (fun (shape, device) -> BFloat16Tensor.randn(shape, device.ToTorch)), 
-        (fun (shape, low, high, device) -> BFloat16Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((float low).ToScalar())), 
+        (fun (shape, device) -> torch.BFloat16Tensor.empty(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.BFloat16Tensor.zeros(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.BFloat16Tensor.ones(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.BFloat16Tensor.rand(shape, device.ToTorch)), 
+        (fun (shape, device) -> torch.BFloat16Tensor.randn(shape, device.ToTorch)), 
+        (fun (shape, low, high, device) -> torch.BFloat16Tensor.randint(int64 (high-low), shape, device.ToTorch).add_((float low).ToScalar())), 
         System.Convert.ToSingle, 
-        TorchScalar.op_Implicit)
+        TorchSharp.Scalar.op_Implicit)
 
 type TorchBackendTensorStatics() =
     inherit BackendTensorStatics()
@@ -1377,7 +1376,7 @@ type TorchBackendTensorStatics() =
         match supported.[n] with 
         | 0 ->
             try
-                Float32Tensor.empty([| 1L |], device= Torch.Device(deviceType.ToTorch, index=0)) |> ignore
+                torch.Float32Tensor.empty([| 1L |], device= torch.Device(deviceType.ToTorch, index=0)) |> ignore
                 supported.[n] <- 1
                 true
              with _ -> 
@@ -1395,8 +1394,8 @@ type TorchBackendTensorStatics() =
 
           match deviceType with
           | None | Some DiffSharp.DeviceType.CUDA ->
-              if Torch.IsCudaAvailable() then 
-                  let ncuda = Torch.CudaDeviceCount()
+              if torch.cuda.is_available() then 
+                  let ncuda = torch.cuda.device_count()
                   for i in 0 .. ncuda - 1 do
                       yield (DiffSharp.Device(DiffSharp.DeviceType.CUDA, i))
           | _ -> ()
@@ -1408,13 +1407,13 @@ type TorchBackendTensorStatics() =
     override _.IsDeviceTypeSupported (deviceType) =
         match deviceType with 
         | DiffSharp.DeviceType.CPU -> true
-        | DiffSharp.DeviceType.CUDA -> Torch.IsCudaAvailable()
+        | DiffSharp.DeviceType.CUDA -> torch.cuda.is_available()
         | _ -> isSupported deviceType
 
     override _.Seed(seed) =
         // TODO (important): we need to do *both* this Torch.SetSeed and CUDA SetSeed when device is GPU. CPU seed and CUDA seed are handled separately in torch and libtorch.
         // However at the point of writing this comment, Cuda SetSeed was not available in TorchSharp
-        Torch.SetSeed(int64 seed) 
+        torch.random.manual_seed(int64 seed)  |> ignore
 
     override _.Zero(dtype, device) =
         match dtype with 

--- a/tests/DiffSharp.Benchmarks/BasicTensorOpsPerf.fs
+++ b/tests/DiffSharp.Benchmarks/BasicTensorOpsPerf.fs
@@ -16,7 +16,7 @@ open System.IO
 open System.Threading
 open DiffSharp.Backends
 open TorchSharp
-open TorchSharp.Tensor
+// open TorchSharp.Tensor
 
 type TorchDevice = Torch.Device
 type Device = DiffSharp.Device
@@ -27,7 +27,7 @@ module Extensions =
         member x.ToTorch : TorchSharp.DeviceType = enum (int x)
 
     type DiffSharp.Device with 
-        member x.ToTorch = TorchSharp.Device(x.DeviceType.ToTorch, x.DeviceIndex)
+        member x.ToTorch = torch.Device(x.DeviceType.ToTorch, x.DeviceIndex)
 
 
 /// For testing perf costs of the TorchSharp layer - going straght to the C++
@@ -72,9 +72,9 @@ type BasicTensorOps() =
     let mutable rawMatrixTensor = Unchecked.defaultof<RawTensor>
     let mutable rawScalarTensor = Unchecked.defaultof<RawTensor>
     let mutable rawScalar = Unchecked.defaultof<scalar>
-    let mutable torchTensor = Unchecked.defaultof<TorchTensor>
-    let mutable matrixTorchTensor = Unchecked.defaultof<TorchTensor>
-    let mutable torchScalar = Unchecked.defaultof<TorchScalar>
+    let mutable torchTensor = Unchecked.defaultof<torch.Tensor>
+    let mutable matrixTorchTensor = Unchecked.defaultof<torch.Tensor>
+    let mutable torchScalar = Unchecked.defaultof<TorchSharp.Scalar>
     
     // store results temporarily to make sure nothing gets optimised away
     let mutable res = Unchecked.defaultof<Tensor>
@@ -112,9 +112,9 @@ type BasicTensorOps() =
             rawMatrixTensor <- dsharpMatrixTensor.primalRaw
             rawScalarTensor <- dsharpScalarTensor.primalRaw
             rawScalar <- 3
-            torchTensor <- match rawTensor.Handle with :? TorchSharp.Tensor.TorchTensor as tt -> tt | _ -> Unchecked.defaultof<_>
-            matrixTorchTensor <- match rawMatrixTensor.Handle with :? TorchSharp.Tensor.TorchTensor as tt -> tt | _ -> Unchecked.defaultof<_>
-            torchScalar <- TorchSharp.TorchScalar.op_Implicit(3)
+            torchTensor <- match rawTensor.Handle with :? torch.Tensor as tt -> tt | _ -> Unchecked.defaultof<_>
+            matrixTorchTensor <- match rawMatrixTensor.Handle with :? torch.Tensor as tt -> tt | _ -> Unchecked.defaultof<_>
+            torchScalar <- TorchSharp.Scalar.op_Implicit(3)
         | _ -> ()
         perf.numIterations(factor)
 
@@ -127,10 +127,10 @@ type BasicTensorOps() =
         for _ in 1 .. n do 
             res4 <- 
                 match dtype with 
-                | Dtype.Int32 -> Int32Tensor.from(rawData :?> int32[])
-                | Dtype.Int64 -> Int64Tensor.from(rawData :?> int64[])
-                | Dtype.Float32 -> Float32Tensor.from(rawData :?> single[])
-                | Dtype.Float64 -> Float64Tensor.from(rawData :?> double[])
+                | Dtype.Int32 -> torch.Int32Tensor.from(rawData :?> int32[])
+                | Dtype.Int64 -> torch.Int64Tensor.from(rawData :?> int64[])
+                | Dtype.Float32 -> torch.Float32Tensor.from(rawData :?> single[])
+                | Dtype.Float64 -> torch.Float64Tensor.from(rawData :?> double[])
                 | _ -> failwith "unknown dtype in perf testing"
 
     [<Benchmark; BenchmarkCategory("fromCpuData")>]
@@ -166,10 +166,10 @@ type BasicTensorOps() =
         for _ in 1 .. n do 
             res4 <- 
                 match dtype with 
-                | Dtype.Int32 -> Int32Tensor.zeros([| int64 perf.tensorSize |] , Device.Default.ToTorch)
-                | Dtype.Int64 -> Int64Tensor.zeros([| int64 perf.tensorSize |] , Device.Default.ToTorch)
-                | Dtype.Float32 -> Float64Tensor.zeros([| int64 perf.tensorSize |] , Device.Default.ToTorch)
-                | Dtype.Float64 -> Float32Tensor.zeros([| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Int32 -> torch.Int32Tensor.zeros([| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Int64 -> torch.Int64Tensor.zeros([| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Float32 -> torch.Float64Tensor.zeros([| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Float64 -> torch.Float32Tensor.zeros([| int64 perf.tensorSize |] , Device.Default.ToTorch)
                 | _ -> failwith "unknown dtype in perf testing"
 
     [<Benchmark; BenchmarkCategory("zeros")>]
@@ -204,10 +204,10 @@ type BasicTensorOps() =
         for _ in 1 .. n do 
             res4 <- 
                 match dtype with 
-                | Dtype.Int32 -> Int32Tensor.ones([| int64 perf.tensorSize |] , Device.Default.ToTorch)
-                | Dtype.Int64 -> Int64Tensor.ones([| int64 perf.tensorSize |] , Device.Default.ToTorch)
-                | Dtype.Float32 -> Float64Tensor.ones([| int64 perf.tensorSize |] , Device.Default.ToTorch)
-                | Dtype.Float64 -> Float32Tensor.ones([| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Int32 -> torch.Int32Tensor.ones([| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Int64 -> torch.Int64Tensor.ones([| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Float32 -> torch.Float64Tensor.ones([| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Float64 -> torch.Float32Tensor.ones([| int64 perf.tensorSize |] , Device.Default.ToTorch)
                 | _ -> failwith "unknown dtype in perf testing"
 
     [<Benchmark; BenchmarkCategory("ones")>]
@@ -242,10 +242,10 @@ type BasicTensorOps() =
         for _ in 1 .. n do 
             res4 <- 
                 match dtype with 
-                | Dtype.Int32 -> Int32Tensor.randint(10L, [| int64 perf.tensorSize |] , Device.Default.ToTorch)
-                | Dtype.Int64 -> Int64Tensor.randint(10L, [| int64 perf.tensorSize |] , Device.Default.ToTorch)
-                | Dtype.Float32 -> Float64Tensor.rand([| int64 perf.tensorSize |] , Device.Default.ToTorch)
-                | Dtype.Float64 -> Float32Tensor.rand([| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Int32 -> torch.Int32Tensor.randint(10L, [| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Int64 -> torch.Int64Tensor.randint(10L, [| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Float32 -> torch.Float64Tensor.rand([| int64 perf.tensorSize |] , Device.Default.ToTorch)
+                | Dtype.Float64 -> torch.Float32Tensor.rand([| int64 perf.tensorSize |] , Device.Default.ToTorch)
                 | _ -> failwith "unknown dtype in perf testing"
 
     [<Benchmark; BenchmarkCategory("rand")>]

--- a/tests/DiffSharp.Benchmarks/BasicTensorOpsPerf.fs
+++ b/tests/DiffSharp.Benchmarks/BasicTensorOpsPerf.fs
@@ -16,7 +16,6 @@ open System.IO
 open System.Threading
 open DiffSharp.Backends
 open TorchSharp
-// open TorchSharp.Tensor
 
 type TorchDevice = Torch.Device
 type Device = DiffSharp.Device

--- a/tests/DiffSharp.Tests/TestDiffSharp.fs
+++ b/tests/DiffSharp.Tests/TestDiffSharp.fs
@@ -643,12 +643,12 @@ type TestDiffSharp () =
         // Get devices for explicitly specified Torch backend
         let explicitTorchBackendDevices = dsharp.devices(backend=Backend.Torch)
         Assert.True(explicitTorchBackendDevices |> List.contains Device.CPU)
-        let cudaAvailable = TorchSharp.Torch.IsCudaAvailable()
+        let cudaAvailable = TorchSharp.torch.cuda.is_available()
         Assert.CheckEqual(cudaAvailable, (explicitTorchBackendDevices |> List.contains Device.GPU))
 
         let explicitTorchBackendDevices = dsharp.devices(backend=Backend.Torch)
         Assert.True(explicitTorchBackendDevices |> List.contains Device.CPU)
-        let cudaAvailable = TorchSharp.Torch.IsCudaAvailable()
+        let cudaAvailable = TorchSharp.torch.cuda.is_available()
         Assert.CheckEqual(cudaAvailable, (explicitTorchBackendDevices |> List.contains Device.GPU))
 
     [<Test>]
@@ -660,7 +660,7 @@ type TestDiffSharp () =
 
         Assert.True(dsharp.isDeviceTypeSupported(DeviceType.CPU, Backend.Torch))
 
-        let cudaAvailable = TorchSharp.Torch.IsCudaAvailable()
+        let cudaAvailable = TorchSharp.torch.cuda.is_available()
         let deviceSupported = dsharp.isDeviceTypeSupported(DeviceType.CUDA, Backend.Torch)
         Assert.CheckEqual(cudaAvailable, deviceSupported)
 


### PR DESCRIPTION
This is updating TorchSharp to 0.91.52719 which has lots of breaking changes due to mass renamings: https://github.com/xamarin/TorchSharp/pull/302

This is needed going forward with latest TorchSharp, needed for example for `torch.linalg.matrix_norm` and `torch.linalg.vector_norm` needed for DiffSharp 1.0.