### PR TITLE
primitives to allow lifting from operations from TorchSharp tensors to DiffSharp tensors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-     <Version>1.0.4</Version>
+     <Version>1.0.5</Version>
      <Authors>Atılım Güneş Baydin, Don Syme, Barak A. Pearlmutter, Jeffrey Siskind, and DiffSharp contributors</Authors>
      <Owners>DiffSharp maintainers</Owners>
      <PackageProjectUrl>https://diffsharp.github.io</PackageProjectUrl>

--- a/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
+++ b/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
@@ -8,28 +8,21 @@ open TorchSharp
 [<AutoOpen>]
 module Extensions =
 
-    type dsharp with
+    type torch.Tensor with
 
         /// <summary>
-        /// Creates a new tensor from the torch tensor.
+        /// Creates a new DiffSharp tensor from the torch tensor.
         /// </summary>
-        /// <param name="tt">The given TorchSharp tensor.</param>
-        static member ofTorchTensor(tt: torch.Tensor) =
+        member tt.toTensor() : Tensor =
             Tensor.ofRawTensor(TorchRawTensor(tt))
-
-        /// <summary>
-        /// Converts the primal of a tensor to a torch tensor.
-        /// </summary>
-        /// <remarks>If the tensor does not use the Torch backend an exception is raised</remarks>
-        static member primalRawTorch(t: Tensor) =
-            match t.primalRaw with
-            | :? TorchRawTensor as trt -> trt.TorchTensor
-            | _ -> failwith $"primalRawTorch: the input is not a DiffSharp.Backends.Torch tensor, its backend is {t.backend}"
 
     type Tensor with
         /// <summary>
         /// Converts the primal of a tensor to a torch tensor.
         /// </summary>
         /// <remarks>If the tensor does not use the Torch backend an exception is raised</remarks>
-        member t.primalRawTorch() = dsharp.primalRawTorch t
+        member t.primalRawTorch() =
+            match t.primalRaw with
+            | :? TorchRawTensor as trt -> trt.TorchTensor
+            | _ -> failwith $"primalRawTorch: the input is not a DiffSharp.Backends.Torch tensor, its backend is {t.backend}"
 

--- a/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
+++ b/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
@@ -21,15 +21,15 @@ module Extensions =
         /// Converts the primal of a tensor to a torch tensor.
         /// </summary>
         /// <remarks>If the tensor does not use the Torch backend an exception is raised</remarks>
-        static member primalTorch(t: Tensor) =
+        static member primalRawTorch(t: Tensor) =
             match t.primalRaw with
             | :? TorchRawTensor as trt -> trt.TorchTensor
-            | _ -> failwith $"primalTorch: the input is not a DiffSharp.Backends.Torch tensor, its backend is {t.backend}"
+            | _ -> failwith $"primalRawTorch: the input is not a DiffSharp.Backends.Torch tensor, its backend is {t.backend}"
 
     type Tensor with
         /// <summary>
         /// Converts the primal of a tensor to a torch tensor.
         /// </summary>
         /// <remarks>If the tensor does not use the Torch backend an exception is raised</remarks>
-        member t.primalTorch() = dsharp.primalTorch t
+        member t.primalRawTorch() = dsharp.primalRawTorch t
 

--- a/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
+++ b/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
@@ -1,5 +1,5 @@
 ﻿/// Defines extensions to the DiffSharp programming model when the Torch backend can be assumed
-namespace DiffSharp.Torch
+namespace DiffSharp
 
 open DiffSharp
 open DiffSharp.Backends.Torch
@@ -8,20 +8,26 @@ open TorchSharp
 [<AutoOpen>]
 module Extensions =
 
-    type torch.Tensor with
+    type dsharp with
 
         /// <summary>
         /// Creates a new DiffSharp tensor from the torch tensor.
         /// </summary>
-        member tt.toTensor() : Tensor =
+        static member fromTorch(tt: torch.Tensor) =
             Tensor.ofRawTensor(TorchRawTensor(tt))
 
     type Tensor with
         /// <summary>
         /// Converts the primal of a tensor to a torch tensor.
         /// </summary>
-        /// <remarks>If the tensor does not use the Torch backend an exception is raised</remarks>
-        member t.primalRawTorch() =
+        /// <remarks>
+        /// If the tensor does not use the Torch backend an exception is raised.
+        ///
+        /// Note that this operation takes the primal of the tensor. This means
+        /// code that converts to Torch tensors will not be differentiable using
+        /// DiffSharp differentiation capabilities.
+        /// </remarks>
+        member t.toTorch() =
             match t.primalRaw with
             | :? TorchRawTensor as trt -> trt.TorchTensor
             | _ -> failwith $"primalRawTorch: the input is not a DiffSharp.Backends.Torch tensor, its backend is {t.backend}"

--- a/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
+++ b/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
@@ -5,7 +5,7 @@ open DiffSharp.Backends.Torch
 open TorchSharp
 
 [<AutoOpen>]
-module Extensions =
+module TorchExtensions =
 
     type dsharp with
 

--- a/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
+++ b/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
@@ -30,5 +30,5 @@ module Extensions =
         member t.toTorch() =
             match t.primalRaw with
             | :? TorchRawTensor as trt -> trt.TorchTensor
-            | _ -> failwith $"primalRawTorch: the input is not a DiffSharp.Backends.Torch tensor, its backend is {t.backend}"
+            | _ -> failwith $"toTorch: the input is not a DiffSharp.Backends.Torch tensor, its backend is {t.backend}"
 

