### PR TITLE
Implement "true division" promoting integers to floating point

### DIFF
--- a/src/DiffSharp.Core/DiffSharp.fs
+++ b/src/DiffSharp.Core/DiffSharp.fs
@@ -1200,6 +1200,8 @@ type dsharp =
     /// <param name="device">The new default device.</param>
     /// <param name="backend">The new default backend.</param>
     static member config(?dtype: Dtype, ?device: Device, ?backend: Backend) = 
+        if dtype.IsSome then 
+            if not dtype.Value.IsFloatingPoint then failwithf "Only floating point types are supported as the default type."
         dtype |> Option.iter (fun d -> Dtype.Default <- d)
         device |> Option.iter (fun d -> Device.Default <- d)
         backend |> Option.iter (fun d -> Backend.Default <- d)

--- a/src/DiffSharp.Core/DiffSharp.fs
+++ b/src/DiffSharp.Core/DiffSharp.fs
@@ -1196,7 +1196,7 @@ type dsharp =
         input.move(?dtype=dtype, ?device=device, ?backend=backend)
 
     /// <summary>Configure the default element type, device and/or backend.</summary>
-    /// <param name="dtype">The new default element type.</param>
+    /// <param name="dtype">The new default element type. Only floating point types are supported as the default.</param>
     /// <param name="device">The new default device.</param>
     /// <param name="backend">The new default backend.</param>
     static member config(?dtype: Dtype, ?device: Device, ?backend: Backend) = 
@@ -1210,7 +1210,7 @@ type dsharp =
     /// <summary>Return the current default element type, device and backend.</summary>
     static member config() = Dtype.Default, Device.Default, Backend.Default
 
-    /// <summary>Configure the default element type, device and/or backend.</summary>
+    /// <summary>Configure the default element type, device and/or backend. Only floating point types are supported as the default.</summary>
     /// <param name="configuration">A tuple of the new default element type, default device and default backend.</param>
     static member config(configuration: (Dtype * Device * Backend)) =
         let (dtype,device,backend) = configuration

--- a/src/DiffSharp.Core/Dtype.fs
+++ b/src/DiffSharp.Core/Dtype.fs
@@ -115,6 +115,15 @@ module Dtype =
             | Bool, Bool -> Some Bool
             | Int8, Byte | Byte, Int8  -> None
 
-    /// Get or set the default element type used when creating tensors. Note, use <c>dsharp.config(...)</c> instead.
+    /// Get or set the default element type used when creating tensors. Only floating point types are supported as the default type. Note, use <c>dsharp.config(...)</c> instead.
     let mutable Default = Dtype.Float32
+
+    /// Find the Dtype which would result from dividing tensors with dtype1 and dtype2
+    let divisionType (dtype1: Dtype) (dtype2: Dtype) =
+        match dtype1.IsFloatingPoint, dtype2.IsFloatingPoint with
+        | false, false -> Default
+        | false, true -> dtype2
+        | true, false -> dtype1
+        | true, true -> (widen dtype1 dtype2).Value
+
 

--- a/src/DiffSharp.Core/Scalar.fs
+++ b/src/DiffSharp.Core/Scalar.fs
@@ -51,24 +51,20 @@ module ScalarExtensions =
             | Dtype.Int16 -> x.toInt16() :> scalar
             | Dtype.Bool -> x.toBool() :> scalar
 
-    // Floating point scalars force integers to widen to float32
-    //
-    // Double scalars don't force widen to float64
-    // Int64 scalars don't force integers to widen to int64
-    // Int32 scalars don't force integers to widen to int32 etc.
-    //
-    // This is deliberate, scalars never force widening to
-    // float64, but may force widening to float32
+    // Floating point scalars force integers to widen to the default floating point type
     //
     // For example:
     //  >>> import torch
     //  >>> (torch.tensor([1], dtype=torch.int32) * 2.5).dtype
     //  torch.float32
+    //  >>> torch.set_default_dtype(torch.float16)
+    //  >>> (torch.tensor([1], dtype=torch.int32) * 2.5).dtype
+    //  torch.float16
     //  >>> (torch.tensor([1], dtype=torch.int32) * 2).dtype
     //  torch.int32
     let tryWidenScalar (tensorDtype: Dtype) (scalar: scalar) =
         match tensorDtype, scalar.GetTypeCode() with 
-        | Dtype.Integral, (TypeCode.Double | TypeCode.Single) -> ValueSome Dtype.Float32
+        | Dtype.Integral, (TypeCode.Double | TypeCode.Single) -> ValueSome Dtype.Default
         | _, _ -> ValueNone
         
         

