### PR TITLE
include a DiffSharp-cuda bundle

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,3 +121,23 @@ jobs:
       run: dotnet pack --configuration Release --verbosity normal bundles/DiffSharp-cuda-linux
     - name: Publish NuGets
       run: dotnet nuget push "bin/packages/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_TOKEN_2020 }} --skip-duplicate
+
+  # Done in a separate job because it downloads the massive Linux CUDA packages (though only for reference
+  # during the package build, it doesn't actually use them)
+  pack_cuda:
+
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.100-preview.5.21302.13
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Pack (DiffSharp-cuda)
+      run: dotnet pack --configuration Release --verbosity normal bundles/DiffSharp-cuda
+    - name: Publish NuGets
+      run: dotnet nuget push "bin/packages/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_TOKEN_2020 }} --skip-duplicate

--- a/bundles/DiffSharp-cuda/DiffSharp-cuda.fsproj
+++ b/bundles/DiffSharp-cuda/DiffSharp-cuda.fsproj
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DiffSharp-cuda-windows.fsproj" />
-    <ProjectReference Include="..\DiffSharp-cuda-linux.fsproj" />
+    <ProjectReference Include="..\DiffSharp-cuda-windows\DiffSharp-cuda-windows.fsproj" />
+    <ProjectReference Include="..\DiffSharp-cuda-linux\DiffSharp-cuda-linux.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/bundles/DiffSharp-cuda/DiffSharp-cuda.fsproj
+++ b/bundles/DiffSharp-cuda/DiffSharp-cuda.fsproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Empty.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DiffSharp-cuda-windows.fsproj" />
+    <ProjectReference Include="..\DiffSharp-cuda-linux.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/bundles/DiffSharp-cuda/Empty.fs
+++ b/bundles/DiffSharp-cuda/Empty.fs
@@ -1,0 +1,4 @@
+namespace DiffSharp
+
+// This project is to bundle DiffSharp.Core and some default backends into a single project
+// See DiffSharp.Core for main DiffSharp code


### PR DESCRIPTION

Similar to https://github.com/dotnet/TorchSharp/issues/512

I'm coming across situations where I'd like a DiffSharp-cuda package that references both DiffSharp-cuda-linux and DiffSharp-cuda-windows, in particular when writing cross-plaftform examples and scripts that require CUDA.

We should just add this, even if it adds GB of download to the initial experience if referenced - it is just too useful when writing samples.