--- a/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
+++ b/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
@@ -18,18 +18,18 @@ module Extensions =
             Tensor.ofRawTensor(TorchRawTensor(tt))
 
         /// <summary>
-        /// Converts the tensor to a torch tensor.
+        /// Converts the primal of a tensor to a torch tensor.
         /// </summary>
         /// <remarks>If the tensor does not use the Torch backend an exception is raised</remarks>
-        static member toTorchTensor(t: Tensor) =
+        static member primalTorch(t: Tensor) =
             match t.primalRaw with
             | :? TorchRawTensor as trt -> trt.TorchTensor
-            | _ -> failwith $"toTorchTensor: the input is not a DiffSharp.Backends.Torch tensor, its backend is {t.backend}"
+            | _ -> failwith $"primalTorch: the input is not a DiffSharp.Backends.Torch tensor, its backend is {t.backend}"
 
     type Tensor with
         /// <summary>
-        /// Converts the tensor to a torch tensor.
+        /// Converts the primal of a tensor to a torch tensor.
         /// </summary>
         /// <remarks>If the tensor does not use the Torch backend an exception is raised</remarks>
-        member t.toTorchTensor() = dsharp.toTorchTensor(t)
+        member t.primalTorch() = dsharp.primalTorch t
 

--- a/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
+++ b/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
@@ -1,0 +1,35 @@
+﻿/// Defines extensions to the DiffSharp programming model when the Torch backend can be assumed
+namespace DiffSharp.Torch
+
+open DiffSharp
+open DiffSharp.Backends.Torch
+open TorchSharp
+
+[<AutoOpen>]
+module Extensions =
+
+    type dsharp with
+
+        /// <summary>
+        /// Creates a new tensor from the torch tensor.
+        /// </summary>
+        /// <param name="tt">The given TorchSharp tensor.</param>
+        static member ofTorchTensor(tt: torch.Tensor) =
+            Tensor.ofRawTensor(TorchRawTensor(tt))
+
+        /// <summary>
+        /// Converts the tensor to a torch tensor.
+        /// </summary>
+        /// <remarks>If the tensor does not use the Torch backend an exception is raised</remarks>
+        static member toTorchTensor(t: Tensor) =
+            match t.primalRaw with
+            | :? TorchRawTensor as trt -> trt.TorchTensor
+            | _ -> failwith $"toTorchTensor: the input is not a DiffSharp.Backends.Torch tensor, its backend is {t.backend}"
+
+    type Tensor with
+        /// <summary>
+        /// Converts the tensor to a torch tensor.
+        /// </summary>
+        /// <remarks>If the tensor does not use the Torch backend an exception is raised</remarks>
+        member t.toTorchTensor() = dsharp.toTorchTensor(t)
+

--- a/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
+++ b/src/DiffSharp.Backends.Torch/DiffSharp.Torch.fs
@@ -1,5 +1,4 @@
-﻿/// Defines extensions to the DiffSharp programming model when the Torch backend can be assumed
-namespace DiffSharp
+﻿namespace DiffSharp
 
 open DiffSharp
 open DiffSharp.Backends.Torch

--- a/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
+++ b/src/DiffSharp.Backends.Torch/Torch.RawTensor.fs
@@ -67,6 +67,10 @@ module internal Utils =
     type DiffSharp.Device with 
         member x.ToTorch = torch.Device(x.DeviceType.ToTorch, x.DeviceIndex)
 
+    let fromTorchDeviceType (x: TorchSharp.DeviceType) : DiffSharp.DeviceType = enum (int x)
+
+    let fromTorchDevice (x: torch.Device) = DiffSharp.Device(fromTorchDeviceType x.``type``, x.index)
+
     let inline combineHashes (h1 : int) (h2 : int) = ((h1 <<< 5) + h1) ^^^ h2
 
     let torchMoveTo (tt: torch.Tensor) (device: Device) =
@@ -116,6 +120,9 @@ type TorchRawTensor(tt: torch.Tensor, shape: Shape, dtype: Dtype, device: Device
     override t.Device = DiffSharp.Device(t.DeviceType, tt.device_index)
     override _.Backend = Backend.Torch
     override _.Handle = box tt
+
+    new (tt: torch.Tensor) =
+        TorchRawTensor(tt, fromTorchShape tt.shape, fromTorchType tt.dtype, fromTorchDevice tt.device)
 
     member t.MakeLike(tt, ?shape, ?dtype, ?device) : RawTensor =
         upcast TorchRawTensor(tt, defaultArg shape t.Shape, defaultArg dtype t.Dtype, defaultArg device t.Device)

--- a/src/DiffSharp.Core/Tensor.fs
+++ b/src/DiffSharp.Core/Tensor.fs
@@ -943,6 +943,12 @@ type Tensor =
             t.GetSlice(bounds)
 
     /// <summary>
+    /// Creates a new tensor from the raw tensor.
+    /// </summary>
+    /// <param name="rawTensor">The given raw tensor.</param>
+    static member ofRawTensor(rawTensor: RawTensor) = TensorC rawTensor
+
+    /// <summary>
     /// Creates a new tensor from the given data, using the given element type and configuration.
     /// </summary>
     /// <param name="value">The .NET object used to form the initial values for the tensor.</param>


### PR DESCRIPTION
These primitives allow us to lift primal operations implemented in TorchSharp up to DiffSharp when we can assume the user is using the Torch backend 

@pkese you may be intereted in this

The point is to allow the user to program freely with TorchSharp operations to generate primal tensors.

We use the name `primalRawTorch` (like `primalRaw` but getting a `torch.Tensor`) since it discards differentiability.

