### PR TITLE
Support for 5d and 6d arrays

### DIFF
--- a/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
+++ b/src/DiffSharp.Backends.Reference/Reference.RawTensor.fs
@@ -130,6 +130,8 @@ type RawTensorCPU<'T when 'T : equality and 'T :> scalar>(values: 'T[], shape: S
         | 2 -> upcast Array2D.init shape.[0] shape.[1] (fun i j -> t.[i, j])
         | 3 -> upcast Array3D.init shape.[0] shape.[1] shape.[2] (fun i j k -> t.[i, j, k])
         | 4 -> upcast Array4D.init shape.[0] shape.[1] shape.[2] shape.[3] (fun i j k l -> t.[i, j, k, l])
+        | 5 -> upcast Array5D.init shape.[0] shape.[1] shape.[2] shape.[3] shape.[4] (fun i j k l m -> t.[i, j, k, l, m])
+        | 6 -> upcast Array6D.init shape.[0] shape.[1] shape.[2] shape.[3] shape.[4] shape.[5] (fun i j k l m n -> t.[i, j, k, l, m, n])
         | _ -> ArrayND.init shape (fun idxs -> t.[idxs])
 
     override _.StackTs(tensors, dim) =

--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -213,7 +213,9 @@ type TorchRawTensor(tt: torch.Tensor, shape: Shape, dtype: Dtype, device: Device
         | [| d0; d1 |] -> upcast Array2D.init<'T> d0 d1 (fun i j -> tt.[int64 i, int64 j] |> conv)
         | [| d0; d1; d2 |]  -> upcast Array3D.init<'T> d0 d1 d2 (fun i j k -> tt.[int64 i, int64 j, int64 k] |> conv)
         | [| d0; d1; d2; d3 |]  -> upcast Array4D.init<'T> d0 d1 d2 d3 (fun i j k l -> tt.[int64 i, int64 j, int64 k, int64 l] |> conv)
-        | _ -> failwithf "Cannot get array for Tensor dimensions > 4. Consider slicing the Tensor. Shape: %A" t.Shape
+        | [| d0; d1; d2; d3; d4 |]  -> upcast Array5D.init<'T> d0 d1 d2 d3 d4 (fun i j k l m -> tt.[int64 i, int64 j, int64 k, int64 l, int64 m] |> conv)
+        | [| d0; d1; d2; d3; d4; d5 |]  -> upcast Array6D.init<'T> d0 d1 d2 d3 d4 d5 (fun i j k l m n -> tt.[int64 i, int64 j, int64 k, int64 l, int64 m, int64 n] |> conv)
+        | _ -> failwithf "Cannot get array for Tensor dimensions > 6. Consider slicing the Tensor. Shape: %A" t.Shape
 
     override t.ToValues() =
         match dtype with 

--- a/src/DiffSharp.Core/Extensions.fs
+++ b/src/DiffSharp.Core/Extensions.fs
@@ -59,26 +59,76 @@ module Array4D =
     let map mapping (array:'a[,,,]) =
         Array4D.init (array.GetLength(0)) (array.GetLength(1)) (array.GetLength(2)) (array.GetLength(3)) (fun i j k l -> mapping array.[i, j, k, l])
 
+module Array5D =
+    let zeroCreate<'a> (length1:int) length2 length3 length4 length5 = System.Array.CreateInstance(typeof<'a>, [|length1;length2;length3;length4;length5|]) // Reference-type elements are initialized to null. Value-type elements are initialized to zero.
+    let get (array:System.Array) (index1:int) index2 index3 index4 index5 = array.GetValue([|index1;index2;index3;index4;index5|])
+    let set (array:System.Array) (index1:int) index2 index3 index4 index5 value = array.SetValue(value, [|index1;index2;index3;index4;index5|])
+    let length1 (array:System.Array) = array.GetLength(0)
+    let length2 (array:System.Array) = array.GetLength(1)
+    let length3 (array:System.Array) = array.GetLength(2)
+    let length4 (array:System.Array) = array.GetLength(3)
+    let length5 (array:System.Array) = array.GetLength(4)
+    let init<'a> (length1:int) length2 length3 length4 length5 (initializer:int->int->int->int->int->'a) =
+        let arr = zeroCreate<'a> length1 length2 length3 length4 length5
+        for i1=0 to length1-1 do
+            for i2=0 to length2-1 do
+                for i3=0 to length3-1 do
+                    for i4=0 to length4-1 do
+                        for i5=0 to length5-1 do
+                            set arr i1 i2 i3 i4 i5 (initializer i1 i2 i3 i4 i5)
+        arr
+    let create (length1:int) length2 length3 length4 length5 (initial:'a) = init length1 length2 length3 length4 length5 (fun _ _ _ _ _ -> initial)
+    let map mapping (array:System.Array) =
+        init (length1 array) (length2 array) (length3 array) (length4 array) (length5 array) (fun i1 i2 i3 i4 i5 -> mapping (get array i1 i2 i3 i4 i5))
+
+module Array6D =
+    let zeroCreate<'a> (length1:int) length2 length3 length4 length5 length6 = System.Array.CreateInstance(typeof<'a>, [|length1;length2;length3;length4;length5;length6|]) // Reference-type elements are initialized to null. Value-type elements are initialized to zero.
+    let get (array:System.Array) (index1:int) index2 index3 index4 index5 index6 = array.GetValue([|index1;index2;index3;index4;index5;index6|])
+    let set (array:System.Array) (index1:int) index2 index3 index4 index5 index6 value = array.SetValue(value, [|index1;index2;index3;index4;index5;index6|])
+    let length1 (array:System.Array) = array.GetLength(0)
+    let length2 (array:System.Array) = array.GetLength(1)
+    let length3 (array:System.Array) = array.GetLength(2)
+    let length4 (array:System.Array) = array.GetLength(3)
+    let length5 (array:System.Array) = array.GetLength(4)
+    let length6 (array:System.Array) = array.GetLength(5)
+    let init<'a> (length1:int) length2 length3 length4 length5 length6 (initializer:int->int->int->int->int->int->'a) =
+        let arr = zeroCreate<'a> length1 length2 length3 length4 length5 length6
+        for i1=0 to length1-1 do
+            for i2=0 to length2-1 do
+                for i3=0 to length3-1 do
+                    for i4=0 to length4-1 do
+                        for i5=0 to length5-1 do
+                            for i6=0 to length6-1 do
+                                set arr i1 i2 i3 i4 i5 i6 (initializer i1 i2 i3 i4 i5 i6)
+        arr
+    let create (length1:int) length2 length3 length4 length5 length6 (initial:'a) = init length1 length2 length3 length4 length5 length6 (fun _ _ _ _ _ _ -> initial)
+    let map mapping (array:System.Array) =
+        init (length1 array) (length2 array) (length3 array) (length4 array) (length5 array) (length6 array) (fun i1 i2 i3 i4 i5 i6 -> mapping (get array i1 i2 i3 i4 i5 i6))
+
 module ArrayND = 
     /// Initializes an array with a given shape and initializer function.
     let init (shape: int[]) (f: int[] -> 'T) : obj =
         match shape with 
         | [| |] -> f [| |]  :> _
-        | [| d0 |] -> Array.init d0 (fun i -> f [| i |]) :> _
-        | [| d0; d1 |] -> Array2D.init d0 d1 (fun i1 i2 -> f [| i1; i2 |]) :> _
-        | [| d0; d1; d2 |] -> Array3D.init d0 d1 d2 (fun i1 i2 i3 -> f [| i1; i2; i3 |]) :> _
-        | [| d0; d1; d2; d3 |] -> Array4D.init d0 d1 d2 d3 (fun i1 i2 i3 i4 -> f [| i1; i2; i3; i4 |]) :> _
-        | _ -> failwith "ArrayND.init - nyi for dim > 4"
+        | [| d1 |] -> Array.init d1 (fun i -> f [| i |]) :> _
+        | [| d1; d2 |] -> Array2D.init d1 d2 (fun i1 i2 -> f [| i1; i2 |]) :> _
+        | [| d1; d2; d3 |] -> Array3D.init d1 d2 d3 (fun i1 i2 i3 -> f [| i1; i2; i3 |]) :> _
+        | [| d1; d2; d3; d4 |] -> Array4D.init d1 d2 d3 d4 (fun i1 i2 i3 i4 -> f [| i1; i2; i3; i4 |]) :> _
+        | [| d1; d2; d3; d4; d5 |] -> Array5D.init d1 d2 d3 d4 d5 (fun i1 i2 i3 i4 i5 -> f [| i1; i2; i3; i4; i5 |]) :> _
+        | [| d1; d2; d3; d4; d5; d6 |] -> Array6D.init d1 d2 d3 d4 d5 d6 (fun i1 i2 i3 i4 i5 i6 -> f [| i1; i2; i3; i4; i5; i6 |]) :> _
+        | _ -> failwith "ArrayND.init not supported for dim > 6"
 
     /// Initializes an array with a given shape and initializer function.
     let zeroCreate (shape: int[]) : Array =
         match shape with 
         | [| |] -> [| |] :> _
-        | [| d0 |] -> Array.zeroCreate d0 :> _
-        | [| d0; d1 |] -> Array2D.zeroCreate d0 d1 :> _
-        | [| d0; d1; d2 |] -> Array3D.zeroCreate d0 d1 d2 :> _
-        | [| d0; d1; d2; d3 |] -> Array4D.zeroCreate d0 d1 d2 d3 :> _
-        | _ -> failwith "ArrayND.zeroCreate - nyi for dim > 4"
+        | [| d1 |] -> Array.zeroCreate d1 :> _
+        | [| d1; d2 |] -> Array2D.zeroCreate d1 d2 :> _
+        | [| d1; d2; d3 |] -> Array3D.zeroCreate d1 d2 d3 :> _
+        | [| d1; d2; d3; d4 |] -> Array4D.zeroCreate d1 d2 d3 d4 :> _
+        | [| d1; d2; d3; d4; d5 |] -> Array5D.zeroCreate d1 d2 d3 d4 d5
+        | [| d1; d2; d3; d4; d5; d6 |] -> Array6D.zeroCreate d1 d2 d3 d4 d5 d6
+        | _ -> failwith "ArrayND.zeroCreate not supported for dim > 6"
 
 /// Contains extensions to the F# Seq module. 
 module Seq =
@@ -143,13 +193,13 @@ module ExtensionAutoOpens =
             let q2 = data.[i].GetLength(0)
             let q3 = data.[i].GetLength(1)
             if q2 <> r2 || q3 <> r3 then 
-                invalidArg "data" (sprintf "jagged input at position %d: first is _ x %d x %d, later is _ x _ x %d x %d" i r2 r3 q2 q3)
+                invalidArg "data" (sprintf "jagged input at position %d: first is _ x %d x %d, later is _ x %d x %d" i r2 r3 q2 q3)
         Array3D.init r1 r2 r3 (fun i j k -> data.[i].[j,k])
 
     /// Creates a non-jagged 4D array from jagged data.
     let array4D data = 
         let data = data |> array2D |> Array2D.map array2D
-        let r1,r2,r3,r4 = (data.GetLength(0), data.GetLength(1), data.[0,0].GetLength(0),data.[0,0].GetLength(1))
+        let r1,r2,r3,r4 = data.GetLength(0), data.GetLength(1), data.[0,0].GetLength(0), data.[0,0].GetLength(1)
         for i in 0 .. r1-1 do 
           for j in 0 .. r2-1 do 
             let q3 = data.[i,j].GetLength(0)
@@ -157,6 +207,31 @@ module ExtensionAutoOpens =
             if q3 <> r3 || q4 <> r4 then 
                 invalidArg "data" (sprintf "jagged input at position (%d,%d): first is _ x _ x %d x %d, later is _ x _ x %d x %d" i j r2 r3 q3 q4)
         Array4D.init r1 r2 r3 r4 (fun i j k m -> data.[i,j].[k,m])
+
+    let array5D data =
+        let data = data |> Array.ofSeq |> Array.map array4D
+        let r1,r2,r3,r4,r5 = data.Length, data.[0].GetLength(0), data.[0].GetLength(1), data.[0].GetLength(2), data.[0].GetLength(3)
+        for i in 0 .. r1-1 do
+            let q2 = data.[i].GetLength(0)
+            let q3 = data.[i].GetLength(1)
+            let q4 = data.[i].GetLength(2)
+            let q5 = data.[i].GetLength(3)
+            if q2 <> r2 || q3 <> r3 || q4 <> r4 || q5 <> r5 then
+                invalidArg "data" (sprintf "jagged input at position %d: first is _ x %d x %d x %d x %d, later is _ x %d x %d x %d x %d" i r2 r3 r4 r5 q2 q3 q4 q5)
+        Array5D.init r1 r2 r3 r4 r5 (fun i1 i2 i3 i4 i5 -> data.[i1].[i2,i3,i4,i5])
+
+    let array6D data =
+        let data = data |> array2D |> Array2D.map array4D
+        let r1,r2,r3,r4,r5,r6 = data.GetLength(0), data.GetLength(1), data.[0,0].GetLength(0), data.[0,0].GetLength(1), data.[0,0].GetLength(2), data.[0,0].GetLength(3)
+        for i in 0 .. r1-1 do
+            for j in 0 .. r2-2 do
+                let q3 = data.[i,j].GetLength(0)
+                let q4 = data.[i,j].GetLength(1)
+                let q5 = data.[i,j].GetLength(2)
+                let q6 = data.[i,j].GetLength(3)
+                if q3 <> r3 || q4 <> r4 || q5 <> r5 || q6 <> r6 then
+                    invalidArg "data" (sprintf "jagged input at position (%d,%d): first is _ x _ x %d x %d x %d x %d, later is _ x _ x %d x %d x %d x %d" i j r3 r4 r5 r6 q3 q4 q5 q6)
+        Array6D.init r1 r2 r3 r4 r5 r6 (fun i1 i2 i3 i4 i5 i6 -> data.[i1,i2].[i3,i4,i5,i6])
 
     /// Print the given value to the console using the '%A' printf format specifier
     let print x = printfn "%A" x 

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -310,6 +310,16 @@ type Tensor =
         if t.dim <> 4 then failwithf "Cannot convert tensor with shape %A to 4D array" t.shape
         t.cast<'T>().toArray() :?> 'T[,,,]      
 
+    /// Returns the value of a 5D tensor as a 5D array
+    member t.toArray5D<'T>() = 
+        if t.dim <> 5 then failwithf "Cannot convert tensor with shape %A to 5D array" t.shape
+        t.cast<'T>().toArray()
+
+    /// Returns the value of a 6D tensor as a 6D array
+    member t.toArray6D<'T>() = 
+        if t.dim <> 6 then failwithf "Cannot convert tensor with shape %A to 6D array" t.shape
+        t.cast<'T>().toArray()
+
     /// Indicates if two tensors have the same differentiation type
     member t1.isSameDiffType(t2:Tensor) =
         match t1, t2 with

--- a/src/DiffSharp.Core/Util.fs
+++ b/src/DiffSharp.Core/Util.fs
@@ -237,6 +237,38 @@ module DataConverter =
                                 yield v.[i, j, k, m] |]
         arr, [| n1;n2;n3;n4 |]
 
+    let private flatArrayAndShape5D<'T> (v) =
+        let n1 = Array5D.length1 v
+        let n2 = Array5D.length2 v
+        let n3 = Array5D.length3 v
+        let n4 = Array5D.length4 v
+        let n5 = Array5D.length5 v
+        let arr =
+            [|  for i1=0 to n1-1 do
+                    for i2=0 to n2-1 do
+                        for i3=0 to n3-1 do
+                            for i4=0 to n4-1 do
+                                for i5=0 to n5-1 do
+                                    yield Array5D.get v i1 i2 i3 i4 i5 :?> 'T|]
+        arr, [| n1;n2;n3;n4;n5 |]
+
+    let private flatArrayAndShape6D<'T> (v) =
+        let n1 = Array6D.length1 v
+        let n2 = Array6D.length2 v
+        let n3 = Array6D.length3 v
+        let n4 = Array6D.length4 v
+        let n5 = Array6D.length5 v
+        let n6 = Array6D.length6 v
+        let arr =
+            [|  for i1=0 to n1-1 do
+                    for i2=0 to n2-1 do
+                        for i3=0 to n3-1 do
+                            for i4=0 to n4-1 do
+                                for i5=0 to n5-1 do
+                                    for i6=0 to n6-1 do
+                                        yield Array6D.get v i1 i2 i3 i4 i5 i6 :?> 'T|]
+        arr, [| n1;n2;n3;n4;n5;n6 |]
+
     let private seqTupleElements (els: obj) =
         match seqElements els with 
         | [| el |] -> FSharpValue.GetTupleFields(el) 
@@ -264,10 +296,14 @@ module DataConverter =
         | :? ('T[,]) as v -> Some (flatArrayAndShape2D<'T> v)
         | :? ('T[,,]) as v -> Some (flatArrayAndShape3D<'T> v)
         | :? ('T[,,,]) as v -> Some (flatArrayAndShape4D<'T> v)
+        | :? System.Array as v when v.Rank = 5 -> Some (flatArrayAndShape5D<'T> v)
+        | :? System.Array as v when v.Rank = 6 -> Some (flatArrayAndShape6D<'T> v)
         | :? seq<'T> as v -> Some (flatArrayAndShape1D (Seq.toArray v))
         | :? seq<seq<'T>> as v -> Some (flatArrayAndShape2D (array2D v))
         | :? seq<seq<seq<'T>>> as v -> Some (flatArrayAndShape3D (array3D v))
         | :? seq<seq<seq<seq<'T>>>> as v -> Some (flatArrayAndShape4D (array4D v))
+        | :? seq<seq<seq<seq<seq<'T>>>>> as v -> Some (flatArrayAndShape5D (array5D v))
+        | :? seq<seq<seq<seq<seq<seq<'T>>>>>> as v -> Some (flatArrayAndShape6D (array6D v))
         | _ -> 
         let vty = value.GetType()
         let tgt = (typeof<'T>)
@@ -288,6 +324,14 @@ module DataConverter =
         | SeqOrSeqTupleTy (fetcher1, SeqOrSeqTupleTy (fetcher2, SeqOrSeqTupleTy (fetcher3, SeqOrSeqTupleLeafTy tgt fetcher4))) -> 
             let els = value |> fetcher1 |> Array.map (fetcher2 >> Array.map (fetcher3 >> Array.map (fetcher4 >> arrayCast<'T>))) |> array4D
             Some (flatArrayAndShape4D<'T> els)
+        // ... -> dim 5
+        | SeqOrSeqTupleTy (fetcher1, SeqOrSeqTupleTy (fetcher2, SeqOrSeqTupleTy (fetcher3, SeqOrSeqTupleTy (fetcher4, SeqOrSeqTupleLeafTy tgt fetcher5)))) -> 
+            let els = value |> fetcher1 |> Array.map (fetcher2 >> Array.map (fetcher3 >> Array.map (fetcher4 >> Array.map (fetcher5 >> arrayCast<'T>)))) |> array5D
+            Some (flatArrayAndShape5D<'T> els)
+        // ... -> dim 6
+        | SeqOrSeqTupleTy (fetcher1, SeqOrSeqTupleTy (fetcher2, SeqOrSeqTupleTy (fetcher3, SeqOrSeqTupleTy (fetcher4, SeqOrSeqTupleTy (fetcher5, SeqOrSeqTupleLeafTy tgt fetcher6))))) -> 
+            let els = value |> fetcher1 |> Array.map (fetcher2 >> Array.map (fetcher3 >> Array.map (fetcher4 >> Array.map (fetcher5 >> Array.map (fetcher6 >> arrayCast<'T>))))) |> array6D
+            Some (flatArrayAndShape6D<'T> els)
         | _ -> None
 
     [<ExcludeFromCodeCoverage>]


### PR DESCRIPTION
This is implementing tensor creation from and conversion to 5d and 6d arrays to address #148. 

If I'm not missing something F# currently doesn't support types `[,,,,]<'T>` (5d) and `[,,,,,]<'T>` (6d) so these cases are handled using the `System.Array` type instead.