--- a/src/DiffSharp.Core/Scalar.fs
+++ b/src/DiffSharp.Core/Scalar.fs
@@ -67,5 +67,11 @@ module ScalarExtensions =
         | Dtype.Integral, (TypeCode.Double | TypeCode.Single) -> ValueSome Dtype.Default
         | _, _ -> ValueNone
         
-        
+    let widenScalarForDivision (tensorDtype: Dtype) (scalarDtype: Dtype) =
+        match tensorDtype.IsFloatingPoint, scalarDtype.IsFloatingPoint with
+        | false, false -> Dtype.Default
+        | false, true -> Dtype.Default
+        | true, false -> tensorDtype
+        | true, true -> tensorDtype
+
         

--- a/tests/DiffSharp.Tests/TestDiffSharp.fs
+++ b/tests/DiffSharp.Tests/TestDiffSharp.fs
@@ -124,7 +124,7 @@ type TestDiffSharp () =
 
     [<Test>]
     member this.TestSeed () =
-        for combo in Combos.All do
+        for combo in Combos.FloatingPointExcept16s do
             use _holder = dsharp.useConfig(combo.dtype, combo.device, combo.backend)
             dsharp.seed(123)
             let t = combo.randint(0,10,[25])
@@ -622,8 +622,8 @@ type TestDiffSharp () =
 
         // Default reference backend with "int32"
         let dtype = Dtype.Default
-        dsharp.config(dtype=Dtype.Int32)
-        Assert.CheckEqual(Dtype.Int32, Dtype.Default)
+        dsharp.config(dtype=Dtype.Float64)
+        Assert.CheckEqual(Dtype.Float64, Dtype.Default)
         dsharp.config(dtype=dtype)
 
     [<Test>]

--- a/tests/DiffSharp.Tests/TestTensor.fs
+++ b/tests/DiffSharp.Tests/TestTensor.fs
@@ -1038,7 +1038,10 @@ type TestTensor () =
             Assert.CheckEqual(tSubCorrect, tSub)
 
             let tDiv = t / 2
-            let tDivCorrect = t
+            printfn "%A" combo.backend
+            printfn "tt tdiv    %A %A" t.dtype tDiv.dtype
+            printfn "tt outtype %A" (Dtype.divisionType t.dtype t.dtype)
+            let tDivCorrect = t.cast(Dtype.divisionType t.dtype t.dtype)
             Assert.CheckEqual(tDivCorrect, tDiv)
 
             let tNeg = -t
@@ -2275,34 +2278,25 @@ type TestTensor () =
             Assert.CheckEqual(t3.dtype, combo.dtype)
             Assert.CheckEqual(t4.dtype, combo.dtype)
 
-        // Integer tensors support integer division
-        for combo in Combos.Integral do 
+        // Integer and bool tensors get cast to the default floating point type for division
+        for combo in Combos.IntegralAndBool do 
             let t1a = combo.tensor([2; 3; 4])
             let t1b = combo.tensor([1; 2; 3])
             let i1 = t1a / t1b
-            let i1Correct = combo.tensor([2; 1; 1])
-            Assert.CheckEqual(i1Correct, i1)
+            let i1Correct = t1a.cast(Dtype.Default) / t1b.cast(Dtype.Default)
+            Assert.True(i1Correct.allclose(i1, 0.01))
 
             let t2a = combo.tensor(6)
             let t2b = combo.tensor([1; 2; 3])
             let i2 = t2a / t2b
-            let i2Correct = combo.tensor([6; 3; 2])
-            Assert.CheckEqual(i2Correct, i2)
+            let i2Correct = t2a.cast(Dtype.Default) / t2b.cast(Dtype.Default)
+            Assert.True(i2Correct.allclose(i2, 0.01))
 
             let t3a = combo.tensor([6; 12; 18])
             let t3b = combo.tensor(3)
             let i3 = t3a / t3b
-            let i3Correct = combo.tensor([2; 4; 6])
-            Assert.CheckEqual(i3Correct, i3)
-
-        // Bool tensors don't support /
-        //
-        //    torch.ones(10, dtype=torch.bool) / torch.ones(10, dtype=torch.bool)
-        //
-        //    RuntimeError: "div_cpu" not implemented for 'Bool'
-        for combo in Combos.Bool do 
-            let t2 = combo.tensor([true; false])
-            isInvalidOp(fun () -> t2 / t2)
+            let i3Correct = t3a.cast(Dtype.Default) / t3b.cast(Dtype.Default)
+            Assert.True(i3Correct.allclose(i3, 0.01))
 
     [<Test>]
     member _.TestTensorPowTT () =


### PR DESCRIPTION
Addresses #239 and introduces behavior consistent with PyTorch > 1.7.

In PyTorch this is called "true division": https://pytorch.org/docs/stable/generated/torch.div.html

The behavior is ultimately due to: https://www.python.org/dev/peps/pep-0238/