### PR TITLE
Improve model to string

### DIFF
--- a/src/DiffSharp.Core/Model.fs
+++ b/src/DiffSharp.Core/Model.fs
@@ -459,16 +459,14 @@ type ModelBase() =
         m.save(fileName, noDiff=false)
         ModelBase.load(fileName)
 
-    override _.ToString() = 
+    override m.ToString() = 
         let sb = System.Text.StringBuilder()
         sb.Append("Model(") |> ignore
         let mutable prefix = ""
-        for v in modelDict do 
-            // let n = (v :?> DictionaryEntry).Key :?> string
-            let m = (v :?> DictionaryEntry).Value :?> ModelBase
-            // sb.Append(sprintf "%A: %A" n m) |> ignore
-            sb.Append(sprintf "%s%A" prefix m) |> ignore
-            prefix <- ", "
+        for mm in m.descendants do
+            if mm.hasOwnParameters then
+                sb.Append(sprintf "%s%A" prefix mm) |> ignore
+                prefix <- ", "
         sb.Append(")") |> ignore
         sb.ToString()
 


### PR DESCRIPTION
Fixes model strings.

Example:
```fsharp
let nz = 128

let generator =
    dsharp.view([-1;nz])
    --> Linear(nz, 256)
    --> dsharp.leakyRelu(0.2)
    --> Linear(256, 512)
    --> dsharp.leakyRelu(0.2)
    --> Linear(512, 1024)
    --> dsharp.leakyRelu(0.2)
    --> Linear(1024, 28*28)
    --> dsharp.tanh

let discriminator =
    dsharp.view([-1; 28*28])
    --> Linear(28*28, 1024)
    --> dsharp.leakyRelu(0.2)
    --> dsharp.dropout(0.3)
    --> Linear(1024, 512)
    --> dsharp.leakyRelu(0.2)
    --> dsharp.dropout(0.3)
    --> Linear(512, 256)
    --> dsharp.leakyRelu(0.2)
    --> dsharp.dropout(0.3)
    --> Linear(256, 1)
    --> dsharp.sigmoid

print generator
print discriminator
```

Previous behavior:
```
Model(Model(Model(Model(Model(Model(Model(Model(Linear(128, 256))), Linear(256, 512))), Linear(512, 1024))), Linear(1024, 784)))
Model(Model(Model(Model(Model(Model(Model(Model(Model(Model(Model(Linear(784, 1024)))), Linear(1024, 512)))), Linear(512, 256)))), Linear(256, 1)))
```

Fixed behavior:
```
Model(Linear(128, 256), Linear(256, 512), Linear(512, 1024), Linear(1024, 784))
Model(Linear(784, 1024), Linear(1024, 512), Linear(512, 256), Linear(256, 1))
